### PR TITLE
refactor(hud): extract HUD connection controller

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,8 @@ Strong typing is a continuous requirement for all new and modified code.
 - Parse external JSON, configuration, and third-party objects into typed structures.
 - Use `dataclass`, `Enum`, `Protocol`, `TypedDict`, and type aliases when they express the real contract.
 - Give states, commands, events, errors, and configuration explicit structures.
+- Before adding a helper or utility function, search the existing code for an equivalent capability. Reuse the existing function or extend its typed contract when it owns the same responsibility; add a new helper only when the responsibility or ownership is genuinely different.
+- When a value does not satisfy a function's annotated input type, first decide whether the function's contract should accept that value. Prefer widening or clarifying the function's type and testing the resulting contract when the value is semantically valid; do not add call-site conversions merely to satisfy the annotation. Convert at a real boundary only when normalization is part of that boundary's explicit contract, with validation that preserves the intended meaning.
 - Use the type checker configured by the repository; do not hide errors by expanding exclusions.
 - Every type suppression must document its reason, impact, and follow-up path.
 

--- a/docs/architecture/module-boundaries.md
+++ b/docs/architecture/module-boundaries.md
@@ -24,6 +24,11 @@ stable design rule, not a list of current migration tasks.
   developer regression action and must not instantiate raw third-party models.
 - `danmaku_format`, `mirror_state`, and Qt message rendering consume domain
   messages and must not import `blivedm` models directly.
+- `hud_controller` owns room connection transitions, audience refresh tasks,
+  normalized send commands, and typed HUD events; `hud_ports` defines the
+  client capability and factory ports used to inject infrastructure.
+- `danmaku_widget` binds `HudState` and `HudEvent` values to Qt controls and
+  does not own a concrete `DanmakuClient` or its connection tasks.
 - Presentation code binds state and commands; it does not own business workflows.
 - Application code owns use-case lifecycles and coordinates infrastructure through ports.
 - Domain code remains deterministic and independently testable whenever practical.

--- a/src/bilihud/danmaku_client.py
+++ b/src/bilihud/danmaku_client.py
@@ -202,7 +202,7 @@ class DanmakuClient:
 
         return parse_audience_snapshot(self.room_id, room_payload, rank_payload)
 
-    async def fetch_live_emoticons(self):
+    async def fetch_live_emoticons(self) -> list[LiveEmoticonPackage]:
         """Fetch room-specific live emoticon packages."""
         if not self.session:
             raise RuntimeError("弹幕会话未初始化")
@@ -300,7 +300,7 @@ class DanmakuClient:
         self._wbi_mixin_key = mixin_key
         return mixin_key
 
-    async def stop(self, normal_timeout: float = 3.0, forced_timeout: float = 3.0):
+    async def stop(self, normal_timeout: float = 3.0, forced_timeout: float = 3.0) -> None:
         """Stop the underlying client and close all network resources it owns."""
         client = self.client
         session = self.session

--- a/src/bilihud/danmaku_widget.py
+++ b/src/bilihud/danmaku_widget.py
@@ -53,11 +53,19 @@ from PyQt6.QtWidgets import (
 from .audience_widgets import AudiencePopup, AudienceStatusWidget
 from .auth import AuthenticationService
 from .config import AppConfig, ConfigStore
-from .danmaku_client import DanmakuClient
 from .danmaku_format import (
     danmaku_author_badges_html,
     danmaku_message_content_html,
     danmaku_message_emoticon_urls,
+)
+from .domain.hud import (
+    HudConnectionStatus,
+    HudEvent,
+    HudLoginFailed,
+    HudMessageReceived,
+    HudOperationFailed,
+    HudState,
+    HudStateChanged,
 )
 from .domain.messages import (
     DanmakuMessage,
@@ -68,6 +76,7 @@ from .domain.messages import (
     SystemMessageLevel,
     make_system_message,
 )
+from .hud_controller import HudController
 from .layer_shell_loader import (
     LAYER_SHELL_LIBRARY_NAME,
     find_layer_shell_library,
@@ -76,7 +85,6 @@ from .layer_shell_loader import (
 )
 from .lifecycle import TaskScope, TaskSupervisor, cancel_task
 from .live_api import get_anchor_live_room_id
-from .live_audience import AudienceSnapshot
 from .live_control_dialog import LiveControlDialog
 from .live_emoticons import LiveEmoticon, LiveEmoticonPackage
 from .mirror_server import MirrorServer
@@ -87,7 +95,6 @@ from .qr_login_dialog import QRLoginDialog
 from .services import AppServices, create_default_services
 
 logger = logging.getLogger(__name__)
-AUDIENCE_REFRESH_INTERVAL_SECONDS = 30.0
 
 
 class ModernInputWidget(QWidget):
@@ -754,10 +761,6 @@ class DanmakuWidget(QWidget):
         self.services = services if services is not None else create_default_services()
         self.config_store: ConfigStore = self.services.config_store  # Typed settings boundary.
         self.auth_service: AuthenticationService = self.services.auth_service  # Shared auth boundary.
-        self.danmaku_client: DanmakuClient | None = None  # Client owned by this widget.
-        self._audience_refresh_task: asyncio.Task[None] | None = None  # Cancelled on disconnect.
-        self._audience_generation = 0
-        self._audience_snapshot: AudienceSnapshot | None = None
         self._live_control_dialog: LiveControlDialog | None = None  # Reused live-control dialog owner.
         self._mirror_settings_dialog: MirrorSettingsDialog | None = None  # Reused Mirror settings owner.
         self._qr_login_dialog: QRLoginDialog | None = None  # Active modal QR-login dialog, if any.
@@ -786,14 +789,25 @@ class DanmakuWidget(QWidget):
         self.init_ui()
         self.setup_tray_icon()
         self.update_gaming_mode_availability()
-        self.setup_danmaku_client()
 
         # 加载保存的配置
         if config.room_id is not None:
             self.room_id = config.room_id
 
+        self.hud_controller: HudController = HudController(
+            initial_room_id=self.room_id,
+            sessdata=self.sessdata,
+            auth_service=self.auth_service,
+            client_factory=self.services.hud_client_factory,
+            config_store=self.config_store,
+            task_scope=self._task_scope.child("hud-controller"),
+        )
+        self._hud_state: HudState = self.hud_controller.state
+        self.hud_controller.subscribe(self._on_hud_event)
+
         # 初始化房间号
         self.room_id_input.setText(str(self.room_id))
+        self._bind_hud_state(self._hud_state)
 
         # Try to activate Layer Shell initially
         QTimer.singleShot(100, self.activate_layer_shell)
@@ -1253,19 +1267,8 @@ class DanmakuWidget(QWidget):
             self.tray_gaming_action.setToolTip("GNOME Wayland 不支持全屏浮窗/锁定穿透，也不保证普通窗口置顶")
 
     async def _send_danmaku_task(self, text: str):
-        """实际执行发送弹幕的Task"""
-        if self.danmaku_client:
-            success, msg = await self.danmaku_client.send_danmaku(text)
-            if success:
-                # print(f"弹幕发送成功: {text}")
-                # 可选：发送成功也显示一条本地回显，或者直接等服务器下发
-                pass
-            else:
-                self.add_system_message(f"发送失败: {msg}", SystemMessageLevel.ERROR)
-                print(f"弹幕发送失败: {msg}")
-        else:
-              self.add_system_message("未连接直播间，无法发送", SystemMessageLevel.ERROR)
-              print("未连接，无法发送")
+        """Execute a text-send command through the application controller."""
+        await self.hud_controller.send_danmaku(text)
 
     def trigger_send(self, text: str):
         """处理发送弹幕请求"""
@@ -1284,7 +1287,7 @@ class DanmakuWidget(QWidget):
         )
 
     async def _open_emoticon_picker(self) -> None:
-        if not self.danmaku_client or not self.danmaku_client.session:
+        if not self.hud_controller.state.is_connected:
             self.add_system_message("未连接直播间，无法加载表情", SystemMessageLevel.ERROR)
             return
 
@@ -1296,9 +1299,11 @@ class DanmakuWidget(QWidget):
         )
         self.emoticon_picker.show()
         try:
-            packages = await self.danmaku_client.fetch_live_emoticons()
-        except Exception as e:
-            self.emoticon_picker.set_error(str(e))
+            packages = await self.hud_controller.fetch_live_emoticons()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self.emoticon_picker.set_error(str(exc))
             return
         self.emoticon_picker.set_packages(packages)
 
@@ -1311,12 +1316,8 @@ class DanmakuWidget(QWidget):
         )
 
     async def _send_live_emoticon_task(self, emoticon: LiveEmoticon):
-        if not self.danmaku_client:
-            self.add_system_message("未连接直播间，无法发送", SystemMessageLevel.ERROR)
-            return
-        success, msg = await self.danmaku_client.send_live_emoticon(emoticon)
-        if not success:
-            self.add_system_message(f"发送失败: {msg}", SystemMessageLevel.ERROR)
+        """Execute a live-emoticon send command through the application controller."""
+        await self.hud_controller.send_live_emoticon(emoticon)
 
     def open_input_dialog(self):
         """打开全局输入框"""
@@ -1382,9 +1383,9 @@ class DanmakuWidget(QWidget):
                 shutdown_errors.append(exc)
             self._mirror_start_task = None
             try:
-                await self._stop_audience_refresh()
+                await self.hud_controller.shutdown()
             except Exception as exc:
-                logger.exception("Failed to stop audience refresh")
+                logger.exception("Failed to close HUD controller")
                 shutdown_errors.append(exc)
             try:
                 await self._task_scope.cancel_all()
@@ -1397,16 +1398,6 @@ class DanmakuWidget(QWidget):
             except Exception as exc:
                 logger.exception("Failed to close Mirror server")
                 shutdown_errors.append(exc)
-
-            client = self.danmaku_client
-            if client is not None:
-                try:
-                    await client.stop()
-                except Exception as exc:
-                    logger.exception("Failed to close danmaku client")
-                    shutdown_errors.append(exc)
-                else:
-                    self.danmaku_client = None
         finally:
             if self._owns_task_supervisor:
                 try:
@@ -1694,9 +1685,6 @@ class DanmakuWidget(QWidget):
         # Delayed to ensure window is mapped
         QTimer.singleShot(100, self.activate_layer_shell)
 
-    def setup_danmaku_client(self):
-        self.danmaku_client = None
-
     def _persist_config(self, config: AppConfig) -> bool:
         """Persist one complete typed configuration value through the injected store."""
         return self.config_store.save(config)
@@ -1713,76 +1701,62 @@ class DanmakuWidget(QWidget):
         return self._persist_config(updated)
 
     def open_audience_popup(self):
-        if self._audience_snapshot is None or self.is_gaming_mode:
+        snapshot = self._hud_state.audience_snapshot
+        if snapshot is None or self.is_gaming_mode:
             return
-        self.audience_popup.set_snapshot(self._audience_snapshot)
+        self.audience_popup.set_snapshot(snapshot)
         self.audience_popup.show_below(self.audience_status.online_button, self)
 
-    async def _refresh_audience_once(
-        self,
-        client: DanmakuClient,
-        generation: int,
-    ) -> bool:
-        try:
-            snapshot = await client.fetch_audience_snapshot()
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            logger.info("Failed to refresh room audience data: %s", exc)
-            return False
-
-        if (
-            generation != self._audience_generation
-            or self.danmaku_client is not client
-            or self.room_id != snapshot.room_id
-        ):
-            return False
-
-        self._audience_snapshot = snapshot
-        self.audience_status.set_snapshot(snapshot)
-        self.audience_popup.set_snapshot(snapshot)
-        self._sync_audience_visibility()
-        return True
-
-    async def _audience_refresh_loop(
-        self,
-        client: DanmakuClient,
-        generation: int,
-    ) -> None:
-        while True:
-            await self._refresh_audience_once(client, generation)
-            await asyncio.sleep(AUDIENCE_REFRESH_INTERVAL_SECONDS)
-
-    async def _start_audience_refresh(self, client: DanmakuClient) -> None:
-        await self._stop_audience_refresh()
-        generation = self._audience_generation
-        self._audience_refresh_task = self._task_scope.create_task(
-            self._audience_refresh_loop(client, generation),
-            name="audience-refresh",
-        )
-
-    async def _stop_audience_refresh(self) -> None:
-        self._audience_generation += 1
-        task = self._audience_refresh_task
-        self._audience_refresh_task = None
-        if task is not None:
-            await cancel_task(task)
-        self._audience_snapshot = None
-        self.audience_popup.hide()
-        self.audience_status.clear()
-
     def _sync_audience_visibility(self) -> None:
-        visible = self._audience_snapshot is not None and not self.is_gaming_mode
+        visible = self._hud_state.audience_snapshot is not None and not self.is_gaming_mode
         self.audience_status.setVisible(visible)
         if not visible:
             self.audience_popup.hide()
 
-    def _wire_danmaku_client(self, client: DanmakuClient) -> None:
-        client.set_message_callback(self.on_message_received)
-        client.set_login_failed_callback(self.on_login_failed)
+    def _on_hud_event(self, event: HudEvent) -> None:
+        """Bind typed controller events to Qt rendering and user notifications."""
+        if isinstance(event, HudStateChanged):
+            self._bind_hud_state(event.state)
+        elif isinstance(event, HudMessageReceived):
+            self.on_message_received(event.message)
+        elif isinstance(event, HudLoginFailed):
+            self.on_login_failed(event.message)
+        elif isinstance(event, HudOperationFailed):
+            self.add_system_message(event.message, SystemMessageLevel.ERROR)
+
+    def _bind_hud_state(self, state: HudState) -> None:
+        """Render one complete controller snapshot without reading network objects."""
+        previous_room_id = self._hud_state.room_id
+        self._hud_state = state
+        if state.room_id is not None and state.room_id != previous_room_id:
+            self.room_id = state.room_id
+            self.room_id_input.setText(str(state.room_id))
+
+        if state.connection is HudConnectionStatus.CONNECTING:
+            self._set_connecting_ui()
+        elif state.connection is HudConnectionStatus.DISCONNECTING:
+            self._set_disconnecting_ui()
+        elif state.connection is HudConnectionStatus.CONNECTED:
+            self._set_connected_ui()
+        else:
+            self._set_disconnected_ui()
+
+        snapshot = state.audience_snapshot
+        if snapshot is None:
+            self.audience_popup.hide()
+            self.audience_status.clear()
+        else:
+            self.audience_status.set_snapshot(snapshot)
+            self.audience_popup.set_snapshot(snapshot)
+        self._sync_audience_visibility()
 
     def _set_connecting_ui(self):
         self.connect_button.setText("连接中...")
+        self.connect_button.setEnabled(False)
+
+    def _set_disconnecting_ui(self):
+        self.connect_button.setText("断开中...")
+        self.connect_button.setChecked(True)
         self.connect_button.setEnabled(False)
 
     def _set_connected_ui(self):
@@ -1815,72 +1789,6 @@ class DanmakuWidget(QWidget):
             QPushButton:checked { background-color: rgba(76, 175, 80, 150); }
         """)
 
-    def _has_active_danmaku_connection(self) -> bool:
-        client = self.danmaku_client
-        return client is not None and client.is_running
-
-    async def _connect_to_room_id(self, room_id: int):
-        if room_id <= 0:
-            raise ValueError("直播间号无效")
-
-        if self._has_active_danmaku_connection() and self.room_id == room_id:
-            self.room_id_input.setText(str(room_id))
-            self._set_connected_ui()
-            client = self.danmaku_client
-            if client is None:
-                return
-            if self._audience_refresh_task is None:
-                await self._start_audience_refresh(client)
-            return
-
-        if self.danmaku_client is not None and self.danmaku_client.client:
-            await self._disconnect_current_room()
-
-        self.room_id = room_id
-        self.room_id_input.setText(str(room_id))
-        client = DanmakuClient(room_id, self.sessdata, auth_service=self.auth_service)
-        self.danmaku_client = client
-        self._wire_danmaku_client(client)
-        self._update_persisted_config(room_id=room_id)
-        self._set_connecting_ui()
-        try:
-            await client.start()
-        except BaseException:
-            try:
-                await client.stop()
-            except BaseException:
-                logger.exception("Failed to clean up danmaku client after connection failure")
-            else:
-                if self.danmaku_client is client:
-                    self.danmaku_client = None
-            self._set_disconnected_ui()
-            raise
-        self._set_connected_ui()
-        await self._start_audience_refresh(client)
-
-    async def _disconnect_current_room(self):
-        self.connect_button.setEnabled(False)
-        client = self.danmaku_client
-        previous_snapshot = self._audience_snapshot
-        await self._stop_audience_refresh()
-        try:
-            if client is not None:
-                await client.stop()
-        except Exception as e:
-            self._set_connected_ui()
-            if client is not None:
-                await self._start_audience_refresh(client)
-            if previous_snapshot is not None:
-                self._audience_snapshot = previous_snapshot
-                self.audience_status.set_snapshot(previous_snapshot)
-                self.audience_popup.set_snapshot(previous_snapshot)
-                self._sync_audience_visibility()
-            self.add_system_message(f"断开失败: {e}", SystemMessageLevel.ERROR)
-            print(f"Disconnect failed: {e}")
-            raise
-        self.danmaku_client = None
-        self._set_disconnected_ui()
-
     @pyqtSlot()
     def toggle_connection(self) -> asyncio.Task[None] | None:
         """Schedule the room connection workflow under the widget owner."""
@@ -1889,22 +1797,20 @@ class DanmakuWidget(QWidget):
         return self._create_action_task(self._toggle_connection(), name="toggle-connection")
 
     async def _toggle_connection(self) -> None:
-        """切换连接状态"""
+        """Convert the room input into a typed controller toggle command."""
         if self._shutting_down:
             return
-        if not self._has_active_danmaku_connection():
-            # 连接
-            try:
-                await self._connect_to_room_id(int(self.room_id_input.text()))
-            except Exception as e:
-                self._set_disconnected_ui()
-                print(f"Connection failed: {e}")
-        else:
-            # 断开
-            try:
-                await self._disconnect_current_room()
-            except Exception:
-                return
+        try:
+            room_id = int(self.room_id_input.text().strip())
+        except ValueError:
+            self.add_system_message("直播间号无效", SystemMessageLevel.ERROR)
+            return
+        try:
+            await self.hud_controller.toggle_connection(room_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            return
 
     def save_room_id(self):
         try:
@@ -1952,7 +1858,7 @@ class DanmakuWidget(QWidget):
             if session is not None and not session.closed:
                 await session.close()
 
-        await self._connect_to_room_id(anchor_room_id)
+        await self.hud_controller.connect(anchor_room_id)
         return anchor_room_id
 
     @pyqtSlot()
@@ -2152,11 +2058,6 @@ class DanmakuWidget(QWidget):
             2000
         )
         self.add_system_message("登录成功！请断开并重新连接以应用新的登录信息。")
-
-        # 自动重连逻辑 (如果已连接)
-        if self.danmaku_client and self.danmaku_client.session:
-            # 简单处理：提示用户
-            pass
 
     def on_login_failed(self, msg: str):
         """登录失效回调"""

--- a/src/bilihud/domain/__init__.py
+++ b/src/bilihud/domain/__init__.py
@@ -1,5 +1,17 @@
 """Stable domain contracts used by the application and presentation layers."""
 
+from .hud import (
+    HudConnectionStatus,
+    HudEvent,
+    HudEventListener,
+    HudLoginFailed,
+    HudMessageReceived,
+    HudOperation,
+    HudOperationFailed,
+    HudSendResult,
+    HudState,
+    HudStateChanged,
+)
 from .messages import (
     DanmakuMessage,
     GiftCurrency,
@@ -24,6 +36,16 @@ __all__ = (
     "GiftMessage",
     "GiftCurrency",
     "HudMessage",
+    "HudConnectionStatus",
+    "HudEvent",
+    "HudEventListener",
+    "HudLoginFailed",
+    "HudMessageReceived",
+    "HudOperation",
+    "HudOperationFailed",
+    "HudSendResult",
+    "HudState",
+    "HudStateChanged",
     "ImageSegment",
     "InteractionKind",
     "InteractMessage",

--- a/src/bilihud/domain/hud.py
+++ b/src/bilihud/domain/hud.py
@@ -1,0 +1,100 @@
+"""Typed contracts for the HUD application workflow."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+
+from ..live_audience import AudienceSnapshot
+from .messages import HudMessage
+
+
+class HudConnectionStatus(StrEnum):
+    """Describe the lifecycle state of the active HUD room connection."""
+
+    DISCONNECTED = "disconnected"
+    CONNECTING = "connecting"
+    CONNECTED = "connected"
+    DISCONNECTING = "disconnecting"
+
+
+class HudOperation(StrEnum):
+    """Identify an application operation that can report a user-facing error."""
+
+    CONNECT = "connect"
+    DISCONNECT = "disconnect"
+    SEND_DANMAKU = "send_danmaku"
+    FETCH_EMOTICONS = "fetch_emoticons"
+    SEND_EMOTICON = "send_emoticon"
+    REFRESH_AUDIENCE = "refresh_audience"
+
+
+@dataclass(frozen=True, slots=True)
+class HudState:
+    """Immutable snapshot rendered by the HUD presentation layer."""
+
+    connection: HudConnectionStatus = HudConnectionStatus.DISCONNECTED
+    room_id: int | None = None
+    audience_snapshot: AudienceSnapshot | None = None
+    error: str | None = None
+
+    @property
+    def is_connected(self) -> bool:
+        """Return whether the active room can receive HUD commands."""
+        return self.connection is HudConnectionStatus.CONNECTED
+
+
+@dataclass(frozen=True, slots=True)
+class HudSendResult:
+    """Report the normalized result of a message or emoticon send command."""
+
+    success: bool
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class HudStateChanged:
+    """Notify a presentation consumer that the rendered HUD state changed."""
+
+    state: HudState
+
+
+@dataclass(frozen=True, slots=True)
+class HudMessageReceived:
+    """Carry one normalized live-room message to presentation consumers."""
+
+    message: HudMessage
+
+
+@dataclass(frozen=True, slots=True)
+class HudLoginFailed:
+    """Report that the current connection could not use the saved login."""
+
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class HudOperationFailed:
+    """Report an expected operation failure without coupling to a UI toolkit."""
+
+    operation: HudOperation
+    message: str
+
+
+type HudEvent = HudStateChanged | HudMessageReceived | HudLoginFailed | HudOperationFailed
+type HudEventListener = Callable[[HudEvent], None]
+
+
+__all__ = (
+    "HudConnectionStatus",
+    "HudEvent",
+    "HudEventListener",
+    "HudLoginFailed",
+    "HudMessageReceived",
+    "HudOperation",
+    "HudOperationFailed",
+    "HudSendResult",
+    "HudState",
+    "HudStateChanged",
+)

--- a/src/bilihud/helpers.py
+++ b/src/bilihud/helpers.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 
-def validate_room_id(room_id_str: str) -> bool:
-    """Return whether a user-entered room identifier is a positive integer."""
+def validate_room_id(room_id: str | int) -> bool:
+    """Return whether a room identifier is a positive integer."""
     try:
-        return int(room_id_str) > 0
-    except ValueError:
+        return int(room_id) > 0
+    except (TypeError, ValueError):
         return False

--- a/src/bilihud/hud_controller.py
+++ b/src/bilihud/hud_controller.py
@@ -1,0 +1,500 @@
+"""Application coordination for the HUD room and message workflows."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import replace
+
+from .auth import AuthenticationService
+from .config import ConfigStore
+from .domain.hud import (
+    HudConnectionStatus,
+    HudEvent,
+    HudEventListener,
+    HudLoginFailed,
+    HudMessageReceived,
+    HudOperation,
+    HudOperationFailed,
+    HudSendResult,
+    HudState,
+    HudStateChanged,
+)
+from .domain.messages import HudMessage
+from .helpers import validate_room_id
+from .hud_ports import HudClient, HudClientFactory
+from .lifecycle import TaskScope, TaskSupervisor, cancel_task
+from .live_audience import AudienceSnapshot
+from .live_emoticons import LiveEmoticon, LiveEmoticonPackage
+
+logger = logging.getLogger(__name__)
+AUDIENCE_REFRESH_INTERVAL_SECONDS = 30.0
+
+class HudController:
+    """Own HUD connection, room switching, audience refresh, and send commands."""
+
+    def __init__(
+        self,
+        *,
+        initial_room_id: int,
+        sessdata: str,
+        auth_service: AuthenticationService,
+        client_factory: HudClientFactory,
+        config_store: ConfigStore | None = None,
+        task_scope: TaskScope | None = None,
+    ) -> None:
+        """Create a controller with explicit infrastructure and task ownership."""
+        self._sessdata = sessdata  # Optional one-off session override for new connections.
+        self._auth_service = auth_service  # Shared authentication boundary from the composition root.
+        self._client_factory = client_factory  # Infrastructure capability injected by the composition root.
+        self._config_store = config_store  # Optional persistence for the last selected room.
+        if task_scope is None:
+            task_supervisor = TaskSupervisor()
+            self._task_supervisor: TaskSupervisor | None = task_supervisor
+            self._owns_task_supervisor = True
+            self._task_scope = task_supervisor.create_scope("hud-controller")
+        else:
+            self._task_supervisor = None
+            self._owns_task_supervisor = False
+            self._task_scope = task_scope
+
+        room_id = initial_room_id if initial_room_id > 0 else None
+        self._state = HudState(room_id=room_id)
+        self._client: HudClient | None = None  # Current client and its network resources.
+        self._generation = 0  # Invalidates callbacks and refresh results from old rooms.
+        self._audience_task: asyncio.Task[None] | None = None  # Owned periodic audience workflow.
+        self._listeners: list[HudEventListener] = []  # Typed presentation subscribers.
+        self._operation_lock = asyncio.Lock()  # Serializes room changes and outbound sends.
+        self._shutting_down = False
+        self._shutdown_complete = False
+
+    @property
+    def state(self) -> HudState:
+        """Return the latest immutable state snapshot for presentation binding."""
+        return self._state
+
+    def subscribe(self, listener: HudEventListener) -> None:
+        """Register one typed event listener until it is explicitly removed."""
+        if listener not in self._listeners:
+            self._listeners.append(listener)
+
+    def unsubscribe(self, listener: HudEventListener) -> None:
+        """Remove a previously registered event listener when it is still present."""
+        if listener in self._listeners:
+            self._listeners.remove(listener)
+
+    async def connect(self, room_id: int) -> None:
+        """Connect to a room, replacing stale or different active connections."""
+        if not validate_room_id(room_id):
+            raise ValueError("直播间号无效")
+        async with self._operation_lock:
+            self._ensure_open()
+            await self._connect_locked(room_id)
+
+    async def disconnect(self) -> None:
+        """Disconnect the current room and clear its audience workflow."""
+        async with self._operation_lock:
+            self._ensure_open()
+            await self._disconnect_locked()
+
+    async def toggle_connection(self, room_id: int) -> None:
+        """Toggle the connection or connect to the supplied room when disconnected."""
+        if not validate_room_id(room_id):
+            raise ValueError("直播间号无效")
+        async with self._operation_lock:
+            self._ensure_open()
+            client = self._client
+            if (
+                self._state.connection is HudConnectionStatus.CONNECTED
+                and client is not None
+                and client.is_running
+            ):
+                await self._disconnect_locked()
+            else:
+                await self._connect_locked(room_id)
+
+    async def send_danmaku(self, message: str) -> HudSendResult:
+        """Send one text message through the current room-owned client."""
+        if not message.strip():
+            result = HudSendResult(False, "消息为空")
+            self._record_operation_failure(HudOperation.SEND_DANMAKU, result.message)
+            return result
+
+        async with self._operation_lock:
+            self._ensure_open()
+            unavailable_message = "未连接直播间，无法发送"
+            client = self._connected_client(HudOperation.SEND_DANMAKU, unavailable_message)
+            if client is None:
+                return HudSendResult(False, unavailable_message)
+            try:
+                success, response = await client.send_danmaku(message)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                response = self._exception_message(exc, "发送异常")
+                result = HudSendResult(False, response)
+            else:
+                result = HudSendResult(success, response)
+
+            if result.success:
+                self._clear_error()
+            else:
+                self._record_operation_failure(HudOperation.SEND_DANMAKU, result.message)
+            return result
+
+    async def fetch_live_emoticons(self) -> list[LiveEmoticonPackage]:
+        """Fetch live emoticons through the current room-owned client."""
+        async with self._operation_lock:
+            self._ensure_open()
+            unavailable_message = "未连接直播间，无法加载表情"
+            client = self._connected_client(HudOperation.FETCH_EMOTICONS, unavailable_message)
+            if client is None:
+                raise RuntimeError(unavailable_message)
+            try:
+                return await client.fetch_live_emoticons()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                message = self._exception_message(exc, "获取直播间表情失败")
+                self._record_operation_failure(HudOperation.FETCH_EMOTICONS, message)
+                raise
+
+    async def send_live_emoticon(self, emoticon: LiveEmoticon) -> HudSendResult:
+        """Send one live emoticon through the current room-owned client."""
+        async with self._operation_lock:
+            self._ensure_open()
+            unavailable_message = "未连接直播间，无法发送"
+            client = self._connected_client(HudOperation.SEND_EMOTICON, unavailable_message)
+            if client is None:
+                return HudSendResult(False, unavailable_message)
+            try:
+                success, response = await client.send_live_emoticon(emoticon)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                response = self._exception_message(exc, "发送异常")
+                result = HudSendResult(False, response)
+            else:
+                result = HudSendResult(success, response)
+
+            if result.success:
+                self._clear_error()
+            else:
+                self._record_operation_failure(HudOperation.SEND_EMOTICON, result.message)
+            return result
+
+    async def shutdown(self) -> None:
+        """Stop the connection, cancel owned refresh work, and release task ownership."""
+        if self._shutdown_complete:
+            return
+
+        self._shutting_down = True
+        shutdown_error: BaseException | None = None
+        try:
+            async with self._operation_lock:
+                if self._client is not None:
+                    await self._disconnect_locked()
+                else:
+                    await self._stop_audience_refresh()
+                    self._generation += 1
+                    self._publish_state(
+                        HudConnectionStatus.DISCONNECTED,
+                        self._state.room_id,
+                        None,
+                        None,
+                    )
+                await self._task_scope.cancel_all()
+        except BaseException as exc:
+            shutdown_error = exc
+        finally:
+            if self._owns_task_supervisor and self._task_supervisor is not None:
+                try:
+                    await self._task_supervisor.shutdown()
+                except BaseException as exc:
+                    if shutdown_error is None:
+                        shutdown_error = exc
+
+        if shutdown_error is not None:
+            raise shutdown_error
+        self._shutdown_complete = True
+
+    async def _connect_locked(self, room_id: int) -> None:
+        """Connect while the operation lock prevents competing room transitions."""
+        client = self._client
+        if (
+            self._state.connection is HudConnectionStatus.CONNECTED
+            and client is not None
+            and client.is_running
+            and self._state.room_id == room_id
+        ):
+            if self._audience_task is None:
+                await self._start_audience_refresh(client)
+            return
+
+        if client is not None:
+            await self._disconnect_locked()
+
+        self._generation += 1
+        generation = self._generation
+        self._persist_room_id(room_id)
+        self._publish_state(HudConnectionStatus.CONNECTING, room_id, None, None)
+
+        try:
+            client = self._client_factory(room_id, self._sessdata, self._auth_service)
+        except Exception as exc:
+            message = self._exception_message(exc, "创建弹幕连接失败")
+            self._publish_state(HudConnectionStatus.DISCONNECTED, room_id, None, message)
+            self._emit(HudOperationFailed(HudOperation.CONNECT, message))
+            raise
+
+        self._client = client
+        self._wire_client(client, generation)
+        try:
+            await client.start()
+        except asyncio.CancelledError:
+            await self._cleanup_failed_client(client)
+            self._publish_state(HudConnectionStatus.DISCONNECTED, room_id, None, "连接已取消")
+            raise
+        except Exception as exc:
+            message = self._exception_message(exc, "连接失败")
+            await self._cleanup_failed_client(client)
+            self._publish_state(HudConnectionStatus.DISCONNECTED, room_id, None, message)
+            self._emit(HudOperationFailed(HudOperation.CONNECT, message))
+            raise
+
+        self._publish_state(
+            HudConnectionStatus.CONNECTED,
+            room_id,
+            None,
+            self._state.error,
+        )
+        await self._start_audience_refresh(client)
+
+    async def _disconnect_locked(self) -> None:
+        """Disconnect while retaining enough state to restore a failed close."""
+        client = self._client
+        room_id = self._state.room_id
+        if client is None:
+            await self._stop_audience_refresh()
+            self._generation += 1
+            self._publish_state(HudConnectionStatus.DISCONNECTED, room_id, None, None)
+            return
+
+        previous_snapshot = self._state.audience_snapshot
+        self._generation += 1
+        generation = self._generation
+        self._publish_state(HudConnectionStatus.DISCONNECTING, room_id, None, None)
+        await self._stop_audience_refresh()
+
+        try:
+            await client.stop()
+        except asyncio.CancelledError:
+            await self._restore_after_disconnect_failure(client, generation, previous_snapshot, "断开已取消")
+            raise
+        except Exception as exc:
+            message = self._exception_message(exc, "断开失败")
+            await self._restore_after_disconnect_failure(client, generation, previous_snapshot, message)
+            self._emit(HudOperationFailed(HudOperation.DISCONNECT, message))
+            raise
+
+        self._client = None
+        self._publish_state(HudConnectionStatus.DISCONNECTED, room_id, None, None)
+
+    async def _start_audience_refresh(self, client: HudClient) -> None:
+        """Start one generation-bound audience task for the current client."""
+        await self._stop_audience_refresh()
+        generation = self._generation
+        self._audience_task = self._task_scope.create_task(
+            self._audience_refresh_loop(client, generation),
+            name="audience-refresh",
+        )
+
+    async def _stop_audience_refresh(self) -> None:
+        """Cancel the old audience task before a room or client can change."""
+        task = self._audience_task
+        self._audience_task = None
+        await cancel_task(task)
+
+    async def _audience_refresh_loop(self, client: HudClient, generation: int) -> None:
+        """Refresh audience state until cancellation or client generation changes."""
+        while True:
+            try:
+                snapshot = await client.fetch_audience_snapshot()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                message = self._exception_message(exc, "获取观众数据失败")
+                logger.info("Failed to refresh audience data: %s", message)
+                if self._is_current(client, generation):
+                    self._publish_state(
+                        HudConnectionStatus.CONNECTED,
+                        self._state.room_id,
+                        self._state.audience_snapshot,
+                        message,
+                    )
+            else:
+                current_task = asyncio.current_task()
+                if current_task is not None and current_task.cancelling():
+                    raise asyncio.CancelledError
+                if self._is_current(client, generation) and snapshot.room_id == self._state.room_id:
+                    self._publish_state(
+                        HudConnectionStatus.CONNECTED,
+                        self._state.room_id,
+                        snapshot,
+                        self._state.error,
+                    )
+            await asyncio.sleep(AUDIENCE_REFRESH_INTERVAL_SECONDS)
+
+    def _wire_client(self, client: HudClient, generation: int) -> None:
+        """Bind callbacks with client identity and generation guards."""
+        client.set_message_callback(
+            lambda message: self._on_message(client, generation, message)
+        )
+        client.set_login_failed_callback(
+            lambda message: self._on_login_failed(client, generation, message)
+        )
+
+    def _on_message(self, client: HudClient, generation: int, message: HudMessage) -> None:
+        """Forward only messages from the current room generation."""
+        if self._is_current(client, generation, allow_connecting=True):
+            self._emit(HudMessageReceived(message))
+
+    def _on_login_failed(self, client: HudClient, generation: int, message: str) -> None:
+        """Forward only login warnings belonging to the current room generation."""
+        if not self._is_current(client, generation, allow_connecting=True):
+            return
+        self._publish_state(
+            self._state.connection,
+            self._state.room_id,
+            self._state.audience_snapshot,
+            message,
+        )
+        self._emit(HudLoginFailed(message))
+
+    def _is_current(
+        self,
+        client: HudClient,
+        generation: int,
+        *,
+        allow_connecting: bool = False,
+    ) -> bool:
+        """Check client identity and generation before accepting async callbacks."""
+        valid_statuses = (HudConnectionStatus.CONNECTED,)
+        if allow_connecting:
+            valid_statuses = (HudConnectionStatus.CONNECTING, HudConnectionStatus.CONNECTED)
+        return (
+            self._client is client
+            and self._generation == generation
+            and self._state.connection in valid_statuses
+        )
+
+    def _connected_client(self, operation: HudOperation, unavailable_message: str) -> HudClient | None:
+        """Return the active client or record a typed failure for the caller."""
+        client = self._client
+        if (
+            client is not None
+            and self._state.connection is HudConnectionStatus.CONNECTED
+            and client.is_running
+        ):
+            return client
+        self._record_operation_failure(operation, unavailable_message)
+        return None
+
+    async def _restore_after_disconnect_failure(
+        self,
+        client: HudClient,
+        generation: int,
+        previous_snapshot: AudienceSnapshot | None,
+        message: str,
+    ) -> None:
+        """Restore the live connection contract after a failed close attempt."""
+        self._client = client
+        self._wire_client(client, generation)
+        self._publish_state(HudConnectionStatus.CONNECTED, self._state.room_id, previous_snapshot, message)
+        await self._start_audience_refresh(client)
+
+    async def _cleanup_failed_client(self, client: HudClient) -> bool:
+        """Close a partially started client and report whether ownership was released."""
+        try:
+            await client.stop()
+        except BaseException as exc:
+            logger.error(
+                "Failed to clean up HUD client after connection failure",
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
+            return False
+        else:
+            if self._client is client:
+                self._client = None
+            return True
+
+    def _record_operation_failure(self, operation: HudOperation, message: str) -> None:
+        """Publish one stateful operation failure to typed consumers."""
+        self._publish_state(
+            self._state.connection,
+            self._state.room_id,
+            self._state.audience_snapshot,
+            message,
+        )
+        self._emit(HudOperationFailed(operation, message))
+
+    def _clear_error(self) -> None:
+        if self._state.error is None:
+            return
+        self._publish_state(
+            self._state.connection,
+            self._state.room_id,
+            self._state.audience_snapshot,
+            None,
+        )
+
+    def _publish_state(
+        self,
+        connection: HudConnectionStatus,
+        room_id: int | None,
+        audience_snapshot: AudienceSnapshot | None,
+        error: str | None,
+    ) -> None:
+        """Publish a complete immutable state value without implicit defaults."""
+        state = HudState(
+            connection=connection,
+            room_id=room_id,
+            audience_snapshot=audience_snapshot,
+            error=error,
+        )
+        if state == self._state:
+            return
+        self._state = state
+        self._emit(HudStateChanged(state))
+
+    def _emit(self, event: HudEvent) -> None:
+        """Deliver one event while isolating listener failures from application state."""
+        for listener in tuple(self._listeners):
+            try:
+                listener(event)
+            except Exception:
+                logger.exception("HUD event listener failed")
+
+    def _persist_room_id(self, room_id: int) -> None:
+        """Persist the selected room without making configuration failure break a connection."""
+        if self._config_store is None:
+            return
+        try:
+            current = self._config_store.load()
+            updated = replace(current, room_id=room_id)
+            if not self._config_store.save(updated):
+                logger.warning("Failed to persist HUD room id %s", room_id)
+        except Exception as exc:
+            logger.warning("Failed to persist HUD room id %s: %s", room_id, exc)
+
+    def _ensure_open(self) -> None:
+        if self._shutting_down:
+            raise RuntimeError("HUD 控制器已关闭")
+
+    @staticmethod
+    def _exception_message(error: BaseException, fallback: str) -> str:
+        """Return a useful stable message even when an exception has no text."""
+        message = str(error).strip()
+        if not message:
+            return fallback
+        return message

--- a/src/bilihud/hud_ports.py
+++ b/src/bilihud/hud_ports.py
@@ -1,0 +1,70 @@
+"""Infrastructure ports used by the HUD application controller."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol
+
+from .auth import AuthenticationService
+from .domain.messages import HudMessage
+from .live_audience import AudienceSnapshot
+from .live_emoticons import LiveEmoticon, LiveEmoticonPackage
+
+
+class HudClient(Protocol):
+    """Network capability required by the HUD application controller."""
+
+    room_id: int
+
+    @property
+    def is_running(self) -> bool:
+        """Return whether the underlying room connection is active."""
+        ...
+
+    def set_message_callback(self, callback: Callable[[HudMessage], None]) -> None:
+        """Register the normalized message callback owned by the controller."""
+        ...
+
+    def set_login_failed_callback(self, callback: Callable[[str], None]) -> None:
+        """Register the login warning callback owned by the controller."""
+        ...
+
+    async def start(self) -> None:
+        """Start receiving messages for the configured room."""
+        ...
+
+    async def stop(self, normal_timeout: float = 3.0, forced_timeout: float = 3.0) -> None:
+        """Stop the connection and close all client-owned resources."""
+        ...
+
+    async def send_danmaku(self, message: str) -> tuple[bool, str]:
+        """Send one text message to the active room."""
+        ...
+
+    async def fetch_audience_snapshot(self) -> AudienceSnapshot:
+        """Fetch the current audience snapshot for the active room."""
+        ...
+
+    async def fetch_live_emoticons(self) -> list[LiveEmoticonPackage]:
+        """Fetch the available live emoticon packages for the active room."""
+        ...
+
+    async def send_live_emoticon(self, emoticon: LiveEmoticon) -> tuple[bool, str]:
+        """Send one live emoticon to the active room."""
+        ...
+
+
+class HudClientFactory(Protocol):
+    """Build one infrastructure client for an application-owned room session."""
+
+    def __call__(
+        self,
+        room_id: int,
+        sessdata: str,
+        auth_service: AuthenticationService,
+    ) -> HudClient:
+        """Create a client without starting network activity."""
+        ...
+
+
+__all__ = ("HudClient", "HudClientFactory")

--- a/src/bilihud/services.py
+++ b/src/bilihud/services.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from .auth import AuthenticationService, BilibiliAuthService, KeyringSessionStore, SessionStore
 from .config import ConfigStore, JsonConfigStore
 from .config_compat import LegacyConfigMigrator
+from .danmaku_client import DanmakuClient
+from .hud_ports import HudClientFactory
 
 
 @dataclass(frozen=True, slots=True)
@@ -14,6 +16,16 @@ class AppServices:
 
     config_store: ConfigStore  # Shared typed settings boundary for all UI workflows.
     auth_service: AuthenticationService  # Shared authentication and secure-secret boundary.
+    hud_client_factory: HudClientFactory  # Concrete HUD network adapter factory.
+
+
+def create_default_hud_client(
+    room_id: int,
+    sessdata: str,
+    auth_service: AuthenticationService,
+) -> DanmakuClient:
+    """Create the production client behind the application's HUD port."""
+    return DanmakuClient(room_id, sessdata, auth_service=auth_service)
 
 
 def create_default_services(config_path: Path | None = None) -> AppServices:
@@ -25,4 +37,5 @@ def create_default_services(config_path: Path | None = None) -> AppServices:
             migrator=LegacyConfigMigrator(session_store),
         ),
         auth_service=BilibiliAuthService(session_store),
+        hud_client_factory=create_default_hud_client,
     )

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -16,6 +16,7 @@ MESSAGE_CONSUMER_MODULE_NAMES: Final[tuple[str, ...]] = (
     "mirror_state",
     "mock_messages",
 )
+APPLICATION_MODULE_NAMES: Final[tuple[str, ...]] = ("hud_controller", "hud_ports")
 
 
 @dataclass(frozen=True)
@@ -137,3 +138,32 @@ def test_presentation_uses_configuration_and_authentication_boundaries() -> None
                         violations.append(f"{name} imports {alias.name}")
 
     assert violations == []
+
+
+def test_hud_controller_keeps_presentation_and_concrete_network_outside_application() -> None:
+    forbidden_prefixes = frozenset(
+        {
+            "PyQt5",
+            "PyQt6",
+            "qasync",
+            "blivedm",
+            "aiohttp",
+            "bilihud.danmaku_client",
+            "bilihud.live_api",
+        }
+    )
+    violations: list[str] = []
+    for name in APPLICATION_MODULE_NAMES:
+        path = SOURCE_ROOT / f"{name}.py"
+        for module in _imported_modules(path):
+            if _is_forbidden(module, forbidden_prefixes):
+                violations.append(f"{name} imports {module}")
+
+    assert violations == []
+
+
+def test_danmaku_widget_uses_hud_controller_instead_of_concrete_client() -> None:
+    modules = _imported_modules(SOURCE_ROOT / "danmaku_widget.py")
+
+    assert "bilihud.hud_controller" in modules
+    assert "bilihud.danmaku_client" not in modules

--- a/tests/test_danmaku_widget.py
+++ b/tests/test_danmaku_widget.py
@@ -7,7 +7,6 @@ from PyQt6.QtGui import QFont
 from PyQt6.QtWidgets import QApplication, QLabel, QWidget
 
 from bilihud import danmaku_widget
-from bilihud.config import AppConfig
 from bilihud.domain.messages import (
     DanmakuMessage,
     GiftMessage,
@@ -20,7 +19,6 @@ from bilihud.domain.messages import (
     TextSegment,
     make_system_message,
 )
-from bilihud.live_audience import AudienceSnapshot, AudienceUser
 from bilihud.live_emoticons import LiveEmoticon, LiveEmoticonPackage
 
 _QT_APP = None
@@ -596,20 +594,18 @@ def test_emoticon_picker_keeps_one_tab_per_package():
 
 
 def test_danmaku_widget_sends_selected_live_emoticon():
-    class Client:
+    class Controller:
         def __init__(self):
             self.sent = []
 
         async def send_live_emoticon(self, emoticon):
             self.sent.append(emoticon)
-            return False, "没有发送权限"
+            return None
 
     async def run_test():
-        client = Client()
-        errors = []
+        controller = Controller()
         widget = danmaku_widget.DanmakuWidget.__new__(danmaku_widget.DanmakuWidget)
-        widget.danmaku_client = client
-        widget.add_system_message = lambda message, level: errors.append((message, level))
+        widget.hud_controller = controller
         emoticon = LiveEmoticon(
             emoji="啊",
             url="https://i0.hdslb.com/bfs/live/a.png",
@@ -622,8 +618,7 @@ def test_danmaku_widget_sends_selected_live_emoticon():
 
         await danmaku_widget.DanmakuWidget._send_live_emoticon_task(widget, emoticon)
 
-        assert client.sent == [emoticon]
-        assert errors == [("发送失败: 没有发送权限", "error")]
+        assert controller.sent == [emoticon]
 
     asyncio.run(run_test())
 
@@ -656,10 +651,11 @@ def test_live_control_uses_authenticated_anchor_room(monkeypatch):
         widget = danmaku_widget.DanmakuWidget.__new__(danmaku_widget.DanmakuWidget)
         widget.auth_service = auth_manager
 
-        async def connect_to_room(room_id):
-            connected_rooms.append(room_id)
+        class Controller:
+            async def connect(self, room_id):
+                connected_rooms.append(room_id)
 
-        widget._connect_to_room_id = connect_to_room
+        widget.hud_controller = Controller()
         monkeypatch.setattr(danmaku_widget, "get_anchor_live_room_id", get_anchor_room)
 
         room_id = await danmaku_widget.DanmakuWidget._ensure_live_control_room(widget)
@@ -670,417 +666,3 @@ def test_live_control_uses_authenticated_anchor_room(monkeypatch):
 
     auth_manager = None
     asyncio.run(run_test())
-
-
-def test_connect_to_room_replaces_stale_same_room_client(monkeypatch):
-    events = []
-
-    class RoomInput:
-        def __init__(self):
-            self.text = ""
-
-        def setText(self, text):
-            self.text = text
-
-    class StaleBLiveClient:
-        is_running = False
-
-    class StaleDanmakuClient:
-        client = StaleBLiveClient()
-        is_running = False
-
-    class NewDanmakuClient:
-        instances = []
-
-        def __init__(self, room_id, sessdata, auth_service=None):
-            self.room_id = room_id
-            self.sessdata = sessdata
-            self.auth_service = auth_service
-            self.client = None
-            self.started = False
-            NewDanmakuClient.instances.append(self)
-
-        async def start(self):
-            self.started = True
-            self.client = type("RunningBLiveClient", (), {"is_running": True})()
-
-    async def run_test():
-        widget = danmaku_widget.DanmakuWidget.__new__(danmaku_widget.DanmakuWidget)
-        widget.room_id = 7450109
-        widget.sessdata = "sess"
-        widget.auth_service = object()
-        widget.mirror_port = 2233
-        widget.config_store = type(
-            "ConfigStore",
-            (),
-            {
-                "load": lambda _self: AppConfig(),
-                "save": lambda _self, config: events.append(("save", config)) or True,
-            },
-        )()
-        widget.room_id_input = RoomInput()
-        widget.danmaku_client = StaleDanmakuClient()
-
-        async def disconnect_current_room():
-            events.append("disconnect")
-            widget.danmaku_client = None
-
-        widget._disconnect_current_room = disconnect_current_room
-        widget._wire_danmaku_client = lambda client: events.append(("wire", client.room_id))
-        widget._set_connecting_ui = lambda: events.append("connecting")
-        widget._set_connected_ui = lambda: events.append("connected")
-        widget._set_disconnected_ui = lambda: events.append("disconnected")
-
-        async def start_audience_refresh(client):
-            events.append(("audience-start", client.room_id))
-
-        widget._start_audience_refresh = start_audience_refresh
-
-        monkeypatch.setattr(danmaku_widget, "DanmakuClient", NewDanmakuClient)
-
-        await danmaku_widget.DanmakuWidget._connect_to_room_id(widget, 7450109)
-
-        assert events[0] == "disconnect"
-        assert widget.room_id == 7450109
-        assert widget.room_id_input.text == "7450109"
-        assert widget.danmaku_client is NewDanmakuClient.instances[0]
-        assert widget.danmaku_client.started is True
-        assert events[-2:] == ["connected", ("audience-start", 7450109)]
-
-    asyncio.run(run_test())
-
-
-def test_connect_to_room_keeps_partial_client_when_cleanup_fails(monkeypatch):
-    class RoomInput:
-        def __init__(self):
-            self.value = ""
-
-        def text(self):
-            return self.value
-
-        def setText(self, value):
-            self.value = value
-
-    class FailingClient:
-        instances = []
-
-        def __init__(self, room_id, sessdata, auth_service=None):
-            self.room_id = room_id
-            self.sessdata = sessdata
-            self.auth_service = auth_service
-            self.client = object()
-            self.stop_calls = 0
-            self.instances.append(self)
-
-        async def start(self):
-            raise RuntimeError("connect failed")
-
-        async def stop(self):
-            self.stop_calls += 1
-            raise RuntimeError("cleanup failed")
-
-    async def run_test():
-        widget = danmaku_widget.DanmakuWidget.__new__(danmaku_widget.DanmakuWidget)
-        widget.room_id = 7450109
-        widget.sessdata = "sess"
-        widget.auth_service = object()
-        widget.room_id_input = RoomInput()
-        widget.danmaku_client = None
-        widget._wire_danmaku_client = lambda _client: None
-        widget._update_persisted_config = lambda **_kwargs: True
-        widget._set_connecting_ui = lambda: None
-        widget._set_disconnected_ui = lambda: None
-
-        monkeypatch.setattr(danmaku_widget, "DanmakuClient", FailingClient)
-
-        with pytest.raises(RuntimeError, match="connect failed"):
-            await danmaku_widget.DanmakuWidget._connect_to_room_id(widget, 7450109)
-
-        client = FailingClient.instances[0]
-        assert client.stop_calls == 1
-        assert widget.danmaku_client is client
-
-    asyncio.run(run_test())
-
-
-def test_disconnect_current_room_stops_client_and_clears_connection():
-    class Button:
-        def __init__(self):
-            self.enabled = True
-
-        def setEnabled(self, enabled):
-            self.enabled = enabled
-
-    class Client:
-        def __init__(self):
-            self.stop_calls = 0
-
-        async def stop(self):
-            self.stop_calls += 1
-
-    async def run_test():
-        events = []
-        client = Client()
-        widget = danmaku_widget.DanmakuWidget.__new__(danmaku_widget.DanmakuWidget)
-        widget.connect_button = Button()
-        widget.danmaku_client = client
-        widget._audience_snapshot = None
-
-        async def stop_audience_refresh():
-            events.append("audience-stop")
-
-        widget._stop_audience_refresh = stop_audience_refresh
-        widget._set_disconnected_ui = lambda: events.append("disconnected")
-
-        await danmaku_widget.DanmakuWidget._disconnect_current_room(widget)
-
-        assert client.stop_calls == 1
-        assert widget.danmaku_client is None
-        assert widget.connect_button.enabled is False
-        assert events == ["audience-stop", "disconnected"]
-
-    asyncio.run(run_test())
-
-
-def audience_snapshot(room_id=7450109):
-    return AudienceSnapshot(
-        room_id=room_id,
-        popularity=21,
-        watched_count=9,
-        online_rank_count=3,
-        users=(AudienceUser(1001, "用户A", 1, 1, False),),
-    )
-
-
-def test_refresh_audience_once_applies_only_current_room_and_generation():
-    class Client:
-        room_id = 7450109
-
-        async def fetch_audience_snapshot(self):
-            return audience_snapshot()
-
-    class Status:
-        def set_snapshot(self, snapshot):
-            applied.append(snapshot)
-
-        def setVisible(self, visible):
-            visibility.append(visible)
-
-    class Popup:
-        def set_snapshot(self, snapshot):
-            popup_applied.append(snapshot)
-
-        def hide(self):
-            popup_hidden.append(True)
-
-    async def run_test():
-        client = Client()
-        class Widget:
-            pass
-
-        widget = Widget()
-        widget.danmaku_client = client
-        widget.room_id = 7450109
-        widget._audience_generation = 4
-        widget._audience_snapshot = None
-        widget.is_gaming_mode = False
-        widget.audience_status = Status()
-        widget.audience_popup = Popup()
-        widget._sync_audience_visibility = lambda: (
-            danmaku_widget.DanmakuWidget._sync_audience_visibility(widget)
-        )
-
-        updated = await danmaku_widget.DanmakuWidget._refresh_audience_once(widget, client, 4)
-        stale = await danmaku_widget.DanmakuWidget._refresh_audience_once(widget, client, 3)
-
-        assert updated is True
-        assert stale is False
-        assert widget._audience_snapshot == audience_snapshot()
-        assert applied == [audience_snapshot()]
-        assert popup_applied == [audience_snapshot()]
-        assert visibility == [True]
-        assert popup_hidden == []
-
-    applied = []
-    popup_applied = []
-    popup_hidden = []
-    visibility = []
-    asyncio.run(run_test())
-
-
-def test_refresh_audience_once_keeps_last_snapshot_after_failure():
-    previous = audience_snapshot()
-
-    class Client:
-        room_id = 7450109
-
-        async def fetch_audience_snapshot(self):
-            raise RuntimeError("temporary failure")
-
-    async def run_test():
-        client = Client()
-        class Widget:
-            pass
-
-        widget = Widget()
-        widget.danmaku_client = client
-        widget.room_id = 7450109
-        widget._audience_generation = 2
-        widget._audience_snapshot = previous
-
-        updated = await danmaku_widget.DanmakuWidget._refresh_audience_once(widget, client, 2)
-
-        assert updated is False
-        assert widget._audience_snapshot is previous
-
-    asyncio.run(run_test())
-
-
-def test_stop_audience_refresh_cancels_task_and_clears_widgets():
-    class Status:
-        def clear(self):
-            calls.append("status-clear")
-
-    class Popup:
-        def hide(self):
-            calls.append("popup-hide")
-
-    async def run_test():
-        started = asyncio.Event()
-
-        async def forever():
-            started.set()
-            await asyncio.Event().wait()
-
-        class Widget:
-            pass
-
-        widget = Widget()
-        widget._audience_generation = 1
-        widget._audience_snapshot = audience_snapshot()
-        widget.audience_status = Status()
-        widget.audience_popup = Popup()
-        widget._audience_refresh_task = asyncio.create_task(forever())
-        await started.wait()
-
-        await danmaku_widget.DanmakuWidget._stop_audience_refresh(widget)
-
-        assert widget._audience_refresh_task is None
-        assert widget._audience_snapshot is None
-        assert calls == ["popup-hide", "status-clear"]
-
-    calls = []
-    asyncio.run(run_test())
-
-
-def test_disconnect_failure_restores_last_audience_snapshot():
-    previous = audience_snapshot()
-
-    class Client:
-        async def stop(self):
-            raise RuntimeError("temporary failure")
-
-    class Button:
-        def setEnabled(self, enabled):
-            calls.append(("button", enabled))
-
-    class Status:
-        def set_snapshot(self, snapshot):
-            calls.append(("status", snapshot))
-
-    class Popup:
-        def set_snapshot(self, snapshot):
-            calls.append(("popup", snapshot))
-
-    async def run_test():
-        class Widget:
-            pass
-
-        widget = Widget()
-        widget.connect_button = Button()
-        widget.danmaku_client = Client()
-        widget._audience_snapshot = previous
-        widget.audience_status = Status()
-        widget.audience_popup = Popup()
-        widget._set_connected_ui = lambda: calls.append("connected")
-        widget._sync_audience_visibility = lambda: calls.append("visibility")
-        widget.add_system_message = lambda message, level: calls.append((level, message))
-
-        async def stop_refresh():
-            widget._audience_snapshot = None
-
-        async def start_refresh(client):
-            calls.append(("refresh", client))
-
-        widget._stop_audience_refresh = stop_refresh
-        widget._start_audience_refresh = start_refresh
-
-        with pytest.raises(RuntimeError, match="temporary failure"):
-            await danmaku_widget.DanmakuWidget._disconnect_current_room(widget)
-
-        assert widget._audience_snapshot is previous
-        assert ("status", previous) in calls
-        assert ("popup", previous) in calls
-        assert "visibility" in calls
-
-    calls = []
-    asyncio.run(run_test())
-
-
-def test_sync_audience_visibility_hides_status_and_popup_in_gaming_mode():
-    calls = []
-
-    class Status:
-        def setVisible(self, visible):
-            calls.append(("visible", visible))
-
-    class Popup:
-        def hide(self):
-            calls.append(("popup", False))
-
-    class Widget:
-        pass
-
-    widget = Widget()
-    widget._audience_snapshot = audience_snapshot()
-    widget.is_gaming_mode = True
-    widget.audience_status = Status()
-    widget.audience_popup = Popup()
-
-    danmaku_widget.DanmakuWidget._sync_audience_visibility(widget)
-
-    assert calls == [("visible", False), ("popup", False)]
-
-
-def test_audience_refresh_loop_waits_thirty_seconds(monkeypatch):
-    class Client:
-        room_id = 7450109
-
-    async def run_test():
-        class Widget:
-            pass
-
-        widget = Widget()
-
-        async def refresh_once(client, generation):
-            calls.append(("refresh", client.room_id, generation))
-            return True
-
-        async def fake_sleep(delay):
-            calls.append(("sleep", delay))
-            raise asyncio.CancelledError
-
-        widget._refresh_audience_once = refresh_once
-        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
-
-        with pytest.raises(asyncio.CancelledError):
-            await danmaku_widget.DanmakuWidget._audience_refresh_loop(widget, Client(), 7)
-
-    calls = []
-    asyncio.run(run_test())
-
-    assert calls == [
-        ("refresh", 7450109, 7),
-        ("sleep", danmaku_widget.AUDIENCE_REFRESH_INTERVAL_SECONDS),
-    ]
-    assert danmaku_widget.AUDIENCE_REFRESH_INTERVAL_SECONDS == 30.0

--- a/tests/test_hud_controller.py
+++ b/tests/test_hud_controller.py
@@ -1,0 +1,270 @@
+import asyncio
+
+from bilihud.config import AppConfig
+from bilihud.domain.hud import (
+    HudConnectionStatus,
+    HudLoginFailed,
+    HudMessageReceived,
+    HudOperation,
+    HudOperationFailed,
+    HudStateChanged,
+)
+from bilihud.domain.messages import DanmakuMessage, MessageAuthor, TextSegment
+from bilihud.hud_controller import HudController
+from bilihud.live_audience import AudienceSnapshot
+
+
+class FakeConfigStore:
+    def __init__(self):
+        self.config = AppConfig()
+        self.saved = []
+
+    def load(self):
+        return self.config
+
+    def save(self, config):
+        self.config = config
+        self.saved.append(config)
+        return True
+
+
+class FakeClient:
+    def __init__(self, room_id, *, stop_error=None):
+        self.room_id = room_id
+        self.stop_error = stop_error
+        self.started = False
+        self.running = False
+        self.start_calls = 0
+        self.stop_calls = 0
+        self.message_callback = None
+        self.login_failed_callback = None
+        self.audience_snapshot = AudienceSnapshot(room_id, 1, 2, 0, ())
+        self.send_started = asyncio.Event()
+        self.send_release = asyncio.Event()
+        self.stop_started = asyncio.Event()
+        self.block_send = False
+
+    @property
+    def is_running(self):
+        return self.running
+
+    def set_message_callback(self, callback):
+        self.message_callback = callback
+
+    def set_login_failed_callback(self, callback):
+        self.login_failed_callback = callback
+
+    async def start(self):
+        self.start_calls += 1
+        self.started = True
+        self.running = True
+
+    async def stop(self):
+        self.stop_calls += 1
+        self.stop_started.set()
+        if self.stop_error is not None:
+            error = self.stop_error
+            self.stop_error = None
+            raise error
+        self.running = False
+
+    async def send_danmaku(self, _message):
+        if self.block_send:
+            self.send_started.set()
+            await self.send_release.wait()
+        return True, "发送成功"
+
+    async def fetch_audience_snapshot(self):
+        return self.audience_snapshot
+
+    async def fetch_live_emoticons(self):
+        return []
+
+    async def send_live_emoticon(self, _emoticon):
+        return True, "发送成功"
+
+    def emit_message(self, message):
+        if self.message_callback is not None:
+            self.message_callback(message)
+
+    def emit_login_failure(self, message):
+        if self.login_failed_callback is not None:
+            self.login_failed_callback(message)
+
+
+def _message(text):
+    return DanmakuMessage(
+        author=MessageAuthor(uid=1, name="user", color="#fff"),
+        segments=(TextSegment(text),),
+    )
+
+
+def _controller(factory, config_store=None):
+    return HudController(
+        initial_room_id=0,
+        sessdata="",
+        auth_service=object(),
+        client_factory=factory,
+        config_store=config_store,
+    )
+
+
+def test_controller_reuses_same_room_and_discards_old_client_events():
+    async def run_test():
+        clients = []
+        events = []
+        config_store = FakeConfigStore()
+
+        def factory(room_id, _sessdata, _auth_service):
+            client = FakeClient(room_id)
+            clients.append(client)
+            return client
+
+        controller = _controller(factory, config_store)
+        controller.subscribe(events.append)
+
+        await controller.connect(100)
+        await controller.connect(100)
+        assert len(clients) == 1
+        assert clients[0].start_calls == 1
+
+        first_message = _message("first")
+        clients[0].emit_message(first_message)
+        assert any(
+            isinstance(event, HudMessageReceived) and event.message == first_message
+            for event in events
+        )
+
+        await controller.connect(200)
+        assert len(clients) == 2
+        assert clients[0].stop_calls == 1
+        assert clients[1].started is True
+        assert controller.state.connection is HudConnectionStatus.CONNECTED
+        assert controller.state.room_id == 200
+        assert [config.room_id for config in config_store.saved] == [100, 200]
+
+        event_count = len([event for event in events if isinstance(event, HudMessageReceived)])
+        clients[0].emit_message(_message("stale"))
+        clients[1].emit_message(_message("current"))
+        assert len([event for event in events if isinstance(event, HudMessageReceived)]) == event_count + 1
+
+        await controller.shutdown()
+        assert clients[1].stop_calls == 1
+
+    asyncio.run(run_test())
+
+
+def test_controller_publishes_login_failure_and_operation_errors():
+    async def run_test():
+        events = []
+        client = FakeClient(100)
+        controller = _controller(lambda *_args: client)
+        controller.subscribe(events.append)
+
+        await controller.connect(100)
+        client.emit_login_failure("登录已失效")
+        assert any(
+            isinstance(event, HudLoginFailed) and event.message == "登录已失效"
+            for event in events
+        )
+        assert controller.state.error == "登录已失效"
+
+        result = await controller.send_danmaku("hello")
+        assert result.success is True
+        assert controller.state.error is None
+
+        client.stop_error = RuntimeError("close failed")
+        try:
+            await controller.disconnect()
+        except RuntimeError as exc:
+            assert str(exc) == "close failed"
+        else:
+            raise AssertionError("disconnect should expose the cleanup failure")
+
+        assert controller.state.connection is HudConnectionStatus.CONNECTED
+        assert controller.state.error == "close failed"
+        assert any(
+            isinstance(event, HudOperationFailed)
+            and event.operation is HudOperation.DISCONNECT
+            and event.message == "close failed"
+            for event in events
+        )
+
+        await controller.disconnect()
+        await controller.shutdown()
+
+    asyncio.run(run_test())
+
+
+def test_controller_serializes_send_and_disconnect():
+    async def run_test():
+        client = FakeClient(100)
+        controller = _controller(lambda *_args: client)
+        await controller.connect(100)
+        client.block_send = True
+
+        send_task = asyncio.create_task(controller.send_danmaku("hello"))
+        await client.send_started.wait()
+        disconnect_task = asyncio.create_task(controller.disconnect())
+        assert disconnect_task.done() is False
+        assert client.stop_started.is_set() is False
+
+        client.send_release.set()
+        result = await send_task
+        await disconnect_task
+        assert result.success is True
+        assert controller.state.connection is HudConnectionStatus.DISCONNECTED
+        await controller.shutdown()
+
+    asyncio.run(run_test())
+
+
+def test_controller_ignores_audience_result_from_old_room_generation():
+    class SlowAudienceClient(FakeClient):
+        def __init__(self, room_id):
+            super().__init__(room_id)
+            self.audience_started = asyncio.Event()
+            self.cancel_seen = asyncio.Event()
+            self.audience_release = asyncio.Event()
+
+        async def fetch_audience_snapshot(self):
+            self.audience_started.set()
+            try:
+                await self.audience_release.wait()
+            except asyncio.CancelledError:
+                self.cancel_seen.set()
+                await self.audience_release.wait()
+            return self.audience_snapshot
+
+    async def run_test():
+        clients = []
+        audience_applied = asyncio.Event()
+
+        def factory(room_id, _sessdata, _auth_service):
+            client = SlowAudienceClient(room_id) if room_id == 100 else FakeClient(room_id)
+            clients.append(client)
+            return client
+
+        controller = _controller(factory)
+
+        def on_event(event):
+            if isinstance(event, HudStateChanged) and event.state.audience_snapshot is not None:
+                audience_applied.set()
+
+        controller.subscribe(on_event)
+        await controller.connect(100)
+        slow_client = clients[0]
+        await slow_client.audience_started.wait()
+
+        switch_task = asyncio.create_task(controller.connect(200))
+        await slow_client.cancel_seen.wait()
+        slow_client.audience_release.set()
+        await switch_task
+        await asyncio.wait_for(audience_applied.wait(), timeout=1.0)
+
+        assert controller.state.room_id == 200
+        assert controller.state.audience_snapshot is not None
+        assert controller.state.audience_snapshot.room_id == 200
+        await controller.shutdown()
+
+    asyncio.run(run_test())

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -169,8 +169,8 @@ def test_danmaku_widget_shutdown_cancels_work_before_closing_resources():
             started.set()
             await asyncio.Event().wait()
 
-        class Client:
-            async def stop(self):
+        class HudController:
+            async def shutdown(self):
                 events.append("client-stop")
 
         widget = DanmakuWidget.__new__(DanmakuWidget)
@@ -184,7 +184,7 @@ def test_danmaku_widget_shutdown_cancels_work_before_closing_resources():
         widget._qr_login_dialog = None
         widget._shutdown_complete = False
         widget._shutting_down = False
-        widget.danmaku_client = Client()
+        widget.hud_controller = HudController()
 
         send_task = DanmakuWidget._create_action_task(
             widget,
@@ -193,20 +193,16 @@ def test_danmaku_widget_shutdown_cancels_work_before_closing_resources():
         )
         await started.wait()
 
-        async def stop_audience_refresh():
-            events.append("audience-stop")
-
         async def shutdown_mirror_server():
             events.append("mirror-stop")
 
-        widget._stop_audience_refresh = stop_audience_refresh
         widget.shutdown_mirror_server = shutdown_mirror_server
 
         await DanmakuWidget.shutdown(widget)
         await DanmakuWidget.shutdown(widget)
 
         assert send_task.cancelled()
-        assert events == ["audience-stop", "mirror-stop", "client-stop"]
+        assert events == ["client-stop", "mirror-stop"]
 
     asyncio.run(run_test())
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,3 +11,6 @@ def test_validate_room_id():
     assert validate_room_id("-1") is False
     assert validate_room_id("abc") is False
     assert validate_room_id("") is False
+    assert validate_room_id(123) is True
+    assert validate_room_id(0) is False
+    assert validate_room_id(-1) is False


### PR DESCRIPTION
## Summary

- Extract HUD room connection, room switching, audience refresh, and send workflows into a typed `HudController`.
- Keep `DanmakuWidget` as a Qt binding and rendering layer, with infrastructure injected through `HudClient` ports.
- Add generation guards, operation serialization, shutdown handling, and failure-path coverage.
- Add architecture documentation and durable `AGENTS.md` guidance for helper reuse and function contracts.

## Verification

- `pytest -q`: 158 passed
- Focused Ruff and ty checks passed
- `uv build` passed
- `git diff --check` passed

## Risks and follow-up

- Repository-wide Ruff still reports 30 pre-existing issues in older files; no new errors were introduced in the changed application modules.
- Live-control authentication lookup remains in the presentation workflow and is outside this issue scope.

Closes #25
Refs #19