### PR TITLE
fix: close T4 type gap and apply safe Ruff fixes

### DIFF
--- a/src/bilihud/__init__.py
+++ b/src/bilihud/__init__.py
@@ -1,7 +1,7 @@
 """Top-level package for bilihud."""
 
-import sys
 import os
+import sys
 
 # 优先查找包内的 vendor (安装模式)
 _local_vendor = os.path.join(os.path.dirname(__file__), 'vendor')
@@ -16,7 +16,7 @@ if os.path.exists(_local_vendor):
     # But for simplicity, we will instruct pip to install flatly or we handle it in CI.
     # Actually, simpler: We will install dependencies into src/bilihud/vendor directly.
     # So imports like 'import qasync' will work if 'src/bilihud/vendor/qasync' exists AND 'src/bilihud/vendor' is in sys.path.
-    
+
 elif os.path.exists(_dev_vendor):
     # Only for blivedm submodule in dev mode
     if _dev_vendor not in sys.path:

--- a/src/bilihud/danmaku_widget.py
+++ b/src/bilihud/danmaku_widget.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import asyncio
 import ctypes
 import html
@@ -147,7 +146,7 @@ class ModernInputWidget(QWidget):
         """)
         self.emoticon_btn.clicked.connect(self.emoticon_requested.emit)
         self.emoticon_btn.setVisible(show_emoticon_button)
-        
+
         # 发送按钮
         self.send_btn = QPushButton("发送")
         self.send_btn.setCursor(Qt.CursorShape.PointingHandCursor)
@@ -356,20 +355,20 @@ class EmoticonPickerPopup(QDialog):
 
 class DanmakuInputDialog(QDialog):
     """全局弹幕输入框 (用于游戏模式/快捷唤起)"""
-    
+
     send_message = pyqtSignal(str)
-    
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowFlags(Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnTopHint | Qt.WindowType.Window)
         self.setAttribute(Qt.WidgetAttribute.WA_InputMethodEnabled)
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
         self.resize(450, 60)
-        
+
         # 整体布局
         layout = QHBoxLayout(self)
         layout.setContentsMargins(5, 5, 5, 5)
-        
+
         # 背景容器 (实现Glass效果)
         self.container = QFrame(self)
         self.container.setStyleSheet("""
@@ -379,27 +378,27 @@ class DanmakuInputDialog(QDialog):
                 border: 1px solid rgba(255, 255, 255, 30);
             }
         """)
-        
+
         # 加阴影
         shadow = QGraphicsDropShadowEffect(self)
         shadow.setBlurRadius(15)
         shadow.setOffset(0, 3)
         shadow.setColor(QColor(0, 0, 0, 150))
         self.container.setGraphicsEffect(shadow)
-        
+
         container_layout = QHBoxLayout(self.container)
         container_layout.setContentsMargins(10, 8, 10, 8)
-        
+
         self.input_widget = ModernInputWidget(self, placeholder="输入弹幕... [ESC关闭]", show_emoticon_button=False)
         self.input_widget.send_requested.connect(self.on_send)
-        
+
         container_layout.addWidget(self.input_widget)
         layout.addWidget(self.container)
-        
+
     def on_send(self, text):
         self.send_message.emit(text)
         self.hide() # 发送后隐藏
-            
+
     def showEvent(self, event):
         super().showEvent(event)
         self.input_widget.setFocus()
@@ -411,7 +410,7 @@ class DanmakuInputDialog(QDialog):
         )
         self.activateWindow()
         self.raise_()
-        
+
     def keyPressEvent(self, event):
         if event.key() == Qt.Key.Key_Escape:
             self.hide()
@@ -421,24 +420,24 @@ class X11Helper:
     """X11辅助类，用于直接调用XShape扩展实现点击穿透"""
     _x11 = None
     _xext = None
-    
+
     @classmethod
     def init(cls):
         if cls._x11: return
         try:
             cls._x11 = ctypes.cdll.LoadLibrary('libX11.so.6')
             cls._xext = ctypes.cdll.LoadLibrary('libXext.so.6')
-            
+
             cls._x11.XOpenDisplay.restype = c_void_p
             cls._x11.XOpenDisplay.argtypes = [c_void_p]
             cls._x11.XFlush.argtypes = [c_void_p]
             cls._x11.XCloseDisplay.argtypes = [c_void_p]
-            
+
             # XShapeCombineRectangles(display, dest, dest_kind, x_off, y_off, rectangles, n_rects, op, ordering)
             cls._xext.XShapeCombineRectangles.argtypes = [
                 c_void_p, c_ulong, c_int, c_int, c_int, c_void_p, c_int, c_int, c_int
             ]
-            
+
             # XShapeCombineMask(display, dest, dest_kind, x_off, y_off, src, op)
             cls._xext.XShapeCombineMask.argtypes = [
                 c_void_p, c_ulong, c_int, c_int, c_int, c_void_p, c_int
@@ -450,18 +449,18 @@ class X11Helper:
     def set_click_through(cls, win_id, enabled):
         """设置窗口是否通过Input Shape完全穿透"""
         if sys.platform != 'linux': return
-        
+
         cls.init()
         if not cls._x11 or not cls._xext: return
-        
+
         display = cls._x11.XOpenDisplay(None)
         if not display:
             print("Failed to open X Display")
             return
-        
+
         ShapeInput = 2
         ShapeSet = 0
-        
+
         try:
             if enabled:
                 # 设置输入形状为空（0个矩形），使窗口对输入事件完全透明
@@ -565,25 +564,25 @@ class DanmakuDelegate(QStyledItemDelegate):
         """Paint the item content directly."""
         options = option
         self.initStyleOption(options, index)
-        
+
         msg_data = index.data(Qt.ItemDataRole.UserRole)
         if not msg_data:
             return
 
         painter.save()
-        
+
         # Get width
         width = options.rect.width()
         if width <= 0: width = 300
-        
+
         doc = self._get_document(msg_data, width, options.font)
-        
+
         # Translate painter to the correct position
         painter.translate(options.rect.x(), options.rect.y() + 1) # +1 Top Margin
-        
+
         # Draw the document
         doc.drawContents(painter)
-        
+
         painter.restore()
 
     def sizeHint(self, option: QStyleOptionViewItem, index):
@@ -591,15 +590,15 @@ class DanmakuDelegate(QStyledItemDelegate):
         msg_data = index.data(Qt.ItemDataRole.UserRole)
         if not msg_data:
             return QSize(0, 0)
-            
+
         width = option.rect.width()
         if width <= 0:
             if self.parent() and hasattr(self.parent(), 'viewport'):
                 width = self.parent().viewport().width()
         if width <= 0: width = 300
-             
+
         doc = self._get_document(msg_data, width, option.font)
-        
+
         return QSize(width, int(doc.size().height()) + 2) # +2 for margins
 
     def get_html_for_message(self, message: HudMessage) -> str:
@@ -707,7 +706,7 @@ class CustomSizeGrip(QWidget):
             delta = event.globalPosition().toPoint() - self._start_mouse_pos
             new_width = max(self.parent().minimumWidth(), self._start_size.width() + delta.x())
             new_height = max(self.parent().minimumHeight(), self._start_size.height() + delta.y())
-            
+
             self.parent().resize(new_width, new_height)
             event.accept()
 
@@ -717,12 +716,12 @@ class CustomSizeGrip(QWidget):
     def paintEvent(self, event):
         painter = QPainter(self)
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)
-        
+
         # 绘制 resize grip 的外观 (例如右下角的小三角点)
         painter.setPen(Qt.PenStyle.NoPen)
         color = QColor(255, 255, 255, 100)
         painter.setBrush(QBrush(color))
-        
+
         # 绘制几个小点
         painter.drawEllipse(10, 10, 3, 3)
         painter.drawEllipse(6, 10, 3, 3)
@@ -773,13 +772,13 @@ class DanmakuWidget(QWidget):
         self.mirror_port = config.mirror_port  # Local port used by the Mirror server.
         # Track Layer Shell position manually because Qt frameGeometry() is unreliable (returns 0,0)
         self.layer_pos = QPoint(0, 0)
-        
+
         # [Performance] Resize Debounce Timer
         self._resize_timer = QTimer(self)
         self._resize_timer.setSingleShot(True)
         self._resize_timer.setInterval(30) # 30ms Debounce
         self._resize_timer.timeout.connect(self._delayed_adjust_height)
-        
+
         # Load Layer Shell Library
         self.load_layer_shell_lib()
 
@@ -788,14 +787,14 @@ class DanmakuWidget(QWidget):
         self.setup_tray_icon()
         self.update_gaming_mode_availability()
         self.setup_danmaku_client()
-        
+
         # 加载保存的配置
         if config.room_id is not None:
             self.room_id = config.room_id
-        
+
         # 初始化房间号
         self.room_id_input.setText(str(self.room_id))
-        
+
         # Try to activate Layer Shell initially
         QTimer.singleShot(100, self.activate_layer_shell)
 
@@ -837,7 +836,7 @@ class DanmakuWidget(QWidget):
             task.cancel()
         if pending:
             await asyncio.gather(*pending, return_exceptions=True)
-    
+
     def _delayed_adjust_height(self):
         """Debounced execution of item layout update"""
         if not self.is_gaming_mode:
@@ -859,12 +858,12 @@ class DanmakuWidget(QWidget):
             lib_path = find_layer_shell_library(package_dir)
             if lib_path:
                 self.layer_shell_lib = ctypes.CDLL(lib_path)
-                
+
                 # Define argument types for safety
                 self.layer_shell_lib.make_overlay.argtypes = [ctypes.c_void_p]
                 self.layer_shell_lib.set_passthrough.argtypes = [ctypes.c_void_p, ctypes.c_bool]
                 self.layer_shell_lib.set_anchor_position.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_int]
-                
+
                 # Check if new function exists (for backward compatibility during dev)
                 if hasattr(self.layer_shell_lib, 'set_keyboard_interactivity'):
                     self.layer_shell_lib.set_keyboard_interactivity.argtypes = [ctypes.c_void_p, ctypes.c_bool]
@@ -898,7 +897,7 @@ class DanmakuWidget(QWidget):
                 if handle:
                     cpp_ptr = sip.unwrapinstance(handle)
                     self.layer_shell_lib.make_overlay(ctypes.c_void_p(cpp_ptr))
-                    
+
                     # Ensure interactivity is enabled by default (for Normal Mode)
                     if hasattr(self.layer_shell_lib, 'set_keyboard_interactivity'):
                         self.layer_shell_lib.set_keyboard_interactivity(ctypes.c_void_p(cpp_ptr), True)
@@ -910,7 +909,7 @@ class DanmakuWidget(QWidget):
                         # Important: layer_pos is relative to the screen we are on.
                         # We assume initial setup put us on primary screen consistent with layer_pos
                         self.layer_shell_lib.set_anchor_position(ctypes.c_void_p(cpp_ptr), self.layer_pos.x(), self.layer_pos.y())
-                    
+
 
             except Exception as e:
                 print(f"Error activating Layer Shell: {e}")
@@ -920,26 +919,26 @@ class DanmakuWidget(QWidget):
         self.resize(300, 450)
         # 居中屏幕
         screen_geo = QApplication.primaryScreen().geometry()
-        
+
         # Initialize position relative to primary screen top-left
         initial_x = screen_geo.width() - 330
         initial_y = 100
-        
+
         # Qt move expects global coordinates
         self.move(
-            screen_geo.x() + initial_x, 
+            screen_geo.x() + initial_x,
             screen_geo.y() + initial_y
         )
         self.layer_pos = QPoint(initial_x, initial_y)
         self.setWindowTitle("Danmaku Overlay")
-        
+
         # 基础无边框和置顶设置
         flags = (
-            Qt.WindowType.FramelessWindowHint | 
-            Qt.WindowType.WindowStaysOnTopHint | 
-            Qt.WindowType.Window 
+            Qt.WindowType.FramelessWindowHint |
+            Qt.WindowType.WindowStaysOnTopHint |
+            Qt.WindowType.Window
         )
-            
+
         self.setWindowFlags(flags)
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
 
@@ -948,7 +947,7 @@ class DanmakuWidget(QWidget):
         if not self.is_gaming_mode:
             painter = QPainter(self)
             painter.setRenderHint(QPainter.RenderHint.Antialiasing)
-            
+
             # 使用半透明黑色背景
             painter.setBrush(QBrush(QColor(0, 0, 0, 120)))
             painter.setPen(Qt.PenStyle.NoPen)
@@ -989,7 +988,7 @@ class DanmakuWidget(QWidget):
             }
         """)
         self.live_status_dot.hide()
-        
+
         # 房间号输入
         self.room_id_input = QLineEdit(str(self.room_id))
         self.room_id_input.setPlaceholderText("ID")
@@ -1041,7 +1040,7 @@ class DanmakuWidget(QWidget):
         self.connect_button.setCheckable(True)
         self.connect_button.setStyleSheet(btn_style)
         self.connect_button.clicked.connect(self.toggle_connection)
-        
+
         # 游戏模式切换按钮
         self.gaming_mode_btn = QPushButton("锁定穿透")
         self.gaming_mode_btn.setCursor(Qt.CursorShape.PointingHandCursor)
@@ -1122,12 +1121,12 @@ class DanmakuWidget(QWidget):
         self.main_layout.addWidget(self.audience_status)
         self.main_layout.addWidget(self.danmaku_list)
         self.main_layout.addWidget(self.input_area) # 放在底部
-        
+
         self.setLayout(self.main_layout)
-        
+
         # 信号连接
         self.message_received.connect(self.add_message)
-        
+
         # 初始化全局输入框
         self.input_dialog = DanmakuInputDialog(None)
         self.input_dialog.send_message.connect(self.trigger_send)
@@ -1136,7 +1135,7 @@ class DanmakuWidget(QWidget):
         self._dragging = False
         self._drag_position = QPoint()
         self._message_buffer: list[HudMessage] = [] # [Optimization] Buffer
-        
+
         # 大小调整手柄
         self.size_grip = CustomSizeGrip(self)
         self.size_grip.setStyleSheet("""
@@ -1159,7 +1158,7 @@ class DanmakuWidget(QWidget):
     def setup_tray_icon(self):
         """初始化系统托盘图标"""
         self.tray_icon = QSystemTrayIcon(self)
-        
+
         # 加载图标
         icon_path = os.path.join(os.path.dirname(__file__), 'assets', 'icon.png')
         if os.path.exists(icon_path):
@@ -1168,7 +1167,7 @@ class DanmakuWidget(QWidget):
             self.setWindowIcon(icon)
         else:
             print(f"Icon not found at {icon_path}")
-        
+
         # 创建托盘菜单
         tray_menu = QMenu()
         tray_menu.setStyleSheet("""
@@ -1184,22 +1183,22 @@ class DanmakuWidget(QWidget):
                 background-color: #3d3d3d;
             }
         """)
-        
+
         self.tray_send_action = QAction("发送弹幕", self)
         self.tray_send_action.triggered.connect(self.open_input_dialog)
         tray_menu.addAction(self.tray_send_action)
-        
+
         tray_menu.addSeparator()
-        
+
         self.tray_toggle_action = QAction("显示/隐藏", self)
         self.tray_toggle_action.triggered.connect(self.toggle_visibility)
         tray_menu.addAction(self.tray_toggle_action)
-        
+
         self.tray_gaming_action = QAction("锁定穿透 (游戏模式)", self)
         self.tray_gaming_action.setCheckable(True)
         self.tray_gaming_action.triggered.connect(self.toggle_gaming_mode_from_tray)
         tray_menu.addAction(self.tray_gaming_action)
-        
+
         tray_menu.addSeparator()
 
         self.tray_login_action = QAction("扫码登录", self)
@@ -1217,14 +1216,14 @@ class DanmakuWidget(QWidget):
         self.tray_mock_action = QAction("弹幕模拟", self)
         self.tray_mock_action.triggered.connect(self.trigger_danmaku_simulation)
         tray_menu.addAction(self.tray_mock_action)
-        
+
         quit_action = QAction("退出程序", self)
         quit_action.triggered.connect(self.quit_app)
         tray_menu.addAction(quit_action)
-        
+
         self.tray_icon.setContextMenu(tray_menu)
         self.tray_icon.show()
-        
+
         self.tray_icon.activated.connect(self.on_tray_activated)
 
     def add_system_message(
@@ -1260,7 +1259,7 @@ class DanmakuWidget(QWidget):
             if success:
                 # print(f"弹幕发送成功: {text}")
                 # 可选：发送成功也显示一条本地回显，或者直接等服务器下发
-                pass 
+                pass
             else:
                 self.add_system_message(f"发送失败: {msg}", SystemMessageLevel.ERROR)
                 print(f"弹幕发送失败: {msg}")
@@ -1463,14 +1462,14 @@ class DanmakuWidget(QWidget):
 
     def set_gaming_mode(self, enabled: bool):
         self.is_gaming_mode = enabled
-        
+
         # 保存当前位置和大小
         current_geo = self.geometry()
-        
+
         # 同步各按钮状态
         self.tray_gaming_action.setChecked(enabled)
         self.gaming_mode_btn.setChecked(enabled)
-        
+
         # [Critical Fix] 重新构建Flags
         flags = Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnTopHint | Qt.WindowType.Window
 
@@ -1479,7 +1478,7 @@ class DanmakuWidget(QWidget):
 
         if enabled:
             # --- 开启穿透模式 (Gaming Mode) ---
-            
+
             # 1. 穿透模式核心Flags
             # X11BypassWindowManagerHint: 绕过WM，确保能在全屏游戏之上显示
             # ONLY use this if NOT using Layer Shell (i.e. on X11)
@@ -1487,21 +1486,21 @@ class DanmakuWidget(QWidget):
             is_wayland = QGuiApplication.platformName().startswith('wayland')
             if not has_layer_shell and not is_wayland:
                 flags |= Qt.WindowType.X11BypassWindowManagerHint
-            
+
             # WindowTransparentForInput: 输入事件穿透 (配合XShape)
             # On Wayland with LayerShell, we use the bridge to set mask.
-            # On X11, we use XShape. 
+            # On X11, we use XShape.
             flags |= Qt.WindowType.WindowTransparentForInput
             # WindowDoesNotAcceptFocus: 拒绝焦点，防止抢占游戏输入
             flags |= Qt.WindowType.WindowDoesNotAcceptFocus
-            
+
             # For Layer Shell, we rely on setLayer(Overlay) which is done in activate_layer_shell
 
             # 2. UI调整
             self.header_widget.hide()
             self.input_area.hide()
             self.danmaku_list.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-            
+
             self.danmaku_list.setStyleSheet("""
                 QListWidget {
                     background: transparent;
@@ -1509,24 +1508,24 @@ class DanmakuWidget(QWidget):
                     border-radius: 8px;
                 }
             """)
-            
+
             # 3. 属性设置
             self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
             self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating, True) # 防止show()时触发activate导致日志警告
-            
+
             self.tray_icon.showMessage(
-                "Danmaku Overlay", 
-                "已进入穿透模式 (游戏覆盖)\n弹幕将显示在最顶层，鼠标操作将穿透。", 
-                QSystemTrayIcon.MessageIcon.Information, 
+                "Danmaku Overlay",
+                "已进入穿透模式 (游戏覆盖)\n弹幕将显示在最顶层，鼠标操作将穿透。",
+                QSystemTrayIcon.MessageIcon.Information,
                 2000
             )
         else:
             # --- 关闭穿透模式 (Normal Mode) ---
-            
+
             # 1. Normal Mode Flags
             # 不需要 X11Bypass，也不需要 TransparentForInput
             # 普通无边框窗口；在 GNOME Wayland 上，置顶 hint 可能被 compositor 忽略。
-            
+
             # 2. UI调整
             self.header_widget.show()
             self.input_area.show()
@@ -1535,17 +1534,17 @@ class DanmakuWidget(QWidget):
 
             self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, False)
             self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating, False)
-        
+
         if has_layer_shell:
             # --- Wayland Layer Shell Mode ---
             # Do NOT call setWindowFlags or hide() as it recreates the window surface
             # and breaks the Layer Shell integration.
-            
+
             # Apply native input region changes
             try:
                 cpp_ptr = sip.unwrapinstance(self.windowHandle())
                 self.layer_shell_lib.set_passthrough(ctypes.c_void_p(cpp_ptr), enabled)
-                
+
                 # Toggle keyboard interactivity
                 # Enabled (Gaming Mode) -> No keyboard
                 # Disabled (Normal Mode) -> OnDemand keyboard
@@ -1557,27 +1556,27 @@ class DanmakuWidget(QWidget):
                 self.layout().activate()
                 self.danmaku_list.update()
                 self.update()
-                
+
             except Exception as e:
                 print(f"Failed to set Wayland passthrough: {e}")
-                
+
         else:
             # --- X11 / Standard Mode ---
             # Recreate window to apply flags (necessary for X11Bypass etc on XCB)
             self.hide()
             self.setWindowFlags(flags)
-            
+
             # 延迟执行显示操作
             # 切换 BypassWindowManagerHint 会导致 Native Window 销毁重建
             # 如果同步执行 show()，可能导致 X11 状态未同步而无法映射窗口
             def restore_window_state():
                 # 恢复位置 (在窗口重建后应用)
                 self.setGeometry(current_geo)
-                
+
                 # 显示并置顶
                 self.show()
                 self.raise_()
-                
+
                 if not enabled:
                     self.activateWindow()
 
@@ -1663,21 +1662,21 @@ class DanmakuWidget(QWidget):
 
     def resizeEvent(self, event):
         super().resizeEvent(event)
-        
+
         # 1. 更新SizeGrip位置
         rect = self.rect()
         self.size_grip.move(
             rect.right() - self.size_grip.width(),
             rect.bottom() - self.size_grip.height()
         )
-        
+
         # 2. Debounced Layout Update
         if not self.is_gaming_mode:
             self._resize_timer.start()
 
     def mouseReleaseEvent(self, event):
         self._dragging = False
-        
+
         # [Message Buffering]
         # Process all types of messages
         if self._message_buffer:
@@ -1694,7 +1693,7 @@ class DanmakuWidget(QWidget):
         # Re-activate Layer Shell when shown to ensure overlay/input works
         # Delayed to ensure window is mapped
         QTimer.singleShot(100, self.activate_layer_shell)
-    
+
     def setup_danmaku_client(self):
         self.danmaku_client = None
 
@@ -1906,7 +1905,7 @@ class DanmakuWidget(QWidget):
                 await self._disconnect_current_room()
             except Exception:
                 return
-            
+
     def save_room_id(self):
         try:
             self.room_id = int(self.room_id_input.text())
@@ -2147,13 +2146,13 @@ class DanmakuWidget(QWidget):
     def on_login_success(self):
         """登录成功，提醒用户重连"""
         self.tray_icon.showMessage(
-            "登录成功", 
-            "B站账号已登录，将在下次连接时生效。", 
-            QSystemTrayIcon.MessageIcon.Information, 
+            "登录成功",
+            "B站账号已登录，将在下次连接时生效。",
+            QSystemTrayIcon.MessageIcon.Information,
             2000
         )
         self.add_system_message("登录成功！请断开并重新连接以应用新的登录信息。")
-        
+
         # 自动重连逻辑 (如果已连接)
         if self.danmaku_client and self.danmaku_client.session:
             # 简单处理：提示用户
@@ -2162,9 +2161,9 @@ class DanmakuWidget(QWidget):
     def on_login_failed(self, msg: str):
         """登录失效回调"""
         self.tray_icon.showMessage(
-            "登录失效", 
-            msg, 
-            QSystemTrayIcon.MessageIcon.Warning, 
+            "登录失效",
+            msg,
+            QSystemTrayIcon.MessageIcon.Warning,
             5000
         )
         self.add_system_message(msg, SystemMessageLevel.ERROR)
@@ -2173,11 +2172,11 @@ class DanmakuWidget(QWidget):
         """覆盖关闭事件：最小化到系统托盘，而不是退出程序"""
         event.ignore()
         self.hide()
-        
+
         # Reminder for user
         self.tray_icon.showMessage(
-            "Bilibili Danmaku", 
-            "程序已最小化到托盘运行", 
-            QSystemTrayIcon.MessageIcon.Information, 
+            "Bilibili Danmaku",
+            "程序已最小化到托盘运行",
+            QSystemTrayIcon.MessageIcon.Information,
             2000
         )

--- a/src/bilihud/layer_shell_loader.py
+++ b/src/bilihud/layer_shell_loader.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
 from pathlib import Path
-
 
 LAYER_SHELL_LIBRARY_NAME = "libbili-layer.so"
 LAYER_SHELL_LIBRARY_PREFIX = "libbili-layer."

--- a/src/bilihud/main.py
+++ b/src/bilihud/main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import sys
 
@@ -130,17 +129,17 @@ def entry_point():
         QApplication.setHighDpiScaleFactorRoundingPolicy(
             Qt.HighDpiScaleFactorRoundingPolicy.PassThrough
         )
-    
+
     # Handle SIGINT
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
     app = QApplication(sys.argv)
     app.setApplicationName("bilihud")
-    
+
     loop = qasync.QEventLoop(app)
     asyncio.set_event_loop(loop)
     main_task = loop.create_task(main(app, args.room_id), name="application-main")
-    
+
     try:
         loop.run_forever()
     finally:

--- a/src/bilihud/mirror_server.py
+++ b/src/bilihud/mirror_server.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import Any
+from collections.abc import Mapping
 from urllib.parse import urlparse
 
 import aiohttp
@@ -22,7 +22,7 @@ IMAGE_PROXY_HEADERS = {
 }
 
 
-def mirror_event_payload(event: str, data: Any) -> str:
+def mirror_event_payload(event: str, data: object) -> str:
     return f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False, separators=(',', ':'))}\n\n"
 
 
@@ -289,7 +289,7 @@ class MirrorServer:
             self._clients.discard(queue)
         return response
 
-    def publish_append(self, entry: dict[str, Any]) -> None:
+    def publish_append(self, entry: Mapping[str, object]) -> None:
         payload = mirror_event_payload("append", entry)
         for queue in list(self._clients):
             queue.put_nowait(payload)

--- a/src/bilihud/qr_login_dialog.py
+++ b/src/bilihud/qr_login_dialog.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import asyncio
 import logging
 
@@ -17,7 +16,7 @@ class QRLoginDialog(QDialog):
     """Display the Bilibili QR-login flow through an injected auth service."""
 
     login_success = pyqtSignal()
-    
+
     def __init__(
         self,
         parent: QWidget | None = None,
@@ -28,11 +27,11 @@ class QRLoginDialog(QDialog):
         super().__init__(parent)
         self.setWindowTitle("扫码登录 Bilibili")
         self.setFixedSize(320, 400)
-        
+
         # Modern window styling
         self.setWindowFlags(Qt.WindowType.Dialog | Qt.WindowType.FramelessWindowHint)
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
-        
+
         self.auth_service = (  # Shared authentication boundary supplied by the app.
             auth_service if auth_service is not None else create_default_services().auth_service
         )
@@ -50,20 +49,20 @@ class QRLoginDialog(QDialog):
         self._poll_task: asyncio.Task[None] | None = None  # Current QR status request.
         self._shutting_down = False  # Prevent new requests after application shutdown.
         self._shutdown_complete = False  # Makes application shutdown idempotent.
-        
+
         self.init_ui()
-        
+
         # Timer for polling
         self.poll_timer = QTimer(self)  # Owned by the dialog and stopped on close.
         self.poll_timer.setInterval(2000) # Poll every 2 seconds
         self.poll_timer.timeout.connect(self.check_status)
-        
+
     def init_ui(self):
         """Build the frameless QR-login presentation and its status controls."""
         # Main layout with background container
         main_layout = QVBoxLayout(self)
         main_layout.setContentsMargins(10, 10, 10, 10)
-        
+
         self.container = QWidget()
         self.container.setStyleSheet("""
             QWidget {
@@ -72,17 +71,17 @@ class QRLoginDialog(QDialog):
                 border: 1px solid #3d3d3d;
             }
         """)
-        
+
         # Add shadow
         shadow = QGraphicsDropShadowEffect(self)
         shadow.setBlurRadius(20)
         shadow.setColor(QColor(0, 0, 0, 100))
         self.container.setGraphicsEffect(shadow)
-        
+
         layout = QVBoxLayout(self.container)
         layout.setSpacing(15)
         layout.setContentsMargins(20, 20, 20, 20)
-        
+
         # Title
         title_label = QLabel("扫码登录")
         title_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -93,14 +92,14 @@ class QRLoginDialog(QDialog):
             font-family: 'Microsoft YaHei';
         """)
         layout.addWidget(title_label)
-        
+
         # QR Code Display
         self.qr_label = QLabel()
         self.qr_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.qr_label.setFixedSize(200, 200)
         self.qr_label.setStyleSheet("background-color: white; border-radius: 4px;")
         layout.addWidget(self.qr_label, 0, Qt.AlignmentFlag.AlignCenter)
-        
+
         # Status Label
         self.status_label = QLabel("正在加载二维码...")
         self.status_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -111,7 +110,7 @@ class QRLoginDialog(QDialog):
             font-family: 'Microsoft YaHei';
         """)
         layout.addWidget(self.status_label)
-        
+
         # Refresh Button
         self.refresh_btn = QPushButton("刷新二维码")
         self.refresh_btn.setCursor(Qt.CursorShape.PointingHandCursor)
@@ -149,7 +148,7 @@ class QRLoginDialog(QDialog):
         """)
         close_btn.clicked.connect(self.close)
         layout.addWidget(close_btn, 0, Qt.AlignmentFlag.AlignCenter)
-        
+
         main_layout.addWidget(self.container)
 
     def showEvent(self, event):
@@ -158,7 +157,7 @@ class QRLoginDialog(QDialog):
         if self._shutting_down:
             return
         self.refresh_qrcode()
-        
+
     def closeEvent(self, event):
         """Stop status polling before the dialog is destroyed or hidden."""
         self.poll_timer.stop()
@@ -185,7 +184,7 @@ class QRLoginDialog(QDialog):
             if self._owns_task_supervisor and self._task_supervisor is not None:
                 await self._task_supervisor.shutdown()
         self._shutdown_complete = True
-        
+
     def refresh_qrcode(self):
         """Start one asynchronous QR-code request and reset stale polling state."""
         if self._shutting_down:
@@ -199,20 +198,20 @@ class QRLoginDialog(QDialog):
             self._load_task.cancel()
         if self._poll_task is not None and not self._poll_task.done():
             self._poll_task.cancel()
-        
+
         self._load_task = self._task_scope.create_task(self._load_qrcode(), name="load-qrcode")
-        
+
     async def _load_qrcode(self):
         """Fetch a QR URL, render it, and start polling after a successful render."""
         url, key = await self.auth_service.get_qrcode()
         if url and key:
             self.qrcode_key = key
-            
+
             # Generate Image
             # Note: generate_qr_image is synchronous but fast
             loop = asyncio.get_event_loop()
             bio = await loop.run_in_executor(None, self.auth_service.generate_qr_image, url)
-            
+
             if bio:
                 top_img = QImage.fromData(bio.getvalue())
                 pixmap = QPixmap.fromImage(top_img)
@@ -243,43 +242,43 @@ class QRLoginDialog(QDialog):
             self._poll_status(self.qrcode_key),
             name="poll-qrcode",
         )
-            
+
     async def _poll_status(self, qrcode_key: str) -> None:
         """Persist cookies after successful scanning and update visible failure states."""
         code, msg, cookies = await self.auth_service.poll_status(qrcode_key)
         status_name = QR_LOGIN_STATUS_NAMES.get(code, "Unknown")
         logger.info("QR login poll status: code=%s (%s), message=%s", code, status_name, msg)
-        
+
         if code == 0:
             # Success
             self.status_label.setText("登录成功！")
             self.status_label.setStyleSheet("color: #4caf50; font-weight: bold;")
             self.poll_timer.stop()
-            
+
             # Save cookies
             if cookies:
                 self.auth_service.save_cookies(cookies)
                 self.login_success.emit()
                 self.accept()
-                
+
         elif code == 86101:
             # Scanned
             # User requested to keep text fixed and avoid "false positive" updates
             # self.status_label.setText("扫描成功，请在手机上确认")
             # self.status_label.setStyleSheet("color: #ff9800;")
             pass
-            
+
         elif code == 86038:
             # Expired
             self.status_label.setText("二维码已过期")
             self.status_label.setStyleSheet("color: #ff5555;")
             self.poll_timer.stop()
             self.refresh_btn.setVisible(True)
-            
+
         elif code == 86090:
             # Not scanned yet, do nothing
             pass
-            
+
         else:
             # Other error
             pass

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ def test_validate_room_id():
     """Test room ID validation logic"""
     assert validate_room_id("123") is True
     assert validate_room_id("2145") is True
-    
+
     # Invalid cases
     assert validate_room_id("0") is False
     assert validate_room_id("-1") is False


### PR DESCRIPTION
## Summary

- Align the Mirror Server append boundary with typed MirrorEntry payloads.
- Apply Ruff default safe fixes for whitespace, import ordering, and UTF-8 encoding declarations.
- Keep the T4 fix and mechanical lint cleanup as separate signed commits.

## Verification

- uv run pytest -q: 161 passed
- uv build: passed
- git diff --check: passed
- PYTHONPATH=vendor/blivedm uv run ty check src: 66 diagnostics remain; the T4 MirrorEntry mismatch is resolved.
- uv run ruff check src tests --statistics: 30 errors remain; no unsafe fixes were applied.

## Remaining work

- Ruff: 11 E501, 10 E402, 5 E701, and 4 W291.
- ty: existing Qt nullability and override diagnostics, plus issues in __main__.py, live_control_dialog.py, and obs_api.py.
- xvfb-run is unavailable in this environment; Qt tests ran in offscreen/direct mode.

Refs: #19
Refs: #24