### PR TITLE
fix: make application lifecycle shutdown explicit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,16 @@ Strong typing is a continuous requirement for all new and modified code.
 - Use the type checker configured by the repository; do not hide errors by expanding exclusions.
 - Every type suppression must document its reason, impact, and follow-up path.
 
+## Explicit Contracts and Dynamic Access
+
+- Initialize every instance attribute in `__init__` or an explicit factory, with a declared type. Optional state must be initialized to `None`; callers should use direct attribute access and explicit `is None` checks.
+- Do not use reflection-style access (`getattr`, `hasattr`, `setattr`, `delattr`, `__dict__`, `globals()`, or `locals()`) to model application or domain state, discover fields, or hide incomplete initialization. Do not add trivial getter/setter methods or generic `get(name)` APIs for ordinary fields; use typed attributes or properties. Use a method when it performs computation, validation, a meaningful side effect, or protects an invariant.
+- Dynamic access is allowed only at an external compatibility boundary, such as a Qt/plugin/third-party version probe. Isolate it in a typed adapter or small helper, document why it is unavoidable, validate the result, and test both supported and unavailable cases. Do not scatter capability checks through business or presentation logic.
+- Do not use `value or default` or missing-key fallbacks when `False`, `0`, an empty value, or an explicitly missing value have different meanings. Use explicit `None` checks and validation.
+- Do not use `cast`, `# type: ignore`, or `assert` to conceal a missing contract. Narrow types through explicit checks or adapters; use `assert` only for an internal invariant that cannot be supplied by external input and whose failure is a programming error.
+- Do not use `eval`, `exec`, string-based dispatch, or dynamic imports for ordinary control flow. Prefer explicit maps, protocols, registries, or adapters. Isolate and review any plugin boundary that genuinely requires dynamic loading.
+- Dependencies and ownership must be explicit constructor or function inputs. Do not locate services through global state, service factories deep inside a component, widget parent traversal, or reflective lookup; wire them at the composition root.
+
 ## Documentation and Comments
 
 - Public modules, classes, protocols, functions, and methods must have concise docstrings that explain their responsibility and relevant input, output, side effect, ownership, or failure contract.
@@ -82,7 +92,10 @@ Strong typing is a continuous requirement for all new and modified code.
 
 - Use explicit resource ownership and context management.
 - Avoid mutable default arguments, implicit global state, and duplicated business logic.
+- Constructors may build in-memory/UI state, but must not perform network I/O, spawn background tasks or subprocesses, or register process-global hooks. Expose explicit start/initialize and stop/close/shutdown operations for resources and workflows.
 - Catch only exceptions that can be handled; avoid blanket `except Exception` blocks.
+- Never use `except Exception: pass`, convert an unknown failure into success, or log an error while leaving ownership/state ambiguous. Catch expected failures at the boundary, preserve useful context, and make cleanup failures observable.
+- Do not use blocking I/O or `time.sleep` on an event-loop/UI thread. Use an async API or an explicitly owned worker, with a timeout and a cleanup path.
 - Use the repository's logging mechanism instead of `print()` for production diagnostics.
 - Represent failures with explicit error types or result values.
 - Keep functions focused and avoid unnecessary complexity.
@@ -94,9 +107,13 @@ Strong typing is a continuous requirement for all new and modified code.
 - Every asynchronous task must have a clear creator and owner.
 - Keep task handles and cancel, await, and inspect them at the appropriate lifecycle boundary.
 - Do not create unowned fire-and-forget tasks.
+- Treat tasks created by callbacks, Qt signals, timers, `qasync`, `asyncio.create_task`, or `ensure_future` the same way: retain the handle under the owning component or supervisor and provide a cancellation/await path.
+- Treat `run_in_executor`, `asyncio.to_thread`, and subprocess work as owned resources too. Define timeout, cancellation, and shutdown behavior; cancellation of the wrapper must not be mistaken for cancellation of the underlying blocking operation.
+- Handle `asyncio.CancelledError` as control flow: release owned resources and re-raise unless the caller explicitly owns cancellation recovery. Use `BaseException` catches only for narrowly scoped cleanup that re-raises or records the failure.
 - Start, stop, retry, and shutdown operations should be predictable and as idempotent as practical.
 - Network sessions, files, servers, threads, and subprocesses must have explicit cleanup paths.
 - Do not rely on object destruction or process exit to release critical resources.
+- Do not use nested event loops such as `exec()` to make an asynchronous workflow appear synchronous. Keep modal behavior at the presentation boundary; prefer non-blocking `open()`/`show()` plus an explicit completion or shutdown contract. If a platform API requires a nested loop, document its ownership and cancellation limitations.
 - Test cancellation, timeouts, repeated calls, and exceptional shutdown paths.
 
 ## Security
@@ -106,6 +123,7 @@ Strong typing is a continuous requirement for all new and modified code.
 - Do not bypass authentication, TLS, validation, or permission checks for convenience.
 - Validate every external input.
 - Treat external URLs, file paths, redirects, and subprocess arguments as security boundaries.
+- Pass subprocess arguments as an explicit argument list; do not use `os.system`, shell string concatenation, or `shell=True` unless the boundary is deliberate, validated, and documented.
 - Apply reasonable timeouts and response-size limits to network requests.
 - Security behavior must be covered by automated tests rather than relying on callers to use an API correctly.
 
@@ -139,6 +157,8 @@ changed lines or restate the implementation.
   file.
 - Use fakes, stubs, or adapters for external services.
 - Cover normal, failure, cancellation, timeout, and repeated-call paths.
+- Exercise behavior through public construction and interfaces. Do not use `__new__` or manually populate private fields to bypass initialization for ordinary behavior tests; an isolated lifecycle/Qt harness may do so only when full construction invokes unavailable platform resources, and it must initialize the tested contract explicitly.
+- Synchronize asynchronous tests with events, futures, or task handles. Do not rely on arbitrary sleeps or wall-clock timing except for an explicit timeout contract.
 - Run the full test suite when changing public behavior, lifecycle management, or cross-module contracts.
 - Run the relevant build, packaging, or CI checks when changing dependencies or build configuration.
 - Never solve a failing test by deleting coverage, weakening assertions, or expanding exclusions without documenting the reason.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,13 @@ Strong typing is a continuous requirement for all new and modified code.
 - Prefer the standard library and existing project tools before adding dependencies.
 - Do not modify third-party vendored code unless the task explicitly requires it.
 
+## File Size
+
+- New or modified Python source files should normally stay within 500 lines.
+- Files over 800 lines should be split by responsibility; document the reason in the PR when that is not practical.
+- Splitting must follow responsibility and dependency boundaries; do not split mechanically just to reduce line count.
+- Generated and third-party code are exempt.
+
 ## Async and Lifecycle
 
 - Every asynchronous task must have a clear creator and owner.

--- a/src/bilihud/danmaku_client.py
+++ b/src/bilihud/danmaku_client.py
@@ -69,6 +69,12 @@ class DanmakuClient:
         self._live_emoticon_cache: list[LiveEmoticonPackage] | None = None  # Short-lived room cache.
         self._live_emoticon_cache_at = 0.0  # Monotonic timestamp for the emoticon cache.
 
+    @property
+    def is_running(self) -> bool:
+        """Report the underlying BLive connection state through this client boundary."""
+        client = self.client
+        return client is not None and client.is_running
+
     def set_danmaku_callback(self, callback: Callable[[web_models.DanmakuMessage], None]) -> None:
         """设置弹幕接收回调函数"""
         self.on_danmaku_received = callback
@@ -310,17 +316,17 @@ class DanmakuClient:
 
         if client:
             try:
-                if getattr(client, "is_running", False):
+                if client.is_running:
                     client.stop()
                     join_task = asyncio.create_task(client.join())
                     try:
                         await asyncio.wait_for(asyncio.shield(join_task), timeout=normal_timeout)
-                    except asyncio.TimeoutError:
+                    except TimeoutError:
                         if session and not session.closed:
                             await session.close()
                         try:
                             await asyncio.wait_for(asyncio.shield(join_task), timeout=forced_timeout)
-                        except asyncio.TimeoutError as exc:
+                        except TimeoutError as exc:
                             stop_error = DanmakuShutdownError(
                                 f"弹幕连接未能在强制关闭后停止，room_id={self.room_id}"
                             )

--- a/src/bilihud/danmaku_widget.py
+++ b/src/bilihud/danmaku_widget.py
@@ -5,14 +5,14 @@ import html
 import logging
 import os
 import sys
+from collections.abc import Coroutine
 from ctypes import c_int, c_ulong, c_void_p
 from dataclasses import replace
-from typing import Optional
+from typing import Any, Optional
 
 import blivedm.models.web as web_models
 import PyQt6.sip as sip
-import qasync
-from PyQt6.QtCore import QPoint, QSize, Qt, QTimer, QUrl, pyqtSignal
+from PyQt6.QtCore import QPoint, QSize, Qt, QTimer, QUrl, pyqtSignal, pyqtSlot
 from PyQt6.QtGui import (
     QAction,
     QBrush,
@@ -66,6 +66,7 @@ from .layer_shell_loader import (
     gaming_mode_available,
     should_disable_layer_shell,
 )
+from .lifecycle import TaskScope, TaskSupervisor, cancel_task
 from .live_api import get_anchor_live_room_id
 from .live_audience import AudienceSnapshot
 from .live_control_dialog import LiveControlDialog
@@ -744,9 +745,17 @@ class DanmakuWidget(QWidget):
         room_id: int = 0,
         sessdata: str = "",
         services: AppServices | None = None,
+        task_supervisor: TaskSupervisor | None = None,
     ) -> None:
         """Create the widget and load its shared typed services and saved settings."""
         super().__init__()
+        self._task_supervisor = task_supervisor if task_supervisor is not None else TaskSupervisor()
+        self._owns_task_supervisor = task_supervisor is None
+        self._task_scope: TaskScope = self._task_supervisor.create_scope("danmaku-widget")
+        self._mirror_start_task: asyncio.Task[None] | None = None  # Startup task canceled before server cleanup.
+        self._action_tasks: set[asyncio.Task[Any]] = set()  # Qt-triggered workflows owned by this widget.
+        self._shutting_down = False  # Prevent new work from starting during application shutdown.
+        self._shutdown_complete = False  # Makes repeated application stop requests idempotent.
         self.room_id = room_id  # Current room displayed and used by the client.
         self.sessdata = sessdata  # Optional session override supplied by the caller.
         self.services = services if services is not None else create_default_services()
@@ -756,6 +765,9 @@ class DanmakuWidget(QWidget):
         self._audience_refresh_task: asyncio.Task[None] | None = None  # Cancelled on disconnect.
         self._audience_generation = 0
         self._audience_snapshot: AudienceSnapshot | None = None
+        self._live_control_dialog: LiveControlDialog | None = None  # Reused live-control dialog owner.
+        self._mirror_settings_dialog: MirrorSettingsDialog | None = None  # Reused Mirror settings owner.
+        self._qr_login_dialog: QRLoginDialog | None = None  # Active modal QR-login dialog, if any.
         self.is_gaming_mode = False
         self.layer_shell_lib = None
         self.layer_shell_disabled_reason = ""
@@ -782,8 +794,6 @@ class DanmakuWidget(QWidget):
         self.setup_tray_icon()
         self.update_gaming_mode_availability()
         self.setup_danmaku_client()
-        if self.mirror_enabled:
-            asyncio.create_task(self.start_mirror_server())
         
         # 加载保存的配置
         if config.room_id is not None:
@@ -794,6 +804,45 @@ class DanmakuWidget(QWidget):
         
         # Try to activate Layer Shell initially
         QTimer.singleShot(100, self.activate_layer_shell)
+
+    async def start(self) -> None:
+        """Start widget-owned background workflows after construction is complete."""
+        if self._shutting_down or not self.mirror_enabled:
+            return
+        if self._mirror_start_task is None or self._mirror_start_task.done():
+            self._mirror_start_task = self._task_scope.create_task(
+                self.start_mirror_server(),
+                name="mirror-startup",
+            )
+
+    def _create_action_task(
+        self,
+        coroutine: Coroutine[Any, Any, None],
+        *,
+        name: str,
+    ) -> asyncio.Task[None]:
+        """Create and retain one Qt-triggered workflow under the widget owner."""
+        task = self._task_scope.create_task(coroutine, name=name)
+        self._action_tasks.add(task)
+        task.add_done_callback(self._discard_action_task)
+        return task
+
+    def _discard_action_task(self, task: asyncio.Task[Any]) -> None:
+        """Remove a completed Qt-triggered workflow from the widget registry."""
+        self._action_tasks.discard(task)
+
+    async def _cancel_action_tasks(self) -> None:
+        """Cancel and await Qt-triggered workflows before closing their resources."""
+        current_task = asyncio.current_task()
+        pending = tuple(
+            task
+            for task in self._action_tasks
+            if not task.done() and task is not current_task
+        )
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
     
     def _delayed_adjust_height(self):
         """Debounced execution of item layout update"""
@@ -1233,11 +1282,21 @@ class DanmakuWidget(QWidget):
 
     def trigger_send(self, text: str):
         """处理发送弹幕请求"""
-        if not text: return
-        asyncio.create_task(self._send_danmaku_task(text))
+        if not text or self._shutting_down:
+            return
+        self._task_scope.create_task(self._send_danmaku_task(text), name="send-danmaku")
 
-    @qasync.asyncSlot()
-    async def open_emoticon_picker(self):
+    @pyqtSlot()
+    def open_emoticon_picker(self) -> asyncio.Task[None] | None:
+        """Schedule the emoticon loading workflow under the widget owner."""
+        if self._shutting_down:
+            return None
+        return self._create_action_task(
+            self._open_emoticon_picker(),
+            name="open-emoticon-picker",
+        )
+
+    async def _open_emoticon_picker(self) -> None:
         if not self.danmaku_client or not self.danmaku_client.session:
             self.add_system_message("未连接直播间，无法加载表情", "error")
             return
@@ -1257,7 +1316,12 @@ class DanmakuWidget(QWidget):
         self.emoticon_picker.set_packages(packages)
 
     def trigger_send_live_emoticon(self, emoticon: LiveEmoticon):
-        asyncio.create_task(self._send_live_emoticon_task(emoticon))
+        if self._shutting_down:
+            return
+        self._task_scope.create_task(
+            self._send_live_emoticon_task(emoticon),
+            name="send-live-emoticon",
+        )
 
     async def _send_live_emoticon_task(self, emoticon: LiveEmoticon):
         if not self.danmaku_client:
@@ -1283,11 +1347,94 @@ class DanmakuWidget(QWidget):
             self.show()
             self.activateWindow()
 
-    @qasync.asyncSlot()
-    async def quit_app(self):
-        await self._stop_audience_refresh()
-        if self.mirror_server is not None:
-            await self.shutdown_mirror_server()
+    async def shutdown(self) -> None:
+        """Stop widget-owned workflows and release their network resources."""
+        if self._shutdown_complete:
+            return
+
+        self._shutting_down = True
+        shutdown_errors: list[Exception] = []
+        try:
+            await self._cancel_action_tasks()
+
+            live_control_dialog = self._live_control_dialog
+            if live_control_dialog is not None:
+                try:
+                    await live_control_dialog.shutdown()
+                    live_control_dialog.close()
+                except Exception as exc:
+                    logger.exception("Failed to close live control dialog")
+                    shutdown_errors.append(exc)
+
+            qr_login_dialog = self._qr_login_dialog
+            if qr_login_dialog is not None:
+                try:
+                    await qr_login_dialog.shutdown()
+                    qr_login_dialog.close()
+                except Exception as exc:
+                    logger.exception("Failed to close QR login dialog")
+                    shutdown_errors.append(exc)
+                else:
+                    self._qr_login_dialog = None
+
+            mirror_settings_dialog = self._mirror_settings_dialog
+            if mirror_settings_dialog is not None:
+                mirror_settings_dialog.close()
+
+            try:
+                await cancel_task(self._mirror_start_task)
+            except Exception as exc:
+                logger.exception("Failed to cancel Mirror startup")
+                shutdown_errors.append(exc)
+            self._mirror_start_task = None
+            try:
+                await self._stop_audience_refresh()
+            except Exception as exc:
+                logger.exception("Failed to stop audience refresh")
+                shutdown_errors.append(exc)
+            try:
+                await self._task_scope.cancel_all()
+            except Exception as exc:
+                logger.exception("Failed to cancel widget tasks")
+                shutdown_errors.append(exc)
+
+            try:
+                await self.shutdown_mirror_server()
+            except Exception as exc:
+                logger.exception("Failed to close Mirror server")
+                shutdown_errors.append(exc)
+
+            client = self.danmaku_client
+            if client is not None:
+                try:
+                    await client.stop()
+                except Exception as exc:
+                    logger.exception("Failed to close danmaku client")
+                    shutdown_errors.append(exc)
+                else:
+                    self.danmaku_client = None
+        finally:
+            if self._owns_task_supervisor:
+                try:
+                    await self._task_supervisor.shutdown()
+                except Exception as exc:
+                    logger.exception("Failed to close widget task supervisor")
+                    shutdown_errors.append(exc)
+
+        if shutdown_errors:
+            raise shutdown_errors[0]
+        self._shutdown_complete = True
+
+    @pyqtSlot()
+    def quit_app(self) -> asyncio.Task[None] | None:
+        """Schedule resource cleanup before requesting the Qt process exit."""
+        if self._shutting_down:
+            return None
+        return self._create_action_task(self._quit_app(), name="quit-app")
+
+    async def _quit_app(self) -> None:
+        """Close application resources before requesting the Qt process exit."""
+        await self.shutdown()
         QApplication.quit()
 
     def toggle_gaming_mode_from_tray(self, checked):
@@ -1538,7 +1685,7 @@ class DanmakuWidget(QWidget):
         
         # [Message Buffering]
         # Process all types of messages
-        if hasattr(self, '_message_buffer') and self._message_buffer:
+        if self._message_buffer:
             for item_type, item_data in self._message_buffer:
                 if item_type == 'msg':
                     self.add_message(item_data)
@@ -1620,8 +1767,9 @@ class DanmakuWidget(QWidget):
     async def _start_audience_refresh(self, client: DanmakuClient) -> None:
         await self._stop_audience_refresh()
         generation = self._audience_generation
-        self._audience_refresh_task = asyncio.create_task(
-            self._audience_refresh_loop(client, generation)
+        self._audience_refresh_task = self._task_scope.create_task(
+            self._audience_refresh_loop(client, generation),
+            name="audience-refresh",
         )
 
     async def _stop_audience_refresh(self) -> None:
@@ -1629,8 +1777,7 @@ class DanmakuWidget(QWidget):
         task = self._audience_refresh_task
         self._audience_refresh_task = None
         if task is not None:
-            task.cancel()
-            await asyncio.gather(task, return_exceptions=True)
+            await cancel_task(task)
         self._audience_snapshot = None
         self.audience_popup.hide()
         self.audience_status.clear()
@@ -1682,9 +1829,8 @@ class DanmakuWidget(QWidget):
         """)
 
     def _has_active_danmaku_connection(self) -> bool:
-        if self.danmaku_client is None or self.danmaku_client.client is None:
-            return False
-        return bool(getattr(self.danmaku_client.client, "is_running", False))
+        client = self.danmaku_client
+        return client is not None and client.is_running
 
     async def _connect_to_room_id(self, room_id: int):
         if room_id <= 0:
@@ -1694,7 +1840,8 @@ class DanmakuWidget(QWidget):
             self.room_id_input.setText(str(room_id))
             self._set_connected_ui()
             client = self.danmaku_client
-            assert client is not None
+            if client is None:
+                return
             if self._audience_refresh_task is None:
                 await self._start_audience_refresh(client)
             return
@@ -1711,8 +1858,14 @@ class DanmakuWidget(QWidget):
         self._set_connecting_ui()
         try:
             await client.start()
-        except Exception:
-            self.danmaku_client = None
+        except BaseException:
+            try:
+                await client.stop()
+            except BaseException:
+                logger.exception("Failed to clean up danmaku client after connection failure")
+            else:
+                if self.danmaku_client is client:
+                    self.danmaku_client = None
             self._set_disconnected_ui()
             raise
         self._set_connected_ui()
@@ -1741,9 +1894,17 @@ class DanmakuWidget(QWidget):
         self.danmaku_client = None
         self._set_disconnected_ui()
 
-    @qasync.asyncSlot()
-    async def toggle_connection(self):
+    @pyqtSlot()
+    def toggle_connection(self) -> asyncio.Task[None] | None:
+        """Schedule the room connection workflow under the widget owner."""
+        if self._shutting_down:
+            return None
+        return self._create_action_task(self._toggle_connection(), name="toggle-connection")
+
+    async def _toggle_connection(self) -> None:
         """切换连接状态"""
+        if self._shutting_down:
+            return
         if not self._has_active_danmaku_connection():
             # 连接
             try:
@@ -1818,40 +1979,84 @@ class DanmakuWidget(QWidget):
         await self._connect_to_room_id(anchor_room_id)
         return anchor_room_id
 
-    @qasync.asyncSlot()
-    async def open_live_control(self):
+    @pyqtSlot()
+    def open_live_control(self) -> asyncio.Task[None] | None:
+        """Schedule opening the live control dialog under the widget owner."""
+        if self._shutting_down:
+            return None
+        return self._create_action_task(
+            self._open_live_control(),
+            name="open-live-control",
+        )
+
+    async def _open_live_control(self) -> None:
         """打开直播控制窗口"""
+        if self._shutting_down:
+            return
         try:
             anchor_room_id = await self._ensure_live_control_room()
         except Exception as e:
             self.add_system_message(f"无法打开直播控制: {e}", "error")
             print(f"Open live control failed: {e}")
             return
+        if self._shutting_down:
+            return
 
-        if not hasattr(self, '_live_control_dialog'):
-            self._live_control_dialog = LiveControlDialog(self, services=self.services)
+        if self._live_control_dialog is None:
+            self._live_control_dialog = LiveControlDialog(
+                self,
+                services=self.services,
+                task_scope=self._task_scope.child("live-control"),
+            )
             self._live_control_dialog.live_status_changed.connect(self.set_live_status_indicator)
-        self._live_control_dialog.set_room_id(anchor_room_id)
-        self._live_control_dialog.show()
-        self._live_control_dialog.raise_()
-        self._live_control_dialog.activateWindow()
+        dialog = self._live_control_dialog
+        if dialog is None:
+            return
+        dialog.set_room_id(anchor_room_id)
+        dialog.show()
+        dialog.raise_()
+        dialog.activateWindow()
 
     def open_mirror_settings(self):
-        if not hasattr(self, '_mirror_settings_dialog'):
+        if self._shutting_down:
+            return
+        if self._mirror_settings_dialog is None:
             self._mirror_settings_dialog = MirrorSettingsDialog(self)
-        self._mirror_settings_dialog.refresh()
-        self._mirror_settings_dialog.show()
-        self._mirror_settings_dialog.raise_()
-        self._mirror_settings_dialog.activateWindow()
+            self._mirror_settings_dialog.mirror_enabled_requested.connect(
+                self._schedule_mirror_toggle
+            )
+        dialog = self._mirror_settings_dialog
+        dialog.refresh()
+        dialog.show()
+        dialog.raise_()
+        dialog.activateWindow()
 
     @property
     def mirror_url(self) -> str:
         return f"http://127.0.0.1:{self.mirror_port}{MIRROR_ROUTE}"
 
-    @qasync.asyncSlot()
-    async def toggle_mirror_server(self):
+    @pyqtSlot()
+    def toggle_mirror_server(self) -> asyncio.Task[None] | None:
+        """Schedule the Mirror toggle workflow under the widget owner."""
+        if self._shutting_down:
+            return None
+        return self._create_action_task(
+            self._toggle_mirror_server(),
+            name="toggle-mirror-server",
+        )
+
+    async def _toggle_mirror_server(self) -> None:
         await self.set_mirror_enabled(self.mirror_server is None)
         self.refresh_mirror_settings()
+
+    def _schedule_mirror_toggle(self, enabled: bool) -> None:
+        """Schedule a Mirror settings request from the presentation signal."""
+        if self._shutting_down:
+            return
+        self._create_action_task(
+            self.set_mirror_enabled(enabled),
+            name="toggle-mirror-settings",
+        )
 
     async def set_mirror_enabled(self, enabled: bool):
         if enabled:
@@ -1863,12 +2068,14 @@ class DanmakuWidget(QWidget):
             self.mirror_enabled = False
             self.mirror_error = ""
             self._update_persisted_config(mirror_enabled=False)
+            await cancel_task(self._mirror_start_task)
+            self._mirror_start_task = None
             await self.shutdown_mirror_server()
             self.add_system_message("BiliHUD Mirror 已停止。")
         self.refresh_mirror_settings()
 
     def refresh_mirror_settings(self):
-        if hasattr(self, '_mirror_settings_dialog'):
+        if self._mirror_settings_dialog is not None:
             self._mirror_settings_dialog.refresh()
 
     def mirror_status_text(self) -> str:
@@ -1880,7 +2087,14 @@ class DanmakuWidget(QWidget):
             return "已启用，当前未启动"
         return "未启动"
 
-    async def start_mirror_server(self):
+    async def start_mirror_server(self) -> None:
+        if self._shutting_down:
+            return
+
+        startup_task = self._mirror_start_task
+        if startup_task is not None and startup_task is not asyncio.current_task() and not startup_task.done():
+            await startup_task
+            return
         if self.mirror_server is not None:
             self.refresh_mirror_settings()
             return
@@ -1899,28 +2113,59 @@ class DanmakuWidget(QWidget):
         self.refresh_mirror_settings()
         self.add_system_message(f"BiliHUD Mirror 已启动: {server.url}")
 
-    async def stop_mirror_server(self):
+    async def stop_mirror_server(self) -> None:
         await self.set_mirror_enabled(False)
 
-    async def shutdown_mirror_server(self):
+    async def shutdown_mirror_server(self) -> None:
         if self.mirror_server is None:
             return
 
         server = self.mirror_server
-        self.mirror_server = None
         await server.stop()
+        self.mirror_server = None
         self.refresh_mirror_settings()
 
     def set_live_status_indicator(self, is_live: bool):
         """显示或隐藏标题栏直播状态点。"""
-        if hasattr(self, 'live_status_dot'):
-            self.live_status_dot.setVisible(is_live)
+        self.live_status_dot.setVisible(is_live)
 
     def open_qr_login(self):
-        """打开扫码登录窗口"""
-        dialog = QRLoginDialog(self, auth_service=self.auth_service)
+        """Open the QR-login window without blocking the application event loop."""
+        if self._shutting_down:
+            return
+        dialog = self._qr_login_dialog
+        if dialog is not None:
+            dialog.raise_()
+            dialog.activateWindow()
+            return
+
+        dialog = QRLoginDialog(
+            self,
+            auth_service=self.auth_service,
+            task_scope=self._task_scope.child("qr-login"),
+        )
         dialog.login_success.connect(self.on_login_success)
-        dialog.exec()
+        dialog.finished.connect(lambda _result: self._finish_qr_login(dialog))
+        self._qr_login_dialog = dialog
+        dialog.open()
+        dialog.raise_()
+        dialog.activateWindow()
+
+    def _finish_qr_login(self, dialog: QRLoginDialog) -> None:
+        """Release a completed QR-login dialog through the widget task owner."""
+        if self._shutting_down:
+            return
+        self._create_action_task(
+            self._close_qr_login(dialog),
+            name="close-qr-login",
+        )
+
+    async def _close_qr_login(self, dialog: QRLoginDialog) -> None:
+        """Await QR-login task cancellation before deleting its presentation object."""
+        await dialog.shutdown()
+        if self._qr_login_dialog is dialog:
+            self._qr_login_dialog = None
+        dialog.deleteLater()
 
     def on_login_success(self):
         """登录成功，提醒用户重连"""

--- a/src/bilihud/lifecycle.py
+++ b/src/bilihud/lifecycle.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Coroutine
+from dataclasses import dataclass
+from typing import Any, TypeVar
+
+logger = logging.getLogger(__name__)
+
+TaskResult = TypeVar("TaskResult")
+
+
+async def cancel_task(task: asyncio.Task[Any] | None) -> None:
+    """Cancel and await a task, including tasks not registered with a supervisor."""
+    if task is None or task.done() or task is asyncio.current_task():
+        return
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+
+@dataclass(slots=True)
+class _TaskRecord:
+    """Metadata needed to identify and remove one supervised task."""
+
+    task: asyncio.Task[Any]
+    owner: str
+    label: str
+    scope: TaskScope
+
+
+class TaskScope:
+    """Own a related set of background tasks under one lifecycle boundary."""
+
+    def __init__(self, supervisor: TaskSupervisor, name: str) -> None:
+        """Create a named scope managed by ``supervisor``."""
+        self._supervisor = supervisor
+        self._name = name
+        self._tasks: set[asyncio.Task[Any]] = set()
+
+    @property
+    def name(self) -> str:
+        """Return the stable owner name used in task diagnostics."""
+        return self._name
+
+    def child(self, name: str) -> TaskScope:
+        """Create a child scope for a nested component or dialog."""
+        return self._supervisor.create_scope(f"{self._name}/{name}")
+
+    def create_task(
+        self,
+        coroutine: Coroutine[Any, Any, TaskResult],
+        *,
+        name: str,
+    ) -> asyncio.Task[TaskResult]:
+        """Create and register a task whose owner is this scope."""
+        return self._supervisor._create_task(self, coroutine, name=name)
+
+    async def cancel_task(self, task: asyncio.Task[Any] | None) -> None:
+        """Cancel and await one task, including tasks created outside this scope."""
+        await cancel_task(task)
+
+    async def cancel_all(self) -> None:
+        """Cancel and await every unfinished task owned by this scope."""
+        await self._supervisor._cancel_tasks(tuple(self._tasks))
+
+    def _add(self, task: asyncio.Task[Any]) -> None:
+        self._tasks.add(task)
+
+    def _discard(self, task: asyncio.Task[Any]) -> None:
+        self._tasks.discard(task)
+
+
+class TaskSupervisor:
+    """Track background tasks and make cancellation and failure ownership explicit."""
+
+    def __init__(self) -> None:
+        """Create an open supervisor for one application event loop."""
+        self._tasks: dict[asyncio.Task[Any], _TaskRecord] = {}
+        self._closing = False
+        self._closed = False
+        self._shutdown_future: asyncio.Future[None] | None = None
+
+    def create_scope(self, name: str) -> TaskScope:
+        """Create a task owner that participates in supervisor shutdown."""
+        if self._closing:
+            raise RuntimeError("任务监督器已关闭")
+        if not name.strip():
+            raise ValueError("任务所有者名称不能为空")
+        return TaskScope(self, name)
+
+    async def cancel_task(self, task: asyncio.Task[Any] | None) -> None:
+        """Cancel and await a task without leaking its exception or cancellation."""
+        await cancel_task(task)
+
+    async def shutdown(self) -> None:
+        """Cancel and await all supervised tasks; repeated calls are harmless."""
+        if self._closed:
+            return
+        if self._shutdown_future is not None:
+            await asyncio.shield(self._shutdown_future)
+            return
+
+        self._closing = True
+        loop = asyncio.get_running_loop()
+        self._shutdown_future = loop.create_future()
+        try:
+            await self._cancel_tasks(tuple(self._tasks))
+        except BaseException as exc:
+            self._shutdown_future.set_exception(exc)
+            raise
+        else:
+            self._closed = True
+            self._shutdown_future.set_result(None)
+
+    def pending_tasks(self) -> tuple[asyncio.Task[Any], ...]:
+        """Return unfinished supervised tasks for diagnostics and tests."""
+        return tuple(task for task in self._tasks if not task.done())
+
+    def _create_task(
+        self,
+        scope: TaskScope,
+        coroutine: Coroutine[Any, Any, TaskResult],
+        *,
+        name: str,
+    ) -> asyncio.Task[TaskResult]:
+        """Create one task and record its owner before it can run."""
+        if self._closing:
+            coroutine.close()
+            raise RuntimeError("任务监督器已关闭")
+        if not name.strip():
+            coroutine.close()
+            raise ValueError("任务名称不能为空")
+
+        task = asyncio.create_task(coroutine, name=f"{scope.name}:{name}")
+        record = _TaskRecord(task=task, owner=scope.name, label=name, scope=scope)
+        self._tasks[task] = record
+        scope._add(task)
+        task.add_done_callback(self._on_task_done)
+        return task
+
+    async def _cancel_tasks(self, tasks: tuple[asyncio.Task[Any], ...]) -> None:
+        """Cancel a task snapshot while leaving the caller task alive."""
+        current_task = asyncio.current_task()
+        pending = tuple(task for task in tasks if not task.done() and task is not current_task)
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+    def _on_task_done(self, task: asyncio.Task[Any]) -> None:
+        """Remove a completed task and log failures before they become unobserved."""
+        record = self._tasks.pop(task, None)
+        if record is None:
+            return
+        record.scope._discard(task)
+        if task.cancelled():
+            return
+        exception = task.exception()
+        if exception is not None:
+            logger.error(
+                "后台任务失败: owner=%s task=%s",
+                record.owner,
+                record.label,
+                exc_info=(type(exception), exception, exception.__traceback__),
+            )

--- a/src/bilihud/live_control_dialog.py
+++ b/src/bilihud/live_control_dialog.py
@@ -1,11 +1,11 @@
 import asyncio
 import logging
+from collections.abc import Coroutine
 from dataclasses import replace
 from typing import Any
 
 import aiohttp
-import qasync
-from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtCore import Qt, pyqtSignal, pyqtSlot
 from PyQt6.QtGui import QImage, QPixmap
 from PyQt6.QtWidgets import (
     QApplication,
@@ -27,6 +27,7 @@ from PyQt6.QtWidgets import (
 from .auth import AuthenticationService
 from .config import ConfigStore
 from .helpers import validate_room_id
+from .lifecycle import TaskScope, TaskSupervisor, cancel_task
 from .live_api import (
     LiveApiError,
     RoomInfo,
@@ -81,6 +82,7 @@ class LiveControlDialog(QDialog):
         self,
         parent: QWidget | None = None,
         services: AppServices | None = None,
+        task_scope: TaskScope | None = None,
     ) -> None:
         """Create the dialog with shared configuration and authentication boundaries."""
         super().__init__(parent)
@@ -90,6 +92,15 @@ class LiveControlDialog(QDialog):
         self.services = services if services is not None else create_default_services()
         self.config_store: ConfigStore = self.services.config_store  # Non-sensitive settings boundary.
         self.auth_service: AuthenticationService = self.services.auth_service  # Auth and OBS secret boundary.
+        if task_scope is None:
+            task_supervisor = TaskSupervisor()
+            self._task_supervisor: TaskSupervisor | None = task_supervisor
+            self._owns_task_supervisor = True
+            self._task_scope = task_supervisor.create_scope("live-control")
+        else:
+            self._task_supervisor = None
+            self._owns_task_supervisor = False
+            self._task_scope = task_scope
         self.session: aiohttp.ClientSession | None = None  # Session owned and closed by this dialog.
         self.area_list: list[dict[str, Any]] = []
         self.credentials: list[StreamCredential] = []
@@ -106,6 +117,9 @@ class LiveControlDialog(QDialog):
         self._obs_busy = False
         self._obs_connected = False
         self._obs_streaming_started = False
+        self._action_tasks: set[asyncio.Task[Any]] = set()  # Qt-triggered workflows owned by this dialog.
+        self._shutting_down = False  # Blocks new dialog work during application shutdown.
+        self._shutdown_complete = False  # Makes application shutdown idempotent.
 
         self._init_ui()
         self._load_config_values()
@@ -312,8 +326,39 @@ class LiveControlDialog(QDialog):
         if room_id > 0:
             self.room_id_input.setText(str(room_id))
 
+    def _create_action_task(
+        self,
+        coroutine: Coroutine[Any, Any, None],
+        *,
+        name: str,
+    ) -> asyncio.Task[None]:
+        """Create and retain one dialog action under the dialog task owner."""
+        task = self._task_scope.create_task(coroutine, name=name)
+        self._action_tasks.add(task)
+        task.add_done_callback(self._discard_action_task)
+        return task
+
+    def _discard_action_task(self, task: asyncio.Task[Any]) -> None:
+        """Remove a completed dialog action from the local registry."""
+        self._action_tasks.discard(task)
+
+    async def _cancel_action_tasks(self) -> None:
+        """Cancel and await every Qt-triggered dialog action."""
+        current_task = asyncio.current_task()
+        pending = tuple(
+            task
+            for task in self._action_tasks
+            if not task.done() and task is not current_task
+        )
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
     def showEvent(self, event) -> None:
         super().showEvent(event)
+        if self._shutting_down:
+            return
         if self._initial_load_task and not self._initial_load_task.done():
             return
         if self.session and not self.session.closed:
@@ -321,8 +366,10 @@ class LiveControlDialog(QDialog):
             return
 
         self._load_generation += 1
-        self._initial_load_task = asyncio.create_task(self.load_initial_state(self._load_generation))
-        self._initial_load_task.add_done_callback(self._consume_task_exception)
+        self._initial_load_task = self._task_scope.create_task(
+            self.load_initial_state(self._load_generation),
+            name="initial-load",
+        )
 
     def closeEvent(self, event) -> None:
         """Cancel owned work and schedule all aiohttp sessions for cleanup."""
@@ -334,12 +381,56 @@ class LiveControlDialog(QDialog):
             self._room_info_task.cancel()
         if self._obs_write_task and not self._obs_write_task.done():
             self._obs_write_task.cancel()
+        for task in tuple(self._action_tasks):
+            if not task.done():
+                task.cancel()
         self._clear_credentials()
         self._schedule_session_cleanup(self.session)
         self.session = None
         self._busy = False
         self._update_action_state()
         super().closeEvent(event)
+
+    async def shutdown(self) -> None:
+        """Cancel dialog work and await cleanup of every owned HTTP session."""
+        if self._shutdown_complete:
+            return
+
+        self._shutting_down = True
+        self._load_generation += 1
+        self._action_generation += 1
+        await cancel_task(self._initial_load_task)
+        await cancel_task(self._room_info_task)
+        await cancel_task(self._obs_write_task)
+        await self._cancel_action_tasks()
+        self._clear_credentials()
+
+        if self.session is not None and not self.session.closed:
+            if self.session not in self._sessions_pending_close:
+                self._sessions_pending_close.append(self.session)
+        self.session = None
+
+        cleanup_errors: list[Exception] = []
+        cleanup_task = self._session_cleanup_task
+        if cleanup_task is not None and not cleanup_task.done():
+            try:
+                await cleanup_task
+            except Exception as exc:
+                cleanup_errors.append(exc)
+        try:
+            await self._close_pending_sessions()
+        except Exception as exc:
+            cleanup_errors.append(exc)
+        try:
+            await self._task_scope.cancel_all()
+            self._busy = False
+            self._update_action_state()
+            if cleanup_errors:
+                raise cleanup_errors[0]
+        finally:
+            if self._owns_task_supervisor and self._task_supervisor is not None:
+                await self._task_supervisor.shutdown()
+        self._shutdown_complete = True
 
     async def load_initial_state(self, generation: int) -> None:
         """Create a dialog-owned session and discard it if loading becomes stale."""
@@ -375,34 +466,29 @@ class LiveControlDialog(QDialog):
             if generation == self._load_generation:
                 self._set_busy(False)
 
-    @staticmethod
-    def _consume_task_exception(task: asyncio.Task[None]) -> None:
-        try:
-            task.result()
-        except asyncio.CancelledError:
-            pass
-        except Exception:
-            logger.exception("Unhandled live control dialog task error")
-
     def _schedule_session_cleanup(self, session: aiohttp.ClientSession | None) -> None:
         if session and not session.closed and session not in self._sessions_pending_close:
             self._sessions_pending_close.append(session)
 
+        if self._shutting_down:
+            return
+
         if self._sessions_pending_close and (
             self._session_cleanup_task is None or self._session_cleanup_task.done()
         ):
-            self._session_cleanup_task = asyncio.create_task(self._close_pending_sessions())
-            self._session_cleanup_task.add_done_callback(self._consume_task_exception)
+            self._session_cleanup_task = self._task_scope.create_task(
+                self._close_pending_sessions(),
+                name="session-cleanup",
+            )
 
     async def _close_pending_sessions(self) -> None:
         while self._sessions_pending_close:
-            session = self._sessions_pending_close.pop(0)
+            session = self._sessions_pending_close[0]
             if session.closed:
+                self._sessions_pending_close.pop(0)
                 continue
-            try:
-                await session.close()
-            except Exception:
-                logger.exception("Failed to close live control session")
+            await session.close()
+            self._sessions_pending_close.pop(0)
 
     def _populate_parent_areas(self) -> None:
         self.parent_area_combo.blockSignals(True)
@@ -442,8 +528,20 @@ class LiveControlDialog(QDialog):
             self.set_status("已加载直播间当前标题和分区。")
         return True
 
-    @qasync.asyncSlot()
-    async def reload_room_info(self) -> None:
+    @pyqtSlot()
+    def reload_room_info(self) -> asyncio.Task[None] | None:
+        """Schedule a room-info refresh under the dialog task owner."""
+        if self._shutting_down:
+            return None
+        if self._room_info_task is not None and not self._room_info_task.done():
+            return self._room_info_task
+        task = self._create_action_task(self._reload_room_info(), name="reload-room-info")
+        self._room_info_task = task
+        return task
+
+    async def _reload_room_info(self) -> None:
+        if self._shutting_down:
+            return
         if self._busy or not self.area_list or not self.session or self.session.closed:
             return
         if self._room_id() is None:
@@ -453,8 +551,6 @@ class LiveControlDialog(QDialog):
             self._update_action_state()
             return
         task = asyncio.current_task()
-        if task is not None:
-            self._room_info_task = task
         has_csrf = self._has_csrf()
         if has_csrf:
             self.set_status("正在加载直播间当前标题和分区...")
@@ -718,8 +814,16 @@ class LiveControlDialog(QDialog):
                 return
             raise
 
-    @qasync.asyncSlot()
-    async def handle_update_title(self) -> None:
+    @pyqtSlot()
+    def handle_update_title(self) -> asyncio.Task[None] | None:
+        """Schedule the title update workflow under the dialog task owner."""
+        if self._shutting_down:
+            return None
+        return self._create_action_task(self._handle_update_title(), name="update-title")
+
+    async def _handle_update_title(self) -> None:
+        if self._shutting_down:
+            return
         session = self.session
         if not session:
             return
@@ -745,8 +849,16 @@ class LiveControlDialog(QDialog):
             if self._is_current_action(action_generation, session):
                 self._set_busy(False)
 
-    @qasync.asyncSlot()
-    async def handle_update_area(self) -> None:
+    @pyqtSlot()
+    def handle_update_area(self) -> asyncio.Task[None] | None:
+        """Schedule the area update workflow under the dialog task owner."""
+        if self._shutting_down:
+            return None
+        return self._create_action_task(self._handle_update_area(), name="update-area")
+
+    async def _handle_update_area(self) -> None:
+        if self._shutting_down:
+            return
         session = self.session
         if not session:
             return
@@ -772,8 +884,16 @@ class LiveControlDialog(QDialog):
             if self._is_current_action(action_generation, session):
                 self._set_busy(False)
 
-    @qasync.asyncSlot()
-    async def handle_start_live(self) -> None:
+    @pyqtSlot()
+    def handle_start_live(self) -> asyncio.Task[None] | None:
+        """Schedule the start-live workflow under the dialog task owner."""
+        if self._shutting_down:
+            return None
+        return self._create_action_task(self._handle_start_live(), name="start-live")
+
+    async def _handle_start_live(self) -> None:
+        if self._shutting_down:
+            return
         session = self.session
         if not session:
             return
@@ -809,7 +929,7 @@ class LiveControlDialog(QDialog):
             result = await start_live(session, room_id, area_id, version.curr_version, str(version.build))
             if not self._is_current_action(action_generation, session):
                 return
-            self._handle_start_live_result(result.code, result.message, result.data)
+            await self._handle_start_live_result(result.code, result.message, result.data)
         except LiveApiError as exc:
             if self._is_current_action(action_generation, session):
                 logger.exception("Live API error while starting live")
@@ -822,21 +942,23 @@ class LiveControlDialog(QDialog):
             if self._is_current_action(action_generation, session):
                 self._set_busy(False)
 
-    def _handle_start_live_result(self, code: int, message: str, data: dict[str, Any]) -> None:
+    async def _handle_start_live_result(self, code: int, message: str, data: dict[str, Any]) -> None:
         if code == 0:
             self.credentials = parse_stream_credentials(data)
             self._render_credentials()
             self._set_live_active(True)
             if self.credentials:
                 self.set_status("直播已开始，推流凭证已生成；正在尝试连接 OBS 自动推流。", success=True)
-                self._obs_write_task = asyncio.create_task(self._write_obs_after_start())
-                self._obs_write_task.add_done_callback(self._consume_task_exception)
+                self._obs_write_task = self._task_scope.create_task(
+                    self._write_obs_after_start(),
+                    name="obs-credential-write",
+                )
             else:
                 self.set_status("直播已开始，但接口未返回可识别的推流凭证。", error=True)
             return
 
         if code == 60024:
-            self._show_qr_verification(start_live_verification_url(code, data, uid=None))
+            await self._show_qr_verification(start_live_verification_url(code, data, uid=None))
             self.set_status("本次开播需要扫码验证，完成后请重新点击开始直播。", error=True)
             return
 
@@ -844,9 +966,9 @@ class LiveControlDialog(QDialog):
             uid = get_cookie_value(self.session, "DedeUserID") if self.session else None
             auth_url = start_live_verification_url(code, data, uid=uid)
             if auth_url:
-                self._show_qr_verification(auth_url, title="人脸认证")
+                await self._show_qr_verification(auth_url, title="人脸认证")
             else:
-                self._show_text_dialog("人脸认证", "本次开播需要人脸认证，但当前会话缺少 DedeUserID。")
+                await self._show_text_dialog("人脸认证", "本次开播需要人脸认证，但当前会话缺少 DedeUserID。")
             self.set_status("本次开播需要人脸认证，完成后请重新点击开始直播。", error=True)
             return
 
@@ -856,8 +978,16 @@ class LiveControlDialog(QDialog):
     def _extract_qr_url(data: dict[str, Any]) -> str:
         return extract_qr_url(data)
 
-    @qasync.asyncSlot()
-    async def handle_stop_live(self) -> None:
+    @pyqtSlot()
+    def handle_stop_live(self) -> asyncio.Task[None] | None:
+        """Schedule the stop-live workflow under the dialog task owner."""
+        if self._shutting_down:
+            return None
+        return self._create_action_task(self._handle_stop_live(), name="stop-live")
+
+    async def _handle_stop_live(self) -> None:
+        if self._shutting_down:
+            return
         session = self.session
         if not session:
             return
@@ -949,8 +1079,16 @@ class LiveControlDialog(QDialog):
             self._obs_busy = False
             self._update_action_state()
 
-    @qasync.asyncSlot()
-    async def handle_check_obs(self) -> None:
+    @pyqtSlot()
+    def handle_check_obs(self) -> asyncio.Task[None] | None:
+        """Schedule the OBS check workflow under the dialog task owner."""
+        if self._shutting_down:
+            return None
+        return self._create_action_task(self._handle_check_obs(), name="check-obs")
+
+    async def _handle_check_obs(self) -> None:
+        if self._shutting_down:
+            return
         client = self._obs_client()
         if client is None:
             return
@@ -1116,9 +1254,9 @@ class LiveControlDialog(QDialog):
         QApplication.clipboard().setText(text)
         self.set_status("已复制到剪贴板。")
 
-    def _show_qr_verification(self, url: str, title: str = "开播验证") -> None:
+    async def _show_qr_verification(self, url: str, title: str = "开播验证") -> None:
         if not url:
-            self._show_text_dialog(title, "本次开播需要扫码验证，但接口未返回二维码地址。")
+            await self._show_text_dialog(title, "本次开播需要扫码验证，但接口未返回二维码地址。")
             return
 
         dialog = QDialog(self)
@@ -1149,15 +1287,34 @@ class LiveControlDialog(QDialog):
         close_btn = QPushButton("关闭")
         close_btn.clicked.connect(dialog.accept)
         layout.addWidget(close_btn)
-        dialog.exec()
+        await self._open_dialog(dialog)
 
-    def _show_text_dialog(self, title: str, text: str) -> None:
+    async def _show_text_dialog(self, title: str, text: str) -> None:
         box = QMessageBox(self)
         box.setWindowTitle(title)
         box.setText(text)
         box.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
         box.setStandardButtons(QMessageBox.StandardButton.Ok)
         copy_btn = box.addButton("复制", QMessageBox.ButtonRole.ActionRole)
-        box.exec()
+        await self._open_dialog(box)
         if box.clickedButton() == copy_btn:
             self.copy_to_clipboard(text)
+
+    async def _open_dialog(self, dialog: QDialog) -> int:
+        """Open a modal dialog asynchronously and close it when its owner is canceled."""
+        loop = asyncio.get_running_loop()
+        finished: asyncio.Future[int] = loop.create_future()
+
+        def complete(result: int) -> None:
+            if not finished.done():
+                finished.set_result(result)
+
+        dialog.finished.connect(complete)
+        dialog.open()
+        try:
+            return await finished
+        except asyncio.CancelledError:
+            dialog.close()
+            raise
+        finally:
+            dialog.deleteLater()

--- a/src/bilihud/main.py
+++ b/src/bilihud/main.py
@@ -10,13 +10,72 @@ os.environ["QT_API"] = "pyqt6"
 
 import asyncio
 import signal
+from collections.abc import Iterable
+from typing import Any
 
 import qasync
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QApplication
 
 from .danmaku_widget import DanmakuWidget
+from .lifecycle import TaskSupervisor
 from .services import AppServices, create_default_services
+
+
+class ApplicationRuntime:
+    """Own the top-level widget and the application-wide async lifecycle."""
+
+    def __init__(
+        self,
+        app: QApplication,
+        room_id: int,
+        services: AppServices | None = None,
+        task_supervisor: TaskSupervisor | None = None,
+    ) -> None:
+        """Create a runtime that will assemble and own one application window."""
+        self.app = app
+        self.room_id = room_id
+        self.services = services
+        self.task_supervisor = task_supervisor if task_supervisor is not None else TaskSupervisor()
+        self.widget: DanmakuWidget | None = None
+        self._stop_lock = asyncio.Lock()
+        self._stopped = False
+
+    async def start(self) -> None:
+        """Create, configure, and show the top-level window exactly once."""
+        if self._stopped:
+            raise RuntimeError("应用运行时已关闭")
+        if self.widget is not None:
+            return
+
+        widget = DanmakuWidget(
+            self.room_id,
+            services=self.services,
+            task_supervisor=self.task_supervisor,
+        )
+        self.widget = widget
+        try:
+            widget.activate_layer_shell()
+            widget.show()
+            await widget.start()
+        except BaseException:
+            try:
+                await widget.shutdown()
+            finally:
+                await self.task_supervisor.shutdown()
+            raise
+
+    async def stop(self) -> None:
+        """Stop the window-owned workflows and await all supervised tasks."""
+        async with self._stop_lock:
+            if self._stopped:
+                return
+            try:
+                if self.widget is not None:
+                    await self.widget.shutdown()
+            finally:
+                await self.task_supervisor.shutdown()
+            self._stopped = True
 
 
 async def main(
@@ -29,24 +88,24 @@ async def main(
     app.aboutToQuit.connect(app_close_event.set)
 
     app_services = services if services is not None else create_default_services()
-    danmaku_widget = DanmakuWidget(room_id, services=app_services)
-    
-    # Try to activate Layer Shell BEFORE showing
-    # This ensures the window is mapped as a Layer Shell surface from the start
-    danmaku_widget.activate_layer_shell()
+    runtime = ApplicationRuntime(app, room_id, services=app_services)
+    try:
+        await runtime.start()
+        await app_close_event.wait()
+    finally:
+        await runtime.stop()
 
-    # Show window
-    danmaku_widget.show()
 
-    await app_close_event.wait()
-
-async def cancel_pending_tasks(loop, exclude=None):
+async def cancel_pending_tasks(
+    loop: asyncio.AbstractEventLoop,
+    exclude: Iterable[asyncio.Task[Any]] | None = None,
+) -> None:
     """Cancel and await outstanding asyncio tasks during application shutdown."""
-    exclude = set(exclude or ())
+    excluded_tasks = set(exclude or ())
     current_task = asyncio.current_task(loop=loop)
     if current_task is not None:
-        exclude.add(current_task)
-    pending = [task for task in asyncio.all_tasks(loop) if task not in exclude and not task.done()]
+        excluded_tasks.add(current_task)
+    pending = [task for task in asyncio.all_tasks(loop) if task not in excluded_tasks and not task.done()]
     if not pending:
         return
 
@@ -80,13 +139,18 @@ def entry_point():
     
     loop = qasync.QEventLoop(app)
     asyncio.set_event_loop(loop)
-    _main_task = loop.create_task(main(app, args.room_id))
+    main_task = loop.create_task(main(app, args.room_id), name="application-main")
     
     try:
         loop.run_forever()
     finally:
-        loop.run_until_complete(cancel_pending_tasks(loop))
-        loop.close()
+        try:
+            if not main_task.done():
+                loop.run_until_complete(main_task)
+        finally:
+            # ApplicationRuntime performs the owned shutdown first; this is the last-resort fallback.
+            loop.run_until_complete(cancel_pending_tasks(loop, exclude={main_task}))
+            loop.close()
 
 if __name__ == "__main__":
     entry_point()

--- a/src/bilihud/mirror_server.py
+++ b/src/bilihud/mirror_server.py
@@ -201,7 +201,7 @@ def mirror_html(events_route: str = MIRROR_EVENTS_ROUTE) -> str:
 
 
 class MirrorServer:
-    def __init__(self, state: MirrorState, host: str = "127.0.0.1", port: int = MIRROR_DEFAULT_PORT):
+    def __init__(self, state: MirrorState, host: str = "127.0.0.1", port: int = MIRROR_DEFAULT_PORT) -> None:
         self.state = state
         self.host = host
         self.port = port
@@ -214,21 +214,35 @@ class MirrorServer:
         return f"http://{self.host}:{self.port}{MIRROR_ROUTE}"
 
     async def start(self) -> None:
+        if self._runner is not None:
+            return
+
         app = web.Application()
         app.router.add_get(MIRROR_ROUTE, self._handle_page)
         app.router.add_get(MIRROR_EVENTS_ROUTE, self._handle_events)
         app.router.add_get(MIRROR_IMAGE_ROUTE, self._handle_image)
-        self._runner = web.AppRunner(app)
-        await self._runner.setup()
-        self._site = web.TCPSite(self._runner, self.host, self.port)
-        await self._site.start()
+        runner = web.AppRunner(app)
+        self._runner = runner
+        try:
+            await runner.setup()
+            site = web.TCPSite(runner, self.host, self.port)
+            self._site = site
+            await site.start()
+        except BaseException:
+            try:
+                await runner.cleanup()
+            finally:
+                self._runner = None
+                self._site = None
+            raise
 
     async def stop(self) -> None:
+        runner = self._runner
         for queue in list(self._clients):
             queue.put_nowait("")
         self._clients.clear()
-        if self._runner is not None:
-            await self._runner.cleanup()
+        if runner is not None:
+            await runner.cleanup()
         self._runner = None
         self._site = None
 

--- a/src/bilihud/mirror_settings_dialog.py
+++ b/src/bilihud/mirror_settings_dialog.py
@@ -1,4 +1,4 @@
-import qasync
+from PyQt6.QtCore import pyqtSignal
 from PyQt6.QtGui import QClipboard, QGuiApplication
 from PyQt6.QtWidgets import (
     QCheckBox,
@@ -13,6 +13,8 @@ from PyQt6.QtWidgets import (
 
 
 class MirrorSettingsDialog(QDialog):
+    mirror_enabled_requested = pyqtSignal(bool)
+
     def __init__(self, owner: QWidget):
         super().__init__(owner)
         self.owner = owner
@@ -96,10 +98,9 @@ class MirrorSettingsDialog(QDialog):
         status = self.owner.mirror_status_text()
         self.set_mirror_state(enabled, status, self.owner.mirror_url)
 
-    @qasync.asyncSlot(bool)
-    async def _on_enabled_toggled(self, checked: bool) -> None:
-        await self.owner.set_mirror_enabled(checked)
-        self.refresh()
+    def _on_enabled_toggled(self, checked: bool) -> None:
+        """Forward a settings request to the lifecycle-owning widget."""
+        self.mirror_enabled_requested.emit(checked)
 
     def copy_url(self) -> None:
         QGuiApplication.clipboard().setText(self.url_input.text(), mode=QClipboard.Mode.Clipboard)

--- a/src/bilihud/qr_login_dialog.py
+++ b/src/bilihud/qr_login_dialog.py
@@ -7,6 +7,7 @@ from PyQt6.QtGui import QColor, QImage, QPixmap
 from PyQt6.QtWidgets import QDialog, QGraphicsDropShadowEffect, QLabel, QPushButton, QVBoxLayout, QWidget
 
 from .auth import QR_LOGIN_STATUS_NAMES, AuthenticationService
+from .lifecycle import TaskScope, TaskSupervisor, cancel_task
 from .services import create_default_services
 
 logger = logging.getLogger(__name__)
@@ -21,6 +22,7 @@ class QRLoginDialog(QDialog):
         self,
         parent: QWidget | None = None,
         auth_service: AuthenticationService | None = None,
+        task_scope: TaskScope | None = None,
     ) -> None:
         """Create the dialog and start polling only after it becomes visible."""
         super().__init__(parent)
@@ -34,7 +36,20 @@ class QRLoginDialog(QDialog):
         self.auth_service = (  # Shared authentication boundary supplied by the app.
             auth_service if auth_service is not None else create_default_services().auth_service
         )
+        if task_scope is None:
+            task_supervisor = TaskSupervisor()
+            self._task_supervisor: TaskSupervisor | None = task_supervisor
+            self._owns_task_supervisor = True
+            self._task_scope = task_supervisor.create_scope("qr-login")
+        else:
+            self._task_supervisor = None
+            self._owns_task_supervisor = False
+            self._task_scope = task_scope
         self.qrcode_key: str | None = None  # Key associated with the currently displayed QR code.
+        self._load_task: asyncio.Task[None] | None = None  # Current QR image request.
+        self._poll_task: asyncio.Task[None] | None = None  # Current QR status request.
+        self._shutting_down = False  # Prevent new requests after application shutdown.
+        self._shutdown_complete = False  # Makes application shutdown idempotent.
         
         self.init_ui()
         
@@ -140,22 +155,52 @@ class QRLoginDialog(QDialog):
     def showEvent(self, event):
         """Refresh the QR code whenever the dialog is shown."""
         super().showEvent(event)
+        if self._shutting_down:
+            return
         self.refresh_qrcode()
         
     def closeEvent(self, event):
         """Stop status polling before the dialog is destroyed or hidden."""
         self.poll_timer.stop()
+        self.qrcode_key = None
+        if self._load_task is not None and not self._load_task.done():
+            self._load_task.cancel()
+        if self._poll_task is not None and not self._poll_task.done():
+            self._poll_task.cancel()
         super().closeEvent(event)
+
+    async def shutdown(self) -> None:
+        """Cancel QR requests and await their completion before application exit."""
+        if self._shutdown_complete:
+            return
+
+        self._shutting_down = True
+        self.poll_timer.stop()
+        self.qrcode_key = None
+        await cancel_task(self._load_task)
+        await cancel_task(self._poll_task)
+        try:
+            await self._task_scope.cancel_all()
+        finally:
+            if self._owns_task_supervisor and self._task_supervisor is not None:
+                await self._task_supervisor.shutdown()
+        self._shutdown_complete = True
         
     def refresh_qrcode(self):
         """Start one asynchronous QR-code request and reset stale polling state."""
+        if self._shutting_down:
+            return
         self.status_label.setText("正在获取二维码...")
         self.status_label.setStyleSheet("color: #aaaaaa;")
         self.refresh_btn.setVisible(False)
         self.poll_timer.stop()
+        self.qrcode_key = None
+        if self._load_task is not None and not self._load_task.done():
+            self._load_task.cancel()
+        if self._poll_task is not None and not self._poll_task.done():
+            self._poll_task.cancel()
         
-        # Async call to get QR code
-        asyncio.create_task(self._load_qrcode())
+        self._load_task = self._task_scope.create_task(self._load_qrcode(), name="load-qrcode")
         
     async def _load_qrcode(self):
         """Fetch a QR URL, render it, and start polling after a successful render."""
@@ -190,13 +235,18 @@ class QRLoginDialog(QDialog):
 
     def check_status(self):
         """Schedule one status poll when a QR-login key is available."""
-        if not self.qrcode_key:
+        if not self.qrcode_key or self._shutting_down:
             return
-        asyncio.create_task(self._poll_status())
+        if self._poll_task is not None and not self._poll_task.done():
+            return
+        self._poll_task = self._task_scope.create_task(
+            self._poll_status(self.qrcode_key),
+            name="poll-qrcode",
+        )
             
-    async def _poll_status(self):
+    async def _poll_status(self, qrcode_key: str) -> None:
         """Persist cookies after successful scanning and update visible failure states."""
-        code, msg, cookies = await self.auth_service.poll_status(self.qrcode_key)
+        code, msg, cookies = await self.auth_service.poll_status(qrcode_key)
         status_name = QR_LOGIN_STATUS_NAMES.get(code, "Unknown")
         logger.info("QR login poll status: code=%s (%s), message=%s", code, status_name, msg)
         
@@ -210,8 +260,6 @@ class QRLoginDialog(QDialog):
             if cookies:
                 self.auth_service.save_cookies(cookies)
                 self.login_success.emit()
-                # Wait a bit before closing
-                await asyncio.sleep(1)
                 self.accept()
                 
         elif code == 86101:

--- a/tests/test_danmaku_widget.py
+++ b/tests/test_danmaku_widget.py
@@ -143,12 +143,17 @@ def test_danmaku_widget_exposes_bilihud_mirror_tray_action(monkeypatch):
 
 
 def test_danmaku_widget_opens_single_mirror_settings_dialog(monkeypatch):
+    class Signal:
+        def connect(self, _callback):
+            pass
+
     class FakeDialog:
         instances = []
 
         def __init__(self, owner):
             self.owner = owner
             self.calls = []
+            self.mirror_enabled_requested = Signal()
             self.instances.append(self)
 
         def refresh(self):
@@ -166,6 +171,8 @@ def test_danmaku_widget_opens_single_mirror_settings_dialog(monkeypatch):
     _app()
     widget = danmaku_widget.DanmakuWidget.__new__(danmaku_widget.DanmakuWidget)
     QWidget.__init__(widget)
+    widget._shutting_down = False
+    widget._mirror_settings_dialog = None
     monkeypatch.setattr(danmaku_widget, "MirrorSettingsDialog", FakeDialog)
 
     danmaku_widget.DanmakuWidget.open_mirror_settings(widget)
@@ -206,6 +213,34 @@ def test_danmaku_widget_keeps_mirror_enabled_config_when_shutting_down():
         assert widget.mirror_server is None
         assert widget.mirror_enabled is True
         assert events == ["refresh"]
+
+    asyncio.run(run_test())
+
+
+def test_danmaku_widget_keeps_mirror_reference_when_stop_fails():
+    class FakeServer:
+        def __init__(self):
+            self.stop_calls = 0
+
+        async def stop(self):
+            self.stop_calls += 1
+            if self.stop_calls == 1:
+                raise RuntimeError("mirror close failed")
+
+    async def run_test():
+        server = FakeServer()
+        widget = danmaku_widget.DanmakuWidget.__new__(danmaku_widget.DanmakuWidget)
+        widget.mirror_server = server
+        widget.mirror_enabled = True
+        widget.refresh_mirror_settings = lambda: None
+
+        with pytest.raises(RuntimeError, match="mirror close failed"):
+            await danmaku_widget.DanmakuWidget.shutdown_mirror_server(widget)
+        assert widget.mirror_server is server
+
+        await danmaku_widget.DanmakuWidget.shutdown_mirror_server(widget)
+        assert widget.mirror_server is None
+        assert server.stop_calls == 2
 
     asyncio.run(run_test())
 
@@ -615,6 +650,7 @@ def test_connect_to_room_replaces_stale_same_room_client(monkeypatch):
 
     class StaleDanmakuClient:
         client = StaleBLiveClient()
+        is_running = False
 
     class NewDanmakuClient:
         instances = []
@@ -673,6 +709,59 @@ def test_connect_to_room_replaces_stale_same_room_client(monkeypatch):
         assert widget.danmaku_client is NewDanmakuClient.instances[0]
         assert widget.danmaku_client.started is True
         assert events[-2:] == ["connected", ("audience-start", 7450109)]
+
+    asyncio.run(run_test())
+
+
+def test_connect_to_room_keeps_partial_client_when_cleanup_fails(monkeypatch):
+    class RoomInput:
+        def __init__(self):
+            self.value = ""
+
+        def text(self):
+            return self.value
+
+        def setText(self, value):
+            self.value = value
+
+    class FailingClient:
+        instances = []
+
+        def __init__(self, room_id, sessdata, auth_service=None):
+            self.room_id = room_id
+            self.sessdata = sessdata
+            self.auth_service = auth_service
+            self.client = object()
+            self.stop_calls = 0
+            self.instances.append(self)
+
+        async def start(self):
+            raise RuntimeError("connect failed")
+
+        async def stop(self):
+            self.stop_calls += 1
+            raise RuntimeError("cleanup failed")
+
+    async def run_test():
+        widget = danmaku_widget.DanmakuWidget.__new__(danmaku_widget.DanmakuWidget)
+        widget.room_id = 7450109
+        widget.sessdata = "sess"
+        widget.auth_service = object()
+        widget.room_id_input = RoomInput()
+        widget.danmaku_client = None
+        widget._wire_danmaku_client = lambda _client: None
+        widget._update_persisted_config = lambda **_kwargs: True
+        widget._set_connecting_ui = lambda: None
+        widget._set_disconnected_ui = lambda: None
+
+        monkeypatch.setattr(danmaku_widget, "DanmakuClient", FailingClient)
+
+        with pytest.raises(RuntimeError, match="connect failed"):
+            await danmaku_widget.DanmakuWidget._connect_to_room_id(widget, 7450109)
+
+        client = FailingClient.instances[0]
+        assert client.stop_calls == 1
+        assert widget.danmaku_client is client
 
     asyncio.run(run_test())
 

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,239 @@
+import asyncio
+import logging
+
+import pytest
+from PyQt6.QtWidgets import QApplication
+
+from bilihud import main as main_module
+from bilihud.danmaku_widget import DanmakuWidget
+from bilihud.lifecycle import TaskSupervisor
+from bilihud.main import ApplicationRuntime
+from bilihud.qr_login_dialog import QRLoginDialog
+
+
+def test_task_supervisor_cancels_owned_tasks_and_is_idempotent():
+    async def run_test():
+        supervisor = TaskSupervisor()
+        scope = supervisor.create_scope("test-owner")
+        started = asyncio.Event()
+        cleanup_seen = False
+
+        async def wait_forever():
+            nonlocal cleanup_seen
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cleanup_seen = True
+                raise
+
+        task = scope.create_task(wait_forever(), name="wait-forever")
+        await started.wait()
+
+        await supervisor.shutdown()
+        await supervisor.shutdown()
+        await asyncio.sleep(0)
+
+        assert task.cancelled()
+        assert cleanup_seen is True
+        assert supervisor.pending_tasks() == ()
+
+    asyncio.run(run_test())
+
+
+def test_task_supervisor_logs_unhandled_task_failure(caplog):
+    async def run_test():
+        supervisor = TaskSupervisor()
+        scope = supervisor.create_scope("test-owner")
+
+        async def fail():
+            raise RuntimeError("background failure")
+
+        scope.create_task(fail(), name="failing-task")
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await supervisor.shutdown()
+
+    with caplog.at_level(logging.ERROR, logger="bilihud.lifecycle"):
+        asyncio.run(run_test())
+
+    assert "后台任务失败: owner=test-owner task=failing-task" in caplog.text
+    assert "background failure" in caplog.text
+
+
+def test_task_supervisor_rejects_new_work_after_shutdown():
+    async def run_test():
+        supervisor = TaskSupervisor()
+        scope = supervisor.create_scope("test-owner")
+        await supervisor.shutdown()
+
+        async def never_started():
+            await asyncio.Event().wait()
+
+        with pytest.raises(RuntimeError, match="任务监督器已关闭"):
+            scope.create_task(never_started(), name="late-task")
+
+    asyncio.run(run_test())
+
+
+def test_application_runtime_stops_widget_and_supervised_tasks(monkeypatch):
+    events = []
+    pending_task = None
+
+    class FakeWidget:
+        def __init__(self, _room_id, *, services, task_supervisor):
+            nonlocal pending_task
+            events.append(("create", services))
+            scope = task_supervisor.create_scope("fake-widget")
+
+            async def wait_forever():
+                await asyncio.Event().wait()
+
+            pending_task = scope.create_task(wait_forever(), name="owned-task")
+
+        def activate_layer_shell(self):
+            events.append("activate")
+
+        def show(self):
+            events.append("show")
+
+        async def start(self):
+            events.append("start")
+
+        async def shutdown(self):
+            events.append("widget-shutdown")
+
+    monkeypatch.setattr(main_module, "DanmakuWidget", FakeWidget)
+
+    async def run_test():
+        runtime = ApplicationRuntime(object(), 7450109, services="services")
+        await runtime.start()
+        await runtime.start()
+        await runtime.stop()
+        await runtime.stop()
+        assert pending_task is not None
+        assert pending_task.cancelled()
+
+    asyncio.run(run_test())
+
+    assert events == [("create", "services"), "activate", "show", "start", "widget-shutdown"]
+
+
+def test_application_runtime_can_retry_after_widget_shutdown_failure(monkeypatch):
+    class FakeWidget:
+        shutdown_calls = 0
+
+        def __init__(self, _room_id, *, services, task_supervisor):
+            pass
+
+        def activate_layer_shell(self):
+            pass
+
+        def show(self):
+            pass
+
+        async def start(self):
+            pass
+
+        async def shutdown(self):
+            self.shutdown_calls += 1
+            if self.shutdown_calls == 1:
+                raise RuntimeError("close failed")
+
+    monkeypatch.setattr(main_module, "DanmakuWidget", FakeWidget)
+
+    async def run_test():
+        runtime = ApplicationRuntime(object(), 7450109)
+        await runtime.start()
+
+        with pytest.raises(RuntimeError, match="close failed"):
+            await runtime.stop()
+        assert runtime._stopped is False
+
+        await runtime.stop()
+        assert runtime._stopped is True
+        assert runtime.widget is not None
+        assert runtime.widget.shutdown_calls == 2
+
+    asyncio.run(run_test())
+
+
+def test_danmaku_widget_shutdown_cancels_work_before_closing_resources():
+    async def run_test():
+        supervisor = TaskSupervisor()
+        scope = supervisor.create_scope("danmaku-widget")
+        started = asyncio.Event()
+        events = []
+
+        async def wait_for_send():
+            started.set()
+            await asyncio.Event().wait()
+
+        class Client:
+            async def stop(self):
+                events.append("client-stop")
+
+        widget = DanmakuWidget.__new__(DanmakuWidget)
+        widget._task_supervisor = supervisor
+        widget._owns_task_supervisor = False
+        widget._task_scope = scope
+        widget._action_tasks = set()
+        widget._mirror_start_task = None
+        widget._live_control_dialog = None
+        widget._mirror_settings_dialog = None
+        widget._qr_login_dialog = None
+        widget._shutdown_complete = False
+        widget._shutting_down = False
+        widget.danmaku_client = Client()
+
+        send_task = DanmakuWidget._create_action_task(
+            widget,
+            wait_for_send(),
+            name="send-danmaku",
+        )
+        await started.wait()
+
+        async def stop_audience_refresh():
+            events.append("audience-stop")
+
+        async def shutdown_mirror_server():
+            events.append("mirror-stop")
+
+        widget._stop_audience_refresh = stop_audience_refresh
+        widget.shutdown_mirror_server = shutdown_mirror_server
+
+        await DanmakuWidget.shutdown(widget)
+        await DanmakuWidget.shutdown(widget)
+
+        assert send_task.cancelled()
+        assert events == ["audience-stop", "mirror-stop", "client-stop"]
+
+    asyncio.run(run_test())
+
+
+def test_qr_login_dialog_shutdown_cancels_polling_work():
+    class FakeAuthService:
+        pass
+
+    app = QApplication.instance() or QApplication([])
+    assert app is not None
+    dialog = QRLoginDialog(auth_service=FakeAuthService())
+
+    async def run_test():
+        started = asyncio.Event()
+
+        async def wait_for_poll():
+            started.set()
+            await asyncio.Event().wait()
+
+        dialog._load_task = dialog._task_scope.create_task(wait_for_poll(), name="load-qrcode")
+        await started.wait()
+
+        await dialog.shutdown()
+        await dialog.shutdown()
+
+        assert dialog._load_task.cancelled()
+        assert dialog._shutdown_complete is True
+
+    asyncio.run(run_test())
+    dialog.deleteLater()

--- a/tests/test_mirror_server.py
+++ b/tests/test_mirror_server.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 
+import pytest
 from aiohttp import ClientSession, web
 
 from bilihud.mirror_server import IMAGE_PROXY_HEADERS, MirrorServer, mirror_event_payload, mirror_html
@@ -119,6 +120,49 @@ def test_mirror_server_registers_image_proxy_route():
                     assert await response.text() == "Invalid image URL"
         finally:
             await mirror_server.stop()
+
+    asyncio.run(run_test())
+
+
+def test_mirror_server_stop_is_idempotent():
+    async def run_test():
+        mirror_server = MirrorServer(MirrorState(), port=0)
+        await mirror_server.start()
+
+        await mirror_server.stop()
+        await mirror_server.stop()
+
+        assert mirror_server._runner is None
+        assert mirror_server._site is None
+
+    asyncio.run(run_test())
+
+
+def test_mirror_server_keeps_runner_when_cleanup_fails():
+    class FakeRunner:
+        def __init__(self):
+            self.cleanup_calls = 0
+
+        async def cleanup(self):
+            self.cleanup_calls += 1
+            if self.cleanup_calls == 1:
+                raise RuntimeError("runner cleanup failed")
+
+    async def run_test():
+        mirror_server = MirrorServer(MirrorState())
+        runner = FakeRunner()
+        mirror_server._runner = runner
+        mirror_server._site = object()
+
+        with pytest.raises(RuntimeError, match="runner cleanup failed"):
+            await mirror_server.stop()
+        assert mirror_server._runner is runner
+        assert mirror_server._site is not None
+
+        await mirror_server.stop()
+        assert mirror_server._runner is None
+        assert mirror_server._site is None
+        assert runner.cleanup_calls == 2
 
     asyncio.run(run_test())
 


### PR DESCRIPTION
## Summary

- Add explicit task supervisors and scopes for application, widget, dialog, Mirror, audience, and login workflows.
- Make resource cleanup ordered, retryable, and observable when Mirror, danmaku, or HTTP shutdown fails.
- Replace nested modal event loops and constructor-started background work with explicit lifecycle APIs.
- Extend AGENTS.md with rules for ownership, dynamic access, cancellation, cleanup, and async UI behavior.

## Verification

- `.venv/bin/pytest -q` -> 143 passed
- `uv build` -> passed
- Critical Ruff rules -> passed
- `python -m compileall -q src tests` -> passed
- `git diff --check` -> passed

The full repository Ruff and ty checks still report pre-existing diagnostics outside this change.

Closes #23