### PR TITLE
test(architecture): establish boundary and behavior checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,9 @@ jobs:
         # exit-zero treats all errors as warnings
         ruff check --exit-zero --statistics src/
 
+    - name: Check architecture boundaries
+      run: pytest tests/test_architecture.py
+
     - name: Run tests
       run: |
         xvfb-run pytest

--- a/docs/architecture/module-boundaries.md
+++ b/docs/architecture/module-boundaries.md
@@ -1,0 +1,31 @@
+# Module Boundaries
+
+This document defines the dependency direction for production code. It is a
+stable design rule, not a list of current migration tasks.
+
+## Layers
+
+| Layer | Owns | May depend on | Must not depend on |
+| --- | --- | --- | --- |
+| Presentation | Widgets, dialogs, input binding, rendering | Application contracts, domain values, Qt | Concrete network clients, persistence, platform implementation details |
+| Application | Use cases, workflow coordination, lifecycle ownership | Domain values and ports | Presentation code, concrete infrastructure implementations |
+| Domain | Business rules, value objects, states, stable contracts | Python standard library | Qt, network libraries, persistence, platform APIs, third-party raw models |
+| Infrastructure | Network, persistence, platform and third-party adapters | Application ports, domain contracts, external libraries | Presentation decisions and UI state |
+
+## Rules
+
+- Dependencies should point toward stable contracts and business meaning.
+- External data is parsed and validated before entering the domain or application layer.
+- Third-party raw objects do not cross an infrastructure boundary without an explicit adapter contract.
+- Presentation code binds state and commands; it does not own business workflows.
+- Application code owns use-case lifecycles and coordinates infrastructure through ports.
+- Domain code remains deterministic and independently testable whenever practical.
+- New code must not introduce a circular dependency or a dependency in the forbidden direction.
+- A temporary boundary exception must be narrow, documented, and covered by a removal condition.
+
+## Verification
+
+The executable import rules live in `tests/test_architecture.py` and run as part
+of the normal test suite and CI. Architecture tests may inspect the import AST
+by design; this is different from testing business behavior by matching source
+strings or implementation fragments.

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -1,0 +1,95 @@
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1] / "src" / "bilihud"
+PURE_MODULE_NAMES: Final[tuple[str, ...]] = ("live_audience", "live_emoticons")
+
+
+@dataclass(frozen=True)
+class ImportRule:
+    name: str
+    files: tuple[Path, ...]
+    forbidden_prefixes: frozenset[str]
+
+
+DOMAIN_FORBIDDEN_PREFIXES: Final[frozenset[str]] = frozenset(
+    {
+        "PyQt5",
+        "PyQt6",
+        "aiohttp",
+        "blivedm",
+        "qasync",
+        "bilihud.auth",
+        "bilihud.danmaku_client",
+        "bilihud.live_api",
+        "bilihud.mirror_server",
+        "bilihud.obs_api",
+    }
+)
+
+
+def _python_files(path: Path) -> tuple[Path, ...]:
+    if path.is_file():
+        return (path,)
+    if path.is_dir():
+        return tuple(sorted(path.rglob("*.py")))
+    return ()
+
+
+def _rule_files() -> tuple[ImportRule, ...]:
+    pure_files = tuple(SOURCE_ROOT / f"{name}.py" for name in PURE_MODULE_NAMES)
+    domain_files = _python_files(SOURCE_ROOT / "domain")
+    return (
+        ImportRule("pure modules", pure_files, DOMAIN_FORBIDDEN_PREFIXES),
+        ImportRule("domain package", domain_files, DOMAIN_FORBIDDEN_PREFIXES),
+    )
+
+
+def _module_name(path: Path) -> str:
+    relative = path.relative_to(SOURCE_ROOT).with_suffix("")
+    return ".".join(("bilihud", *relative.parts))
+
+
+def _relative_module_name(path: Path, node: ast.ImportFrom) -> tuple[str, ...]:
+    current_package = _module_name(path).rsplit(".", 1)[0].split(".")
+    base = current_package[: len(current_package) - node.level + 1]
+    if node.module:
+        return (".".join((*base, node.module)),)
+    return tuple(".".join((*base, alias.name)) for alias in node.names)
+
+
+def _imported_modules(path: Path) -> tuple[str, ...]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                modules.extend(_relative_module_name(path, node))
+            elif node.module:
+                modules.append(node.module)
+    return tuple(modules)
+
+
+def _is_forbidden(module: str, prefixes: frozenset[str]) -> bool:
+    return any(module == prefix or module.startswith(f"{prefix}.") for prefix in prefixes)
+
+
+def test_import_rules_cover_current_pure_modules() -> None:
+    pure_files = tuple(SOURCE_ROOT / f"{name}.py" for name in PURE_MODULE_NAMES)
+
+    assert all(path.is_file() for path in pure_files)
+
+
+def test_layer_import_rules_reject_forbidden_dependencies() -> None:
+    violations: list[str] = []
+    for rule in _rule_files():
+        for path in rule.files:
+            for module in _imported_modules(path):
+                if _is_forbidden(module, rule.forbidden_prefixes):
+                    violations.append(f"{rule.name}: {path.relative_to(SOURCE_ROOT)} imports {module}")
+
+    assert violations == []

--- a/tests/test_danmaku_client.py
+++ b/tests/test_danmaku_client.py
@@ -1,5 +1,4 @@
 import asyncio
-from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
 import aiohttp
@@ -8,13 +7,6 @@ import pytest
 from bilihud import danmaku_client
 from bilihud.danmaku_client import DanmakuClient, DanmakuShutdownError
 from bilihud.live_emoticons import LiveEmoticon
-
-
-def test_stop_catches_asyncio_timeout_error_for_python_310_compatibility():
-    source = Path("src/bilihud/danmaku_client.py").read_text(encoding="utf-8")
-
-    assert "except asyncio.TimeoutError" in source
-    assert "except TimeoutError" not in source
 
 
 def test_start_starts_blivedm_client_before_returning(monkeypatch):
@@ -53,6 +45,58 @@ def test_start_starts_blivedm_client_before_returning(monkeypatch):
         assert client.client is not None
         assert client.client.start_calls == 1
         assert client.client.is_running is True
+
+    asyncio.run(run_test())
+
+
+def test_start_reports_expired_keyring_login_without_falling_back_to_browser(monkeypatch):
+    class FakeAuthManager:
+        def load_auth_cookies(self):
+            return {"SESSDATA": "expired"}, True
+
+        async def validate_session(self, _cookies):
+            return False
+
+        def create_session_from_cookies(self, cookies):
+            assert cookies == {}
+            return FakeSession()
+
+    class FakeBLiveClient:
+        def __init__(self, _room_id, *, session):
+            self.session = session
+            self.running = False
+
+        @property
+        def is_running(self):
+            return self.running
+
+        def set_handler(self, _handler):
+            pass
+
+        def start(self):
+            self.running = True
+
+        def stop(self):
+            self.running = False
+
+        async def join(self):
+            pass
+
+        async def close(self):
+            pass
+
+    async def run_test():
+        login_failures = []
+        monkeypatch.setattr(danmaku_client, "AuthManager", FakeAuthManager)
+        monkeypatch.setattr(danmaku_client.blivedm, "BLiveClient", FakeBLiveClient)
+
+        client = DanmakuClient(7450109)
+        client.set_login_failed_callback(login_failures.append)
+
+        await client.start()
+        await client.stop()
+
+        assert login_failures == ["本地保存的登录信息已失效，请重新登录"]
 
     asyncio.run(run_test())
 

--- a/tests/test_danmaku_widget.py
+++ b/tests/test_danmaku_widget.py
@@ -1,12 +1,10 @@
-import ast
 import asyncio
 import os
-from pathlib import Path
 
 import pytest
-from PyQt6.QtCore import QEvent
-from PyQt6.QtGui import QFont, QImage
-from PyQt6.QtWidgets import QApplication, QLabel
+from PyQt6.QtCore import QEvent, QPoint
+from PyQt6.QtGui import QFont
+from PyQt6.QtWidgets import QApplication, QLabel, QWidget
 
 from bilihud import danmaku_widget
 from bilihud.live_audience import AudienceSnapshot, AudienceUser
@@ -22,100 +20,240 @@ def _app():
     return _QT_APP
 
 
-def test_danmaku_widget_does_not_manually_process_qt_events():
-    source = Path("src/bilihud/danmaku_widget.py").read_text(encoding="utf-8")
+def test_layer_shell_drag_updates_anchor_position(monkeypatch):
+    class FakeGeometry:
+        def x(self):
+            return 0
 
-    assert "QApplication.processEvents()" not in source
+        def y(self):
+            return 0
 
+        def width(self):
+            return 1920
 
-def test_layer_shell_drag_does_not_force_widget_repaint():
-    source = Path("src/bilihud/danmaku_widget.py").read_text(encoding="utf-8")
-    tree = ast.parse(source)
-    method_source = None
+        def height(self):
+            return 1080
 
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ClassDef) and node.name == "DanmakuWidget":
-            for item in node.body:
-                if isinstance(item, ast.FunctionDef) and item.name == "mouseMoveEvent":
-                    method_source = ast.get_source_segment(source, item)
-                    break
+    class FakeScreen:
+        def geometry(self):
+            return FakeGeometry()
 
-    assert method_source is not None
-    assert "set_anchor_position" in method_source
-    assert "self.update()" not in method_source
+    class FakeWindow:
+        def screen(self):
+            return FakeScreen()
 
+    class FakeLayerShell:
+        def __init__(self):
+            self.calls = []
 
-def test_layer_shell_anchor_position_commits_surface():
-    source = Path("src/bilihud/layer_shell_bridge.cpp").read_text(encoding="utf-8")
-    function_start = source.index("void set_anchor_position")
-    function_end = source.index("void set_keyboard_interactivity", function_start)
-    function_source = source[function_start:function_end]
+        def set_anchor_position(self, pointer, x, y):
+            self.calls.append((pointer, x, y))
 
-    assert "ls_window->setMargins(margins);" in function_source
-    assert "nativeResourceForWindow(\"surface\", window)" in function_source
-    assert "wl_surface_commit(surface);" in function_source
+    class FakePosition:
+        def toPoint(self):
+            return QPoint(20, 20)
 
+    class FakeEvent:
+        def position(self):
+            return FakePosition()
 
-def test_danmaku_widget_imports_qimage_for_emoticon_loader():
-    assert danmaku_widget.QImage is QImage
+        def accept(self):
+            pass
 
+    layer_shell = FakeLayerShell()
+    widget = danmaku_widget.DanmakuWidget.__new__(danmaku_widget.DanmakuWidget)
+    widget._dragging = True
+    widget._drag_local_pos = QPoint(10, 10)
+    widget.layer_pos = QPoint(100, 100)
+    widget.layer_shell_lib = layer_shell
 
-def test_danmaku_widget_imports_mirror_components():
-    source = Path("src/bilihud/danmaku_widget.py").read_text(encoding="utf-8")
+    monkeypatch.setattr(danmaku_widget.sip, "unwrapinstance", lambda _window: 123)
+    monkeypatch.setattr(danmaku_widget.DanmakuWidget, "windowHandle", lambda _self: FakeWindow())
+    monkeypatch.setattr(danmaku_widget.DanmakuWidget, "width", lambda _self: 300)
 
-    assert "from .mirror_state import MIRROR_DEFAULT_PORT, MIRROR_ROUTE, MirrorState" in source
-    assert "from .mirror_server import MirrorServer" in source
-    assert "from .mirror_settings_dialog import MirrorSettingsDialog" in source
+    danmaku_widget.DanmakuWidget.mouseMoveEvent(widget, FakeEvent())
 
-
-def test_danmaku_widget_add_message_publishes_to_mirror():
-    source = Path("src/bilihud/danmaku_widget.py").read_text(encoding="utf-8")
-
-    assert "entry = self.mirror_state.add_message(message)" in source
-    assert "self.mirror_server.publish_append(entry)" in source
-
-
-def test_danmaku_widget_exposes_bilihud_mirror_tray_action():
-    source = Path("src/bilihud/danmaku_widget.py").read_text(encoding="utf-8")
-
-    assert 'QAction("BiliHUD Mirror", self)' in source
-    assert source.count('QAction("BiliHUD Mirror", self)') == 1
-    assert "open_mirror_settings" in source
-    assert "MIRROR_ROUTE" in source
-    assert "显示 Mirror URL" not in source
-    assert "启动 BiliHUD Mirror" not in source
-    assert "停止 BiliHUD Mirror" not in source
-    assert "obs-mirror" not in source
-    assert "obs-danmaku" not in source
+    assert widget.layer_pos == QPoint(110, 110)
+    pointer, x, y = layer_shell.calls[0]
+    assert pointer.value == 123
+    assert (x, y) == (110, 110)
 
 
-def test_danmaku_widget_opens_single_mirror_settings_dialog():
-    source = Path("src/bilihud/danmaku_widget.py").read_text(encoding="utf-8")
+def test_danmaku_widget_exposes_bilihud_mirror_tray_action(monkeypatch):
+    class Signal:
+        def __init__(self):
+            self.callbacks = []
 
-    assert "def open_mirror_settings(self):" in source
-    assert "MirrorSettingsDialog(self)" in source
-    assert "_mirror_settings_dialog" in source
+        def connect(self, callback):
+            self.callbacks.append(callback)
+
+        def emit(self, *args):
+            for callback in self.callbacks:
+                callback(*args)
+
+    class Action:
+        def __init__(self, text, _parent):
+            self.text = text
+            self.triggered = Signal()
+
+        def setCheckable(self, _checkable):
+            pass
+
+    class Menu:
+        def setStyleSheet(self, _style):
+            pass
+
+        def addAction(self, _action):
+            pass
+
+        def addSeparator(self):
+            pass
+
+    class TrayIcon:
+        def __init__(self, _parent):
+            self.activated = Signal()
+
+        def setContextMenu(self, _menu):
+            pass
+
+        def show(self):
+            pass
+
+    events = []
+    _app()
+    widget = danmaku_widget.DanmakuWidget.__new__(danmaku_widget.DanmakuWidget)
+    widget.open_input_dialog = lambda: events.append("input")
+    widget.toggle_visibility = lambda: events.append("visibility")
+    widget.toggle_gaming_mode_from_tray = lambda checked: events.append(("gaming", checked))
+    widget.open_qr_login = lambda: events.append("login")
+    widget.open_live_control = lambda: events.append("live-control")
+    widget.open_mirror_settings = lambda: events.append("mirror")
+    widget.quit_app = lambda: events.append("quit")
+    monkeypatch.setattr(danmaku_widget, "QAction", Action)
+    monkeypatch.setattr(danmaku_widget, "QMenu", Menu)
+    monkeypatch.setattr(danmaku_widget, "QSystemTrayIcon", TrayIcon)
+    monkeypatch.setattr(danmaku_widget.os.path, "exists", lambda _path: False)
+
+    danmaku_widget.DanmakuWidget.setup_tray_icon(widget)
+
+    assert widget.tray_mirror_action.text == "BiliHUD Mirror"
+    widget.tray_mirror_action.triggered.emit()
+    assert events == ["mirror"]
 
 
-def test_danmaku_widget_keeps_mirror_enabled_config_when_quitting():
-    source = Path("src/bilihud/danmaku_widget.py").read_text(encoding="utf-8")
+def test_danmaku_widget_opens_single_mirror_settings_dialog(monkeypatch):
+    class FakeDialog:
+        instances = []
 
-    assert "await self.shutdown_mirror_server()" in source
-    assert "def mirror_status_text(self)" in source
-    assert "self.mirror_error" in source
-    assert 'return f"启动失败: {self.mirror_error}"' in source
-    assert "async def set_mirror_enabled(self, enabled: bool)" in source
-    assert source.index("async def shutdown_mirror_server") > source.index("async def stop_mirror_server")
-    shutdown_body = source.split("async def shutdown_mirror_server", 1)[1]
-    assert 'save_config({"mirror_enabled": False' not in shutdown_body
+        def __init__(self, owner):
+            self.owner = owner
+            self.calls = []
+            self.instances.append(self)
+
+        def refresh(self):
+            self.calls.append("refresh")
+
+        def show(self):
+            self.calls.append("show")
+
+        def raise_(self):
+            self.calls.append("raise")
+
+        def activateWindow(self):
+            self.calls.append("activate")
+
+    _app()
+    widget = danmaku_widget.DanmakuWidget.__new__(danmaku_widget.DanmakuWidget)
+    QWidget.__init__(widget)
+    monkeypatch.setattr(danmaku_widget, "MirrorSettingsDialog", FakeDialog)
+
+    danmaku_widget.DanmakuWidget.open_mirror_settings(widget)
+    danmaku_widget.DanmakuWidget.open_mirror_settings(widget)
+
+    assert len(FakeDialog.instances) == 1
+    assert FakeDialog.instances[0].calls == [
+        "refresh",
+        "show",
+        "raise",
+        "activate",
+        "refresh",
+        "show",
+        "raise",
+        "activate",
+    ]
 
 
-def test_danmaku_widget_emoticon_requests_include_bilibili_headers():
-    source = Path("src/bilihud/danmaku_widget.py").read_text(encoding="utf-8")
+def test_danmaku_widget_keeps_mirror_enabled_config_when_shutting_down():
+    class FakeServer:
+        def __init__(self):
+            self.stop_calls = 0
 
-    assert 'request.setRawHeader(b"Referer", b"https://live.bilibili.com/")' in source
-    assert "https://live.bilibili.com/" in source
-    assert "QNetworkRequest.KnownHeaders.UserAgentHeader" in source
+        async def stop(self):
+            self.stop_calls += 1
+
+    async def run_test():
+        server = FakeServer()
+        events = []
+        widget = danmaku_widget.DanmakuWidget.__new__(danmaku_widget.DanmakuWidget)
+        widget.mirror_server = server
+        widget.mirror_enabled = True
+        widget.refresh_mirror_settings = lambda: events.append("refresh")
+
+        await danmaku_widget.DanmakuWidget.shutdown_mirror_server(widget)
+
+        assert server.stop_calls == 1
+        assert widget.mirror_server is None
+        assert widget.mirror_enabled is True
+        assert events == ["refresh"]
+
+    asyncio.run(run_test())
+
+
+def test_emoticon_picker_requests_bilibili_headers(monkeypatch):
+    class FakeRequest:
+        class KnownHeaders:
+            UserAgentHeader = "user-agent"
+
+        def __init__(self, url):
+            self.url = url
+            self.raw_headers = {}
+            self.headers = {}
+
+        def setRawHeader(self, name, value):
+            self.raw_headers[name] = value
+
+        def setHeader(self, name, value):
+            self.headers[name] = value
+
+    class Signal:
+        def connect(self, _callback):
+            pass
+
+    class Reply:
+        finished = Signal()
+
+    class NetworkManager:
+        def __init__(self):
+            self.requests = []
+
+        def get(self, request):
+            self.requests.append(request)
+            return Reply()
+
+    class Button:
+        pass
+
+    _app()
+    picker = danmaku_widget.EmoticonPickerPopup()
+    manager = NetworkManager()
+    picker._network_manager = manager
+    monkeypatch.setattr(danmaku_widget, "QNetworkRequest", FakeRequest)
+
+    picker._load_icon(Button(), "https://i0.hdslb.com/bfs/live/emote.png")
+
+    request = manager.requests[0]
+    assert request.raw_headers == {b"Referer": b"https://live.bilibili.com/"}
+    assert request.headers == {"user-agent": "Mozilla/5.0 BiliHUD"}
 
 
 def test_danmaku_delegate_renders_local_system_messages():
@@ -245,8 +383,13 @@ def test_danmaku_widget_prunes_history_before_scrolling_to_bottom():
             calls.append("scroll")
 
     class MirrorState:
-        def add_message(self, _message):
+        def add_message(self, message):
+            calls.append(("mirror-add", message))
             return {"seq": 1}
+
+    class MirrorServer:
+        def publish_append(self, entry):
+            calls.append(("mirror-publish", entry))
 
     calls = []
     class Widget:
@@ -255,11 +398,14 @@ def test_danmaku_widget_prunes_history_before_scrolling_to_bottom():
     widget = Widget()
     widget.danmaku_list = FakeList()
     widget.mirror_state = MirrorState()
-    widget.mirror_server = None
+    widget.mirror_server = MirrorServer()
+    message = Message()
 
-    danmaku_widget.DanmakuWidget.add_message(widget, Message())
+    danmaku_widget.DanmakuWidget.add_message(widget, message)
 
     assert calls.index("take") < calls.index("scroll")
+    assert calls.index("scroll") < calls.index(("mirror-add", message))
+    assert ("mirror-publish", {"seq": 1}) in calls
 
 
 def test_modern_input_widget_exposes_emoticon_button_signal():
@@ -376,24 +522,81 @@ def test_emoticon_picker_keeps_one_tab_per_package():
     assert [picker.tabs.tabText(index) for index in range(picker.tabs.count())] == ["通用表情", "UP主大表情"]
 
 
-def test_danmaku_widget_source_wires_emoticon_picker_to_client_methods():
-    source = Path("src/bilihud/danmaku_widget.py").read_text(encoding="utf-8")
+def test_danmaku_widget_sends_selected_live_emoticon():
+    class Client:
+        def __init__(self):
+            self.sent = []
 
-    assert "self.input_area.emoticon_requested.connect(self.open_emoticon_picker)" in source
-    assert "await self.danmaku_client.fetch_live_emoticons()" in source
-    assert "await self.danmaku_client.send_live_emoticon(emoticon)" in source
+        async def send_live_emoticon(self, emoticon):
+            self.sent.append(emoticon)
+            return False, "没有发送权限"
+
+    async def run_test():
+        client = Client()
+        errors = []
+        widget = danmaku_widget.DanmakuWidget.__new__(danmaku_widget.DanmakuWidget)
+        widget.danmaku_client = client
+        widget.add_system_message = lambda message, level: errors.append((message, level))
+        emoticon = LiveEmoticon(
+            emoji="啊",
+            url="https://i0.hdslb.com/bfs/live/a.png",
+            width=100,
+            height=100,
+            perm=1,
+            unique="official_331",
+            emoticon_id=331,
+        )
+
+        await danmaku_widget.DanmakuWidget._send_live_emoticon_task(widget, emoticon)
+
+        assert client.sent == [emoticon]
+        assert errors == [("发送失败: 没有发送权限", "error")]
+
+    asyncio.run(run_test())
 
 
-def test_live_control_uses_anchor_room_and_connects_hud_when_opened_source():
-    source = Path("src/bilihud/danmaku_widget.py").read_text(encoding="utf-8")
+def test_live_control_uses_authenticated_anchor_room(monkeypatch):
+    class Session:
+        def __init__(self):
+            self.closed = False
+            self.close_calls = 0
 
-    assert "get_anchor_live_room_id" in source
-    assert "async def open_live_control(self):" in source
-    assert "anchor_room_id = await self._ensure_live_control_room()" in source
-    assert "self._live_control_dialog.set_room_id(anchor_room_id)" in source
-    assert "self._live_control_dialog.set_room_id(self.room_id)" not in source
-    assert "await self._connect_to_room_id(anchor_room_id)" in source
-    assert "set_ensure_hud_room_callback" not in source
+        async def close(self):
+            self.closed = True
+            self.close_calls += 1
+
+    class AuthManager:
+        def __init__(self):
+            self.session = Session()
+
+        async def create_authenticated_session(self):
+            return self.session, True
+
+    async def get_anchor_room(session):
+        assert session is auth_manager.session
+        return 998877
+
+    async def run_test():
+        nonlocal auth_manager
+        auth_manager = AuthManager()
+        connected_rooms = []
+        widget = danmaku_widget.DanmakuWidget.__new__(danmaku_widget.DanmakuWidget)
+
+        async def connect_to_room(room_id):
+            connected_rooms.append(room_id)
+
+        widget._connect_to_room_id = connect_to_room
+        monkeypatch.setattr(danmaku_widget, "AuthManager", lambda: auth_manager)
+        monkeypatch.setattr(danmaku_widget, "get_anchor_live_room_id", get_anchor_room)
+
+        room_id = await danmaku_widget.DanmakuWidget._ensure_live_control_room(widget)
+
+        assert room_id == 998877
+        assert connected_rooms == [998877]
+        assert auth_manager.session.close_calls == 1
+
+    auth_manager = None
+    asyncio.run(run_test())
 
 
 def test_connect_to_room_replaces_stale_same_room_client(monkeypatch):
@@ -463,12 +666,43 @@ def test_connect_to_room_replaces_stale_same_room_client(monkeypatch):
     asyncio.run(run_test())
 
 
-def test_live_control_start_live_does_not_manage_hud_connection():
-    source = Path("src/bilihud/live_control_dialog.py").read_text(encoding="utf-8")
+def test_disconnect_current_room_stops_client_and_clears_connection():
+    class Button:
+        def __init__(self):
+            self.enabled = True
 
-    assert "_ensure_hud_room_callback" not in source
-    assert "set_ensure_hud_room_callback" not in source
-    assert "_ensure_hud_room" not in source
+        def setEnabled(self, enabled):
+            self.enabled = enabled
+
+    class Client:
+        def __init__(self):
+            self.stop_calls = 0
+
+        async def stop(self):
+            self.stop_calls += 1
+
+    async def run_test():
+        events = []
+        client = Client()
+        widget = danmaku_widget.DanmakuWidget.__new__(danmaku_widget.DanmakuWidget)
+        widget.connect_button = Button()
+        widget.danmaku_client = client
+        widget._audience_snapshot = None
+
+        async def stop_audience_refresh():
+            events.append("audience-stop")
+
+        widget._stop_audience_refresh = stop_audience_refresh
+        widget._set_disconnected_ui = lambda: events.append("disconnected")
+
+        await danmaku_widget.DanmakuWidget._disconnect_current_room(widget)
+
+        assert client.stop_calls == 1
+        assert widget.danmaku_client is None
+        assert widget.connect_button.enabled is False
+        assert events == ["audience-stop", "disconnected"]
+
+    asyncio.run(run_test())
 
 
 def audience_snapshot(room_id=7450109):

--- a/tests/test_mirror_server.py
+++ b/tests/test_mirror_server.py
@@ -1,5 +1,4 @@
 import asyncio
-import inspect
 import json
 
 from aiohttp import ClientSession, web
@@ -64,22 +63,69 @@ def test_mirror_event_payload_serializes_named_event():
     assert json.loads(data_line.removeprefix("data: ")) == {"seq": 1, "segments": []}
 
 
-def test_mirror_server_registers_sse_client_before_snapshot_write():
-    source = inspect.getsource(MirrorServer._handle_events)
+async def _read_sse_event(response):
+    event_line = await asyncio.wait_for(response.content.readline(), timeout=1)
+    data_line = await asyncio.wait_for(response.content.readline(), timeout=1)
+    blank_line = await asyncio.wait_for(response.content.readline(), timeout=1)
 
-    assert source.index("self._clients.add(queue)") < source.index('mirror_event_payload("snapshot"')
+    assert event_line.startswith(b"event: ")
+    assert data_line.startswith(b"data: ")
+    assert blank_line == b"\n"
+    return event_line.decode().removeprefix("event: ").strip(), json.loads(
+        data_line.decode().removeprefix("data: ").strip()
+    )
+
+
+def test_mirror_server_streams_snapshot_before_later_messages():
+    async def run_test():
+        state = MirrorState()
+        state.add_message({"uname": "Locez", "msg": "历史消息"})
+        mirror_server = MirrorServer(state, port=0)
+        await mirror_server.start()
+
+        try:
+            events_url = f"http://127.0.0.1:{_site_port(mirror_server._site)}{MIRROR_EVENTS_ROUTE}"
+            async with ClientSession() as session:
+                async with session.get(events_url) as response:
+                    assert response.status == 200
+                    assert response.headers["Content-Type"].startswith("text/event-stream")
+                    event_name, snapshot = await _read_sse_event(response)
+
+                    assert event_name == "snapshot"
+                    assert snapshot == state.snapshot()
+
+                    next_entry = {"seq": 2, "user": "新用户", "segments": []}
+                    mirror_server.publish_append(next_entry)
+                    event_name, entry = await _read_sse_event(response)
+
+                    assert event_name == "append"
+                    assert entry == next_entry
+        finally:
+            await mirror_server.stop()
+
+    asyncio.run(run_test())
 
 
 def test_mirror_server_registers_image_proxy_route():
-    source = inspect.getsource(MirrorServer.start)
+    async def run_test():
+        mirror_server = MirrorServer(MirrorState(), port=0)
+        await mirror_server.start()
 
-    assert "self._handle_image" in source
-    assert "MIRROR_IMAGE_ROUTE" in source
+        try:
+            image_url = f"http://127.0.0.1:{_site_port(mirror_server._site)}{MIRROR_IMAGE_ROUTE}"
+            async with ClientSession() as session:
+                async with session.get(image_url, params={"url": "file:///tmp/emote.png"}) as response:
+                    assert response.status == 400
+                    assert await response.text() == "Invalid image URL"
+        finally:
+            await mirror_server.stop()
+
+    asyncio.run(run_test())
 
 
 def test_mirror_image_proxy_fetches_image_with_bilibili_headers():
     async def run_test():
-        seen_headers = {}
+        seen_headers: dict[str, str | None] = {}
 
         async def handle_source_image(request: web.Request) -> web.Response:
             seen_headers["Referer"] = request.headers.get("Referer")

--- a/tests/test_mirror_settings_dialog.py
+++ b/tests/test_mirror_settings_dialog.py
@@ -1,16 +1,41 @@
-from pathlib import Path
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt6.QtWidgets import QApplication, QPushButton, QWidget
 
 from bilihud.mirror_settings_dialog import MirrorSettingsDialog
 
 
 def test_mirror_settings_dialog_exposes_url_and_persistent_enable_controls():
-    source = Path("src/bilihud/mirror_settings_dialog.py").read_text(encoding="utf-8")
+    app = QApplication.instance() or QApplication([])
 
-    assert MirrorSettingsDialog.__name__ == "MirrorSettingsDialog"
-    assert "启用 BiliHUD Mirror" in source
-    assert "复制 URL" in source
-    assert "self.url_input.setReadOnly(True)" in source
-    assert "set_mirror_state" in source
-    assert "mirror_url" in source
-    assert "set_mirror_enabled" in source
-    assert "mirror_status_text" in source
+    class Owner(QWidget):
+        mirror_url = "http://127.0.0.1:8765/bilihud-mirror"
+        mirror_enabled = True
+
+        def mirror_status_text(self):
+            return "已启动"
+
+        async def set_mirror_enabled(self, _enabled):
+            pass
+
+    owner = Owner()
+    dialog = MirrorSettingsDialog(owner)
+
+    assert dialog.enabled_checkbox.text() == "启用 BiliHUD Mirror"
+    buttons = dialog.findChildren(QPushButton)
+    assert [button.text() for button in buttons] == ["复制 URL", "关闭"]
+    assert dialog.url_input.isReadOnly()
+    assert dialog.url_input.text() == owner.mirror_url
+    assert dialog.status_label.text() == "已启动"
+
+    dialog.set_mirror_state(False, "未启动", "http://127.0.0.1:9000/bilihud-mirror")
+
+    assert dialog.enabled_checkbox.isChecked() is False
+    assert dialog.status_label.text() == "未启动"
+    assert dialog.url_input.text() == "http://127.0.0.1:9000/bilihud-mirror"
+
+    dialog.close()
+    owner.close()
+    app.processEvents()

--- a/uv.lock
+++ b/uv.lock
@@ -203,7 +203,7 @@ wheels = [
 
 [[package]]
 name = "bilihud"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -541,7 +541,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -731,17 +731,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -756,18 +756,18 @@ resolution-markers = [
     "python_full_version >= '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "psutil", marker = "python_full_version >= '3.11' and sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil", marker = "sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/59/165d3b4d75cc34add3122c4417ecb229085140ac573103c223cd01dde96f/ipython-9.15.0.tar.gz", hash = "sha256:da2819ce2aa83135257df830660b1176d986c3d2876db24df01974fa955b2756", size = 4442580, upload-time = "2026-06-26T11:03:35.913Z" }
 wheels = [
@@ -779,7 +779,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- document durable Presentation/Application/Domain/Infrastructure dependency rules
- add executable AST import-boundary checks for pure and future domain modules
- replace key source-string and implementation-order assertions with behavior tests for auth failure, room lifecycle, Mirror SSE/routes, Qt UI state, and live controls
- run the architecture check as an explicit CI step
- refresh `uv.lock` in a separate commit

## Verification

- `uv run pytest -q` -> 125 passed
- blocking Ruff checks -> passed
- changed test files Ruff -> passed
- `uv build` -> passed
- `uv run ty check src` -> existing baseline: 83 diagnostics
- full Ruff -> existing baseline: 194 diagnostics

Closes #20