### PR TITLE
[Architecture] T6 抽取 LiveControlService

### DIFF
--- a/src/bilihud/domain/live_control.py
+++ b/src/bilihud/domain/live_control.py
@@ -1,0 +1,334 @@
+"""Typed domain contracts for the live-control workflow."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Final
+
+
+class SessionStatus(StrEnum):
+    """Describe the authentication state of a live-control API session."""
+
+    CLOSED = "closed"
+    ANONYMOUS = "anonymous"
+    AUTHENTICATED = "authenticated"
+
+
+@dataclass(frozen=True, slots=True)
+class LiveSessionInfo:
+    """Identify a live-control session without exposing its transport object."""
+
+    status: SessionStatus = SessionStatus.CLOSED
+    from_saved_session: bool = False
+    user_id: str | None = None
+
+    @property
+    def is_authenticated(self) -> bool:
+        """Return whether the session contains a usable authenticated login."""
+        return self.status is SessionStatus.AUTHENTICATED
+
+
+@dataclass(frozen=True, slots=True)
+class LiveArea:
+    """One normalized Bilibili live sub-area."""
+
+    area_id: str
+    name: str
+
+
+@dataclass(frozen=True, slots=True)
+class LiveAreaGroup:
+    """One normalized Bilibili parent area and its selectable sub-areas."""
+
+    parent_area_id: str
+    name: str
+    areas: tuple[LiveArea, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class StreamCredential:
+    """One normalized stream endpoint and its private stream key."""
+
+    label: str
+    address: str
+    key: str
+
+
+@dataclass(frozen=True, slots=True)
+class LiveVersion:
+    """Version metadata required by Bilibili's start-live endpoint."""
+
+    curr_version: str
+    build: int
+
+
+@dataclass(frozen=True, slots=True)
+class RoomInfo:
+    """Normalized live-room metadata used by the service and presentation."""
+
+    room_id: int
+    title: str
+    parent_area_id: str
+    area_id: str
+    is_live: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class LiveStartResponse:
+    """Normalized response from the start-live API, including verification data."""
+
+    code: int
+    message: str
+    credentials: tuple[StreamCredential, ...] = ()
+    verification_url: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ObsSettings:
+    """User-provided OBS WebSocket settings used for one operation."""
+
+    host: str
+    port: int
+    password: str
+
+    @property
+    def is_valid(self) -> bool:
+        """Return whether the endpoint can be used to create an OBS client."""
+        return bool(self.host.strip()) and 1 <= self.port <= 65535
+
+
+@dataclass(frozen=True, slots=True)
+class LiveControlSettings:
+    """Non-sensitive form settings plus the transient OBS password value."""
+
+    room_id: int | None
+    live_title: str
+    live_parent_area_id: str
+    live_area_id: str
+    obs_host: str
+    obs_port: int
+    obs_password: str
+
+    @property
+    def obs(self) -> ObsSettings:
+        """Return the OBS settings represented by this form snapshot."""
+        return ObsSettings(self.obs_host, self.obs_port, self.obs_password)
+
+
+@dataclass(frozen=True, slots=True)
+class LiveControlState:
+    """Immutable state snapshot rendered by the live-control dialog."""
+
+    session: LiveSessionInfo = LiveSessionInfo()
+    areas: tuple[LiveAreaGroup, ...] = ()
+    room_info: RoomInfo | None = None
+    credentials: tuple[StreamCredential, ...] = ()
+    obs_connected: bool = False
+    obs_streaming: bool | None = None
+
+
+class LiveControlErrorCode(StrEnum):
+    """Stable error categories returned by live-control application operations."""
+
+    AUTHENTICATION_REQUIRED = "authentication_required"
+    LOGIN_EXPIRED = "login_expired"
+    INVALID_ROOM = "invalid_room"
+    INVALID_INPUT = "invalid_input"
+    ALREADY_LIVE = "already_live"
+    NOT_LIVE = "not_live"
+    OPERATION_IN_PROGRESS = "operation_in_progress"
+    API_FAILURE = "api_failure"
+    CREDENTIALS_MISSING = "credentials_missing"
+    OBS_FAILURE = "obs_failure"
+    OBS_SWITCH_REQUIRED = "obs_switch_required"
+    VERIFICATION_REQUIRED = "verification_required"
+    PERSISTENCE_FAILURE = "persistence_failure"
+    CLOSED = "closed"
+    STALE = "stale"
+
+
+@dataclass(frozen=True, slots=True)
+class LiveControlError:
+    """A user-displayable error with a stable machine-readable category."""
+
+    code: LiveControlErrorCode
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class LiveControlOperationResult:
+    """Result for state-loading and room-update operations."""
+
+    state: LiveControlState
+    error: LiveControlError | None = None
+
+    @property
+    def success(self) -> bool:
+        """Return whether the operation completed without an application error."""
+        return self.error is None
+
+
+class StartLiveStatus(StrEnum):
+    """Outcome categories for a start-live request."""
+
+    STARTED = "started"
+    STARTED_WITHOUT_CREDENTIALS = "started_without_credentials"
+    VERIFICATION_REQUIRED = "verification_required"
+    OBS_SWITCH_REQUIRED = "obs_switch_required"
+    FAILED = "failed"
+    ALREADY_LIVE = "already_live"
+
+
+@dataclass(frozen=True, slots=True)
+class StartLiveOutcome:
+    """Typed result of the complete start-live workflow."""
+
+    status: StartLiveStatus
+    state: LiveControlState
+    error: LiveControlError | None = None
+    verification_url: str = ""
+    obs_started: bool = False
+    notice: str = ""
+
+    @property
+    def success(self) -> bool:
+        """Return whether Bilibili accepted the start-live request."""
+        return self.status in {
+            StartLiveStatus.STARTED,
+            StartLiveStatus.STARTED_WITHOUT_CREDENTIALS,
+        }
+
+
+class StopLiveStatus(StrEnum):
+    """Outcome categories for a stop-live request."""
+
+    STOPPED = "stopped"
+    STOPPED_WITH_OBS_FAILURE = "stopped_with_obs_failure"
+    FAILED = "failed"
+    NOT_LIVE = "not_live"
+
+
+@dataclass(frozen=True, slots=True)
+class StopLiveOutcome:
+    """Typed result of stopping Bilibili live and cleaning up OBS."""
+
+    status: StopLiveStatus
+    state: LiveControlState
+    error: LiveControlError | None = None
+    obs_was_streaming: bool | None = None
+    obs_stopped: bool = False
+
+    @property
+    def success(self) -> bool:
+        """Return whether Bilibili accepted the stop-live request."""
+        return self.status in {
+            StopLiveStatus.STOPPED,
+            StopLiveStatus.STOPPED_WITH_OBS_FAILURE,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ObsCheckOutcome:
+    """Typed result of checking or launching OBS."""
+
+    connected: bool
+    process_running: bool
+    launched: bool = False
+    error: LiveControlError | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ObsStreamOutcome:
+    """Typed result of an OBS stream start or stop request."""
+
+    success: bool
+    error: LiveControlError | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SettingsSaveOutcome:
+    """Report whether form settings and the secure OBS password were persisted."""
+
+    success: bool
+    error: LiveControlError | None = None
+
+
+def room_title_needs_update(current_room: RoomInfo | None, room_id: int, title: str) -> bool:
+    """Return whether a room title differs from the normalized requested title."""
+    return current_room is None or current_room.room_id != room_id or current_room.title.strip() != title.strip()
+
+
+def room_area_needs_update(current_room: RoomInfo | None, room_id: int, area_id: str) -> bool:
+    """Return whether a room area differs from the requested area."""
+    return current_room is None or current_room.room_id != room_id or current_room.area_id != area_id
+
+
+def room_action_enabled_state(can_start: bool, can_stop: bool, is_live: bool) -> tuple[bool, bool]:
+    """Return the enabled state for start and stop controls."""
+    return (can_start and not is_live, can_stop and is_live)
+
+
+def obs_check_button_state(port_valid: bool, checking: bool, connected: bool) -> tuple[bool, str]:
+    """Return the enabled state and label for the OBS check control."""
+    if checking:
+        return False, "检查中"
+    return port_valid, "重新检查" if connected else "检查 OBS"
+
+
+def start_live_confirmation_needed(obs_streaming: bool | None) -> bool:
+    """Return whether starting live would replace a known active OBS stream."""
+    return obs_streaming is True
+
+
+def obs_cleanup_after_stop_state(obs_streaming: bool | None) -> tuple[bool, str]:
+    """Translate an optional OBS status into the stop-cleanup decision."""
+    if obs_streaming is True:
+        return True, "streaming"
+    if obs_streaming is False:
+        return False, "not_streaming"
+    return False, "unknown"
+
+
+def pick_primary_credential(credentials: Sequence[StreamCredential]) -> StreamCredential | None:
+    """Select the preferred RTMP credential, falling back to the first endpoint."""
+    for credential in credentials:
+        if credential.label == "rtmp-1":
+            return credential
+    for credential in credentials:
+        if credential.label.lower().startswith("rtmp"):
+            return credential
+    return credentials[0] if credentials else None
+
+
+__all__: Final[tuple[str, ...]] = (
+    "LiveArea",
+    "LiveAreaGroup",
+    "LiveControlError",
+    "LiveControlErrorCode",
+    "LiveControlOperationResult",
+    "LiveControlSettings",
+    "LiveControlState",
+    "LiveSessionInfo",
+    "LiveStartResponse",
+    "LiveVersion",
+    "ObsCheckOutcome",
+    "ObsSettings",
+    "ObsStreamOutcome",
+    "RoomInfo",
+    "SessionStatus",
+    "SettingsSaveOutcome",
+    "StartLiveOutcome",
+    "StartLiveStatus",
+    "StopLiveOutcome",
+    "StopLiveStatus",
+    "StreamCredential",
+    "obs_cleanup_after_stop_state",
+    "pick_primary_credential",
+    "obs_check_button_state",
+    "room_area_needs_update",
+    "room_action_enabled_state",
+    "room_title_needs_update",
+    "start_live_confirmation_needed",
+)

--- a/src/bilihud/infrastructure/live_control.py
+++ b/src/bilihud/infrastructure/live_control.py
@@ -1,0 +1,233 @@
+"""Concrete live-control adapters for Bilibili HTTP and OBS WebSocket APIs."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Mapping, Sequence
+from typing import TypeVar
+
+import aiohttp
+
+from ..auth import AuthenticationService
+from ..domain.live_control import (
+    LiveArea,
+    LiveAreaGroup,
+    LiveSessionInfo,
+    LiveStartResponse,
+    LiveVersion,
+    ObsSettings,
+    RoomInfo,
+    SessionStatus,
+    StreamCredential,
+)
+from ..live_api import (
+    LiveApiError,
+    get_area_list,
+    get_cookie_value,
+    get_live_version,
+    get_room_info,
+    parse_stream_credentials,
+    start_live,
+    start_live_verification_url,
+    stop_live,
+    update_room_area,
+    update_room_title,
+)
+from ..live_control_ports import LiveControlApiError, ObsAdapterError
+from ..obs_api import ObsApiError, ObsWebSocketClient, is_obs_process_running, launch_obs
+
+Result = TypeVar("Result")
+
+
+class BilibiliLiveControlApi:
+    """Adapt the existing Bilibili HTTP functions to the live-control port."""
+
+    def __init__(self, auth_service: AuthenticationService) -> None:
+        """Create an adapter with an explicit owner for authenticated sessions."""
+        self._auth_service = auth_service
+        self._session: aiohttp.ClientSession | None = None
+
+    async def open_session(self) -> LiveSessionInfo:
+        """Create a fresh session and expose only normalized authentication state."""
+        await self.close_session()
+        session, from_saved_session = await self._auth_service.create_authenticated_session()
+        self._session = session
+        csrf = get_cookie_value(session, "bili_jct")
+        user_id = get_cookie_value(session, "DedeUserID")
+        return LiveSessionInfo(
+            status=SessionStatus.AUTHENTICATED if csrf else SessionStatus.ANONYMOUS,
+            from_saved_session=from_saved_session,
+            user_id=user_id,
+        )
+
+    async def close_session(self) -> None:
+        """Close the adapter-owned HTTP session when one exists."""
+        session = self._session
+        self._session = None
+        if session is not None and not session.closed:
+            await session.close()
+
+    async def load_area_groups(self) -> tuple[LiveAreaGroup, ...]:
+        """Load and normalize the raw Bilibili area response at the boundary."""
+        session = self._require_session()
+        raw_areas = await self._request(get_area_list(session))
+        return _normalize_area_groups(raw_areas)
+
+    async def get_room_info(self, room_id: int) -> RoomInfo:
+        """Load one normalized room record."""
+        return await self._request(get_room_info(self._require_session(), room_id))
+
+    async def update_room_title(self, room_id: int, title: str) -> None:
+        """Update a room title through the existing HTTP boundary."""
+        await self._request(update_room_title(self._require_session(), room_id, title))
+
+    async def update_room_area(self, room_id: int, area_id: str) -> None:
+        """Update a room area through the existing HTTP boundary."""
+        await self._request(update_room_area(self._require_session(), room_id, area_id))
+
+    async def get_live_version(self) -> LiveVersion:
+        """Load current Bilibili live-version metadata."""
+        return await self._request(get_live_version(self._require_session()))
+
+    async def start_live(self, room_id: int, area_id: str, version: LiveVersion) -> LiveStartResponse:
+        """Start live and normalize credentials plus verification URLs."""
+        session = self._require_session()
+        result = await self._request(
+            start_live(session, room_id, area_id, version.curr_version, str(version.build))
+        )
+        verification_url = start_live_verification_url(
+            result.code,
+            result.data,
+            get_cookie_value(session, "DedeUserID"),
+        )
+        return LiveStartResponse(
+            code=result.code,
+            message=result.message,
+            credentials=tuple(parse_stream_credentials(result.data)),
+            verification_url=verification_url,
+        )
+
+    async def stop_live(self, room_id: int) -> None:
+        """Stop live through the Bilibili HTTP boundary."""
+        await self._request(stop_live(self._require_session(), room_id))
+
+    def _require_session(self) -> aiohttp.ClientSession:
+        """Return the active session or raise an adapter-owned lifecycle error."""
+        session = self._session
+        if session is None or session.closed:
+            raise LiveControlApiError("直播控制会话未初始化。")
+        return session
+
+    async def _request(self, operation: Awaitable[Result]) -> Result:
+        """Normalize expected HTTP and response-shape failures for application code."""
+        try:
+            return await operation
+        except asyncio.CancelledError:
+            raise
+        except LiveApiError as exc:
+            raise LiveControlApiError(str(exc), code=exc.code) from exc
+        except (aiohttp.ClientError, KeyError, OSError, TimeoutError, TypeError, ValueError) as exc:
+            raise LiveControlApiError(f"Bilibili 请求失败: {exc}") from exc
+
+
+class ObsWebSocketAdapter:
+    """Adapt the concrete OBS WebSocket client to the typed OBS port."""
+
+    async def check_connection(self, settings: ObsSettings) -> None:
+        """Check one OBS endpoint and normalize its expected failures."""
+        await self._request(_obs_client(settings).check_connection())
+
+    async def is_streaming(self, settings: ObsSettings) -> bool:
+        """Read the current OBS stream state."""
+        return await self._request(_obs_client(settings).is_streaming())
+
+    async def stop_stream(self, settings: ObsSettings) -> None:
+        """Stop the current OBS stream."""
+        await self._request(_obs_client(settings).stop_stream())
+
+    async def set_stream_service_settings_and_start(
+        self,
+        settings: ObsSettings,
+        credential: StreamCredential,
+    ) -> None:
+        """Configure OBS with the selected credential and start streaming."""
+        await self._request(
+            _obs_client(settings).set_stream_service_settings_and_start(credential)
+        )
+
+    def is_process_running(self) -> bool:
+        """Return whether OBS is running through the platform process adapter."""
+        try:
+            return is_obs_process_running()
+        except OSError as exc:
+            raise ObsAdapterError(f"检查 OBS 进程失败: {exc}") from exc
+
+    def launch(self) -> None:
+        """Launch OBS through the existing process adapter."""
+        try:
+            launch_obs()
+        except (ObsApiError, OSError) as exc:
+            raise ObsAdapterError(str(exc)) from exc
+
+    async def _request(self, operation: Awaitable[Result]) -> Result:
+        """Normalize concrete OBS failures without hiding cancellation."""
+        try:
+            return await operation
+        except asyncio.CancelledError:
+            raise
+        except ObsApiError as exc:
+            raise ObsAdapterError(str(exc)) from exc
+        except (aiohttp.ClientError, OSError, TimeoutError, TypeError, ValueError) as exc:
+            raise ObsAdapterError(f"OBS 请求失败: {exc}") from exc
+
+
+def _obs_client(settings: ObsSettings) -> ObsWebSocketClient:
+    """Build the concrete OBS client at the infrastructure boundary."""
+    return ObsWebSocketClient(host=settings.host, port=settings.port, password=settings.password)
+
+
+def _normalize_area_groups(raw_areas: Sequence[object]) -> tuple[LiveAreaGroup, ...]:
+    """Validate and normalize the untrusted area payload before it reaches the service."""
+    groups: list[LiveAreaGroup] = []
+    for raw_parent in raw_areas:
+        if not isinstance(raw_parent, Mapping):
+            continue
+        parent_id = _identifier(raw_parent.get("id"))
+        parent_name = _text(raw_parent.get("name"))
+        if not parent_id or not parent_name:
+            continue
+        raw_children = raw_parent.get("list")
+        children: list[LiveArea] = []
+        if isinstance(raw_children, Sequence) and not isinstance(raw_children, (str, bytes, bytearray)):
+            for raw_child in raw_children:
+                if not isinstance(raw_child, Mapping):
+                    continue
+                area_id = _identifier(raw_child.get("id"))
+                name = _text(raw_child.get("name"))
+                if area_id and name:
+                    children.append(LiveArea(area_id=area_id, name=name))
+        groups.append(
+            LiveAreaGroup(
+                parent_area_id=parent_id,
+                name=parent_name,
+                areas=tuple(children),
+            )
+        )
+    return tuple(groups)
+
+
+def _identifier(value: object) -> str:
+    """Normalize a numeric or string API identifier while preserving zero explicitly."""
+    if isinstance(value, bool) or value is None:
+        return ""
+    if isinstance(value, (int, str)):
+        return str(value).strip()
+    return ""
+
+
+def _text(value: object) -> str:
+    """Accept only scalar textual API values at the normalization boundary."""
+    return value.strip() if isinstance(value, str) else ""
+
+
+__all__ = ("BilibiliLiveControlApi", "ObsWebSocketAdapter")

--- a/src/bilihud/live_api.py
+++ b/src/bilihud/live_api.py
@@ -7,6 +7,21 @@ from urllib.parse import urlencode
 
 import aiohttp
 
+from .domain.live_control import (
+    LiveVersion,
+    RoomInfo,
+    StreamCredential,
+)
+from .domain.live_control import (
+    room_action_enabled_state as _room_action_enabled_state,
+)
+from .domain.live_control import (
+    room_area_needs_update as _room_area_needs_update,
+)
+from .domain.live_control import (
+    room_title_needs_update as _room_title_needs_update,
+)
+
 BASE_URL = "https://api.live.bilibili.com"
 APP_KEY = "aae92bc66f3edfab"
 APP_SECRET = "af125a0d5279fd576c1b4418a3e8276d"
@@ -15,28 +30,6 @@ USER_AGENT = (
     "AppleWebKit/537.36 (KHTML, like Gecko) "
     "Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0"
 )
-
-
-@dataclass(frozen=True)
-class StreamCredential:
-    label: str
-    address: str
-    key: str
-
-
-@dataclass(frozen=True)
-class LiveVersion:
-    curr_version: str
-    build: int
-
-
-@dataclass(frozen=True)
-class RoomInfo:
-    room_id: int
-    title: str
-    parent_area_id: str
-    area_id: str
-    is_live: bool = False
 
 
 @dataclass(frozen=True)
@@ -88,15 +81,18 @@ def is_live_rate_limited_error(exc: BaseException) -> bool:
 
 
 def room_title_needs_update(current_room: RoomInfo | None, room_id: int, title: str) -> bool:
-    return current_room is None or current_room.room_id != room_id or current_room.title.strip() != title.strip()
+    """Keep the historical live-api helper name while delegating pure domain logic."""
+    return _room_title_needs_update(current_room, room_id, title)
 
 
 def room_area_needs_update(current_room: RoomInfo | None, room_id: int, area_id: str) -> bool:
-    return current_room is None or current_room.room_id != room_id or current_room.area_id != area_id
+    """Keep the historical live-api helper name while delegating pure domain logic."""
+    return _room_area_needs_update(current_room, room_id, area_id)
 
 
 def room_action_enabled_state(can_start: bool, can_stop: bool, is_live: bool) -> tuple[bool, bool]:
-    return (can_start and not is_live, can_stop and is_live)
+    """Keep the historical live-api helper name for existing callers."""
+    return _room_action_enabled_state(can_start, can_stop, is_live)
 
 
 def get_cookie_value(session: aiohttp.ClientSession, name: str) -> str | None:

--- a/src/bilihud/live_control_dialog.py
+++ b/src/bilihud/live_control_dialog.py
@@ -1,12 +1,10 @@
 import asyncio
 import logging
 from collections.abc import Coroutine
-from dataclasses import replace
 from typing import Any
 
-import aiohttp
 from PyQt6.QtCore import Qt, pyqtSignal, pyqtSlot
-from PyQt6.QtGui import QImage, QPixmap
+from PyQt6.QtGui import QCloseEvent, QImage, QPixmap, QShowEvent
 from PyQt6.QtWidgets import (
     QApplication,
     QComboBox,
@@ -24,53 +22,44 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from .auth import AuthenticationService
-from .config import ConfigStore
+from .domain.live_control import (
+    LiveAreaGroup,
+    LiveControlErrorCode,
+    LiveControlSettings,
+    LiveControlState,
+    ObsSettings,
+    RoomInfo,
+    SessionStatus,
+    StartLiveOutcome,
+    StartLiveStatus,
+    StopLiveStatus,
+    StreamCredential,
+    obs_check_button_state,
+    room_action_enabled_state,
+)
+from .domain.live_control import (
+    obs_cleanup_after_stop_state as _obs_cleanup_after_stop_state,
+)
+from .domain.live_control import (
+    start_live_confirmation_needed as _start_live_confirmation_needed,
+)
 from .helpers import validate_room_id
 from .lifecycle import TaskScope, TaskSupervisor, cancel_task
-from .live_api import (
-    LiveApiError,
-    RoomInfo,
-    StreamCredential,
-    extract_qr_url,
-    get_area_list,
-    get_cookie_value,
-    get_live_version,
-    get_room_info,
-    is_live_rate_limited_error,
-    parse_stream_credentials,
-    room_action_enabled_state,
-    room_area_needs_update,
-    room_title_needs_update,
-    start_live,
-    start_live_verification_url,
-    stop_live,
-    update_room_area,
-    update_room_title,
-)
-from .obs_api import (
-    ObsApiError,
-    ObsWebSocketClient,
-    is_obs_process_running,
-    launch_obs,
-    obs_check_button_state,
-    pick_primary_credential,
-)
+from .live_control_service import LiveControlService
 from .services import AppServices, create_default_services
 
 logger = logging.getLogger(__name__)
 
 
+# TODO: remove these compatibility exports after callers import the service helpers directly.
 def start_live_confirmation_needed(obs_streaming: bool | None) -> bool:
-    return obs_streaming is True
+    """Keep the historical pure helper available to existing callers."""
+    return _start_live_confirmation_needed(obs_streaming)
 
 
 def obs_cleanup_after_stop_state(obs_streaming: bool | None) -> tuple[bool, str]:
-    if obs_streaming is True:
-        return True, "streaming"
-    if obs_streaming is False:
-        return False, "not_streaming"
-    return False, "unknown"
+    """Keep the historical pure helper available to existing callers."""
+    return _obs_cleanup_after_stop_state(obs_streaming)
 
 
 class LiveControlDialog(QDialog):
@@ -90,8 +79,7 @@ class LiveControlDialog(QDialog):
         self.setMinimumSize(520, 540)
 
         self.services = services if services is not None else create_default_services()
-        self.config_store: ConfigStore = self.services.config_store  # Non-sensitive settings boundary.
-        self.auth_service: AuthenticationService = self.services.auth_service  # Auth and OBS secret boundary.
+        self.live_control_service: LiveControlService = self.services.live_control_service
         if task_scope is None:
             task_supervisor = TaskSupervisor()
             self._task_supervisor: TaskSupervisor | None = task_supervisor
@@ -101,22 +89,18 @@ class LiveControlDialog(QDialog):
             self._task_supervisor = None
             self._owns_task_supervisor = False
             self._task_scope = task_scope
-        self.session: aiohttp.ClientSession | None = None  # Session owned and closed by this dialog.
-        self.area_list: list[dict[str, Any]] = []
+        self.area_list: tuple[LiveAreaGroup, ...] = ()
         self.credentials: list[StreamCredential] = []
         self.current_room_info: RoomInfo | None = None
         self.is_live_active = False
         self._initial_load_task: asyncio.Task[None] | None = None  # Canceled when the dialog closes.
         self._room_info_task: asyncio.Task[None] | None = None  # Latest room-info request.
-        self._obs_write_task: asyncio.Task[None] | None = None  # Latest OBS settings request.
         self._load_generation = 0
         self._action_generation = 0
-        self._session_cleanup_task: asyncio.Task[None] | None = None  # Owner of deferred closes.
-        self._sessions_pending_close: list[aiohttp.ClientSession] = []  # Sessions awaiting cleanup.
+        self._service_close_task: asyncio.Task[None] | None = None  # Deferred reusable-service cleanup.
         self._busy = False
         self._obs_busy = False
         self._obs_connected = False
-        self._obs_streaming_started = False
         self._action_tasks: set[asyncio.Task[Any]] = set()  # Qt-triggered workflows owned by this dialog.
         self._shutting_down = False  # Blocks new dialog work during application shutdown.
         self._shutdown_complete = False  # Makes application shutdown idempotent.
@@ -315,12 +299,12 @@ class LiveControlDialog(QDialog):
 
     def _load_config_values(self) -> None:
         """Load typed settings and the OBS password from their separate boundaries."""
-        config = self.config_store.load()
-        self.room_id_input.setText(str(config.room_id) if config.room_id else "")
-        self.title_input.setText(config.live_title)
-        self.obs_host_input.setText(config.obs_host)
-        self.obs_port_input.setText(str(config.obs_port))
-        self.obs_password_input.setText(self.auth_service.load_obs_password() or "")
+        settings = self.live_control_service.load_settings()
+        self.room_id_input.setText(str(settings.room_id) if settings.room_id else "")
+        self.title_input.setText(settings.live_title)
+        self.obs_host_input.setText(settings.obs_host)
+        self.obs_port_input.setText(str(settings.obs_port))
+        self.obs_password_input.setText(settings.obs_password)
 
     def set_room_id(self, room_id: int) -> None:
         if room_id > 0:
@@ -355,13 +339,16 @@ class LiveControlDialog(QDialog):
         if pending:
             await asyncio.gather(*pending, return_exceptions=True)
 
-    def showEvent(self, event) -> None:
+    def showEvent(self, event: QShowEvent | None) -> None:
         super().showEvent(event)
         if self._shutting_down:
             return
         if self._initial_load_task and not self._initial_load_task.done():
             return
-        if self.session and not self.session.closed:
+        if (
+            self.live_control_service.state.session.status is not SessionStatus.CLOSED
+            and (self._service_close_task is None or self._service_close_task.done())
+        ):
             self._update_action_state()
             return
 
@@ -371,28 +358,29 @@ class LiveControlDialog(QDialog):
             name="initial-load",
         )
 
-    def closeEvent(self, event) -> None:
-        """Cancel owned work and schedule all aiohttp sessions for cleanup."""
+    def closeEvent(self, event: QCloseEvent | None) -> None:
+        """Cancel owned work and schedule reusable service cleanup."""
         self._load_generation += 1
         self._action_generation += 1
         if self._initial_load_task and not self._initial_load_task.done():
             self._initial_load_task.cancel()
         if self._room_info_task and not self._room_info_task.done():
             self._room_info_task.cancel()
-        if self._obs_write_task and not self._obs_write_task.done():
-            self._obs_write_task.cancel()
         for task in tuple(self._action_tasks):
             if not task.done():
                 task.cancel()
         self._clear_credentials()
-        self._schedule_session_cleanup(self.session)
-        self.session = None
+        if self._service_close_task is None or self._service_close_task.done():
+            self._service_close_task = self._task_scope.create_task(
+                self.live_control_service.close(),
+                name="close-live-control-service",
+            )
         self._busy = False
         self._update_action_state()
         super().closeEvent(event)
 
     async def shutdown(self) -> None:
-        """Cancel dialog work and await cleanup of every owned HTTP session."""
+        """Cancel dialog work and await cleanup of the service-owned resources."""
         if self._shutdown_complete:
             return
 
@@ -401,62 +389,41 @@ class LiveControlDialog(QDialog):
         self._action_generation += 1
         await cancel_task(self._initial_load_task)
         await cancel_task(self._room_info_task)
-        await cancel_task(self._obs_write_task)
+        await cancel_task(self._service_close_task)
         await self._cancel_action_tasks()
         self._clear_credentials()
-
-        if self.session is not None and not self.session.closed:
-            if self.session not in self._sessions_pending_close:
-                self._sessions_pending_close.append(self.session)
-        self.session = None
-
-        cleanup_errors: list[Exception] = []
-        cleanup_task = self._session_cleanup_task
-        if cleanup_task is not None and not cleanup_task.done():
-            try:
-                await cleanup_task
-            except Exception as exc:
-                cleanup_errors.append(exc)
         try:
-            await self._close_pending_sessions()
+            await self.live_control_service.shutdown()
         except Exception as exc:
-            cleanup_errors.append(exc)
+            logger.exception("Failed to shut down live-control service")
+            raise exc
         try:
             await self._task_scope.cancel_all()
             self._busy = False
             self._update_action_state()
-            if cleanup_errors:
-                raise cleanup_errors[0]
         finally:
             if self._owns_task_supervisor and self._task_supervisor is not None:
                 await self._task_supervisor.shutdown()
         self._shutdown_complete = True
 
     async def load_initial_state(self, generation: int) -> None:
-        """Create a dialog-owned session and discard it if loading becomes stale."""
+        """Load the service snapshot and discard it when the dialog load is stale."""
         self._set_busy(True, "正在加载登录状态和直播分区...")
-        session: aiohttp.ClientSession | None = None
         try:
-            session, _from_keyring = await self.auth_service.create_authenticated_session()
+            result = await self.live_control_service.initialize(self._room_id())
             if generation != self._load_generation:
-                self._schedule_session_cleanup(session)
                 return
-
-            self.session = session
-            if self._has_csrf():
+            self._apply_service_state(result.state)
+            if result.error is not None:
+                if result.error.code is LiveControlErrorCode.LOGIN_EXPIRED:
+                    self.set_status("保存的登录状态已过期，请先通过托盘菜单重新扫码登录。", error=True)
+                else:
+                    self.set_status(result.error.message, error=True)
+            elif self._has_csrf():
                 self.set_status("登录状态可用。")
             else:
                 self.set_status("未找到 CSRF Token，请先通过托盘菜单扫码登录。", error=True)
-
-            area_list = await get_area_list(self.session)
-            if generation != self._load_generation:
-                return
-
-            self.area_list = area_list
-            self._populate_parent_areas()
-            await self._load_room_info(generation, update_status=self._has_csrf())
         except asyncio.CancelledError:
-            self._schedule_session_cleanup(session)
             raise
         except Exception as exc:
             if generation == self._load_generation:
@@ -466,64 +433,45 @@ class LiveControlDialog(QDialog):
             if generation == self._load_generation:
                 self._set_busy(False)
 
-    def _schedule_session_cleanup(self, session: aiohttp.ClientSession | None) -> None:
-        if session and not session.closed and session not in self._sessions_pending_close:
-            self._sessions_pending_close.append(session)
-
-        if self._shutting_down:
-            return
-
-        if self._sessions_pending_close and (
-            self._session_cleanup_task is None or self._session_cleanup_task.done()
-        ):
-            self._session_cleanup_task = self._task_scope.create_task(
-                self._close_pending_sessions(),
-                name="session-cleanup",
-            )
-
-    async def _close_pending_sessions(self) -> None:
-        while self._sessions_pending_close:
-            session = self._sessions_pending_close[0]
-            if session.closed:
-                self._sessions_pending_close.pop(0)
-                continue
-            await session.close()
-            self._sessions_pending_close.pop(0)
-
     def _populate_parent_areas(self) -> None:
         self.parent_area_combo.blockSignals(True)
         self.parent_area_combo.clear()
         for parent in self.area_list:
-            self.parent_area_combo.addItem(str(parent.get("name") or ""), str(parent.get("id") or ""))
+            self.parent_area_combo.addItem(parent.name, parent.parent_area_id)
         self.parent_area_combo.blockSignals(False)
         self._on_parent_area_changed()
 
+    def _apply_service_state(self, state: LiveControlState) -> None:
+        """Bind one immutable service snapshot to the dialog's presentation fields."""
+        self.area_list = state.areas
+        self.credentials = list(state.credentials)
+        self.current_room_info = state.room_info
+        self._obs_connected = state.obs_connected
+        self._populate_parent_areas()
+        if state.room_info is not None:
+            self._set_live_active(state.room_info.is_live)
+            if state.room_info.title:
+                self.title_input.setText(state.room_info.title)
+            self._select_area(state.room_info.parent_area_id, state.room_info.area_id)
+        else:
+            self._set_live_active(False)
+        self._render_credentials()
+
     async def _load_room_info(self, generation: int, update_status: bool = True) -> bool:
         room_id = self._room_id()
-        if room_id is None or self.session is None:
+        if room_id is None:
             self.current_room_info = None
             self._restore_saved_area()
             return False
-
-        try:
-            room_info = await get_room_info(self.session, room_id)
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            logger.info("Failed to load room info for %s: %s", room_id, exc)
-            if generation == self._load_generation:
-                self.current_room_info = None
-                self._restore_saved_area()
-            return False
-
+        result = await self.live_control_service.load_room_info(room_id)
         if generation != self._load_generation:
             return False
-
-        self.current_room_info = room_info
-        self._set_live_active(room_info.is_live)
-        if room_info.title:
-            self.title_input.setText(room_info.title)
-        self._select_area(room_info.parent_area_id, room_info.area_id)
+        self._apply_service_state(result.state)
+        if result.error is not None:
+            self.current_room_info = None
+            self._restore_saved_area()
+            logger.info("Failed to load room info for %s: %s", room_id, result.error.message)
+            return False
         if update_status:
             self.set_status("已加载直播间当前标题和分区。")
         return True
@@ -542,7 +490,11 @@ class LiveControlDialog(QDialog):
     async def _reload_room_info(self) -> None:
         if self._shutting_down:
             return
-        if self._busy or not self.area_list or not self.session or self.session.closed:
+        if (
+            self._busy
+            or not self.area_list
+            or self.live_control_service.state.session.status is SessionStatus.CLOSED
+        ):
             return
         if self._room_id() is None:
             self.current_room_info = None
@@ -566,26 +518,8 @@ class LiveControlDialog(QDialog):
             self._update_action_state()
 
     def _restore_saved_area(self) -> None:
-        config = self.config_store.load()
-        self._select_area(config.live_parent_area_id, config.live_area_id)
-
-    def _remember_synced_title(self, room_id: int, title: str) -> None:
-        current = self.current_room_info
-        self.current_room_info = RoomInfo(
-            room_id=room_id,
-            title=title,
-            parent_area_id=current.parent_area_id if current and current.room_id == room_id else "",
-            area_id=current.area_id if current and current.room_id == room_id else "",
-        )
-
-    def _remember_synced_area(self, room_id: int, area_id: str) -> None:
-        current = self.current_room_info
-        self.current_room_info = RoomInfo(
-            room_id=room_id,
-            title=current.title if current and current.room_id == room_id else "",
-            parent_area_id=self._selected_parent_area_id(),
-            area_id=area_id,
-        )
+        settings = self.live_control_service.load_settings()
+        self._select_area(settings.live_parent_area_id, settings.live_area_id)
 
     def _select_area(self, parent_id: str, area_id: str) -> None:
         if parent_id:
@@ -600,15 +534,15 @@ class LiveControlDialog(QDialog):
     def _on_parent_area_changed(self) -> None:
         current_parent_id = self._selected_parent_area_id()
         selected_parent = next(
-            (parent for parent in self.area_list if str(parent.get("id") or "") == current_parent_id),
+            (parent for parent in self.area_list if parent.parent_area_id == current_parent_id),
             None,
         )
 
         self.area_combo.blockSignals(True)
         self.area_combo.clear()
         if selected_parent:
-            for area in selected_parent.get("list") or []:
-                self.area_combo.addItem(str(area.get("name") or ""), str(area.get("id") or ""))
+            for area in selected_parent.areas:
+                self.area_combo.addItem(area.name, area.area_id)
         self.area_combo.blockSignals(False)
         self._update_action_state()
 
@@ -641,36 +575,19 @@ class LiveControlDialog(QDialog):
             return None
         return port if 1 <= port <= 65535 else None
 
-    def _obs_client(self) -> ObsWebSocketClient | None:
+    def _obs_settings(self) -> ObsSettings | None:
         port = self._obs_port()
         if port is None:
-            self.set_status("OBS 端口无效。", error=True)
             return None
-        return ObsWebSocketClient(
-            host=self.obs_host_input.text().strip() or "127.0.0.1",
+        host = self.obs_host_input.text().strip()
+        return ObsSettings(
+            host=host if host else "127.0.0.1",
             port=port,
             password=self.obs_password_input.text(),
         )
 
-    async def _current_obs_streaming(self) -> bool | None:
-        client = self._obs_client()
-        if client is None:
-            return None
-        try:
-            streaming = await client.is_streaming()
-        except ObsApiError as exc:
-            logger.info("Failed to query OBS stream status: %s", exc)
-            self._obs_connected = False
-            return None
-        except Exception:
-            logger.exception("Unexpected OBS stream status failure")
-            self._obs_connected = False
-            return None
-        self._obs_connected = True
-        return streaming
-
     def _has_csrf(self) -> bool:
-        return bool(self.session and not self.session.closed and get_cookie_value(self.session, "bili_jct"))
+        return self.live_control_service.state.session.is_authenticated
 
     def _update_action_state(self) -> None:
         if self._busy:
@@ -753,66 +670,28 @@ class LiveControlDialog(QDialog):
 
     def _save_form_config(self) -> bool:
         """Persist form settings and save or clear the OBS password securely."""
-        room_id = self._room_id()
-        current = self.config_store.load()
-        config = replace(
-            current,
-            room_id=room_id,
+        current = self.live_control_service.load_settings()
+        port = self._obs_port()
+        settings = LiveControlSettings(
+            room_id=self._room_id(),
             live_title=self.title_input.text().strip(),
             live_parent_area_id=self._selected_parent_area_id(),
             live_area_id=self._selected_area_id(),
             obs_host=self.obs_host_input.text().strip() or current.obs_host,
-            obs_port=self._obs_port() or current.obs_port,
+            obs_port=port if port is not None else current.obs_port,
+            obs_password=self.obs_password_input.text(),
         )
-        config_saved = self.config_store.save(config)
-        password = self.obs_password_input.text()
-        secret_saved = self.auth_service.save_obs_password(password) if password else True
-        if not password:
-            self.auth_service.clear_obs_password()
-        return config_saved and secret_saved
+        return self.live_control_service.save_settings(settings).success
 
     def _begin_action(self) -> int:
         self._action_generation += 1
         return self._action_generation
 
-    def _is_current_action(self, generation: int, session: aiohttp.ClientSession) -> bool:
+    def _is_current_action(self, generation: int) -> bool:
         return (
             generation == self._action_generation
             and self.isVisible()
-            and self.session is session
-            and not session.closed
         )
-
-    async def _sync_room_before_start(
-        self,
-        session: aiohttp.ClientSession,
-        room_id: int,
-        title: str,
-        area_id: str,
-    ) -> None:
-        if room_title_needs_update(self.current_room_info, room_id, title):
-            await update_room_title(session, room_id, title)
-            self._remember_synced_title(room_id, title)
-
-        if room_area_needs_update(self.current_room_info, room_id, area_id):
-            await update_room_area(session, room_id, area_id)
-            self._remember_synced_area(room_id, area_id)
-
-    async def _sync_room_before_start_lenient(
-        self,
-        session: aiohttp.ClientSession,
-        room_id: int,
-        title: str,
-        area_id: str,
-    ) -> None:
-        try:
-            await self._sync_room_before_start(session, room_id, title, area_id)
-        except LiveApiError as exc:
-            if is_live_rate_limited_error(exc):
-                logger.info("Room update skipped before start because Bilibili rate limited it: %s", exc)
-                self.set_status("直播间信息刚更新过，已跳过重复同步并继续开播...")
-                return
-            raise
 
     @pyqtSlot()
     def handle_update_title(self) -> asyncio.Task[None] | None:
@@ -824,8 +703,7 @@ class LiveControlDialog(QDialog):
     async def _handle_update_title(self) -> None:
         if self._shutting_down:
             return
-        session = self.session
-        if not session:
+        if self.live_control_service.state.session.status is SessionStatus.CLOSED:
             return
         action_generation = self._begin_action()
         room_id = self._room_id()
@@ -835,18 +713,21 @@ class LiveControlDialog(QDialog):
             return
         self._set_busy(True, "正在更新标题...")
         try:
-            await update_room_title(session, room_id, title)
-            if not self._is_current_action(action_generation, session):
+            result = await self.live_control_service.update_title(room_id, title)
+            if not self._is_current_action(action_generation):
                 return
-            self._remember_synced_title(room_id, title)
+            self._apply_service_state(result.state)
+            if result.error is not None:
+                self.set_status(result.error.message, error=True)
+                return
             self._save_form_config()
             self.set_status("直播间标题已更新。")
         except Exception as exc:
-            if self._is_current_action(action_generation, session):
+            if self._is_current_action(action_generation):
                 logger.exception("Failed to update room title")
                 self.set_status(f"更新标题失败: {exc}", error=True)
         finally:
-            if self._is_current_action(action_generation, session):
+            if self._is_current_action(action_generation):
                 self._set_busy(False)
 
     @pyqtSlot()
@@ -859,8 +740,7 @@ class LiveControlDialog(QDialog):
     async def _handle_update_area(self) -> None:
         if self._shutting_down:
             return
-        session = self.session
-        if not session:
+        if self.live_control_service.state.session.status is SessionStatus.CLOSED:
             return
         action_generation = self._begin_action()
         room_id = self._room_id()
@@ -870,18 +750,21 @@ class LiveControlDialog(QDialog):
             return
         self._set_busy(True, "正在更新分区...")
         try:
-            await update_room_area(session, room_id, area_id)
-            if not self._is_current_action(action_generation, session):
+            result = await self.live_control_service.update_area(room_id, area_id)
+            if not self._is_current_action(action_generation):
                 return
-            self._remember_synced_area(room_id, area_id)
+            self._apply_service_state(result.state)
+            if result.error is not None:
+                self.set_status(result.error.message, error=True)
+                return
             self._save_form_config()
             self.set_status("直播间分区已更新。")
         except Exception as exc:
-            if self._is_current_action(action_generation, session):
+            if self._is_current_action(action_generation):
                 logger.exception("Failed to update room area")
                 self.set_status(f"更新分区失败: {exc}", error=True)
         finally:
-            if self._is_current_action(action_generation, session):
+            if self._is_current_action(action_generation):
                 self._set_busy(False)
 
     @pyqtSlot()
@@ -894,8 +777,7 @@ class LiveControlDialog(QDialog):
     async def _handle_start_live(self) -> None:
         if self._shutting_down:
             return
-        session = self.session
-        if not session:
+        if self.live_control_service.state.session.status is SessionStatus.CLOSED:
             return
         action_generation = self._begin_action()
         room_id = self._room_id()
@@ -906,77 +788,74 @@ class LiveControlDialog(QDialog):
             return
 
         self._set_busy(True, "正在开始直播...")
+        obs_settings = self._obs_settings()
         try:
-            obs_streaming = await self._current_obs_streaming()
-            if not self._is_current_action(action_generation, session):
+            self._save_form_config()
+            outcome = await self.live_control_service.start_live(
+                room_id,
+                title,
+                area_id,
+                obs_settings,
+            )
+            if not self._is_current_action(action_generation):
                 return
-            if start_live_confirmation_needed(obs_streaming):
+            if outcome.status is StartLiveStatus.OBS_SWITCH_REQUIRED:
                 self._set_busy(False)
                 if not await self._confirm_switch_obs_stream():
                     self.set_status("已取消开播，OBS 推流保持不变。")
                     return
-                if not self._is_current_action(action_generation, session):
+                if not self._is_current_action(action_generation):
                     return
                 self._set_busy(True, "正在开始直播...")
-
-            self._save_form_config()
-            await self._sync_room_before_start_lenient(session, room_id, title, area_id)
-            if not self._is_current_action(action_generation, session):
-                return
-            version = await get_live_version(session)
-            if not self._is_current_action(action_generation, session):
-                return
-            result = await start_live(session, room_id, area_id, version.curr_version, str(version.build))
-            if not self._is_current_action(action_generation, session):
-                return
-            await self._handle_start_live_result(result.code, result.message, result.data)
-        except LiveApiError as exc:
-            if self._is_current_action(action_generation, session):
-                logger.exception("Live API error while starting live")
-                self.set_status(str(exc), error=True)
+                outcome = await self.live_control_service.start_live(
+                    room_id,
+                    title,
+                    area_id,
+                    obs_settings,
+                    allow_obs_switch=True,
+                )
+                if not self._is_current_action(action_generation):
+                    return
+            self._apply_service_state(outcome.state)
+            await self._present_start_outcome(outcome)
         except Exception as exc:
-            if self._is_current_action(action_generation, session):
+            if self._is_current_action(action_generation):
                 logger.exception("Failed to start live")
                 self.set_status(f"开始直播失败: {exc}", error=True)
         finally:
-            if self._is_current_action(action_generation, session):
+            if self._is_current_action(action_generation):
                 self._set_busy(False)
 
-    async def _handle_start_live_result(self, code: int, message: str, data: dict[str, Any]) -> None:
-        if code == 0:
-            self.credentials = parse_stream_credentials(data)
-            self._render_credentials()
-            self._set_live_active(True)
-            if self.credentials:
-                self.set_status("直播已开始，推流凭证已生成；正在尝试连接 OBS 自动推流。", success=True)
-                self._obs_write_task = self._task_scope.create_task(
-                    self._write_obs_after_start(),
-                    name="obs-credential-write",
-                )
+    async def _present_start_outcome(self, outcome: StartLiveOutcome) -> None:
+        """Render a typed service outcome and open verification UI when required."""
+        if outcome.status is StartLiveStatus.VERIFICATION_REQUIRED:
+            title = "人脸认证" if "face-auth" in outcome.verification_url else "开播验证"
+            await self._show_qr_verification(outcome.verification_url, title=title)
+            message = "本次开播需要验证，完成后请重新点击开始直播。"
+            self.set_status(self._with_start_notice(outcome, message), error=True)
+            return
+        if outcome.status is StartLiveStatus.STARTED_WITHOUT_CREDENTIALS:
+            message = outcome.error.message if outcome.error else "直播已开始，但未生成推流凭证。"
+            self.set_status(self._with_start_notice(outcome, message), error=True)
+            return
+        if outcome.status is StartLiveStatus.STARTED:
+            if outcome.error is not None and outcome.error.code is LiveControlErrorCode.OBS_FAILURE:
+                message = "直播已开始，RTMP 凭证已生成；OBS 自动推流失败，可手动复制地址和密钥。"
+                self.set_status(self._with_start_notice(outcome, message), error=True)
+            elif outcome.obs_started:
+                message = "直播已开始，推流凭证已生成，OBS 已自动开始推流。"
+                self.set_status(self._with_start_notice(outcome, message), success=True)
             else:
-                self.set_status("直播已开始，但接口未返回可识别的推流凭证。", error=True)
+                message = "直播已开始，推流凭证已生成。"
+                self.set_status(self._with_start_notice(outcome, message), success=True)
             return
-
-        if code == 60024:
-            await self._show_qr_verification(start_live_verification_url(code, data, uid=None))
-            self.set_status("本次开播需要扫码验证，完成后请重新点击开始直播。", error=True)
-            return
-
-        if code == 60043:
-            uid = get_cookie_value(self.session, "DedeUserID") if self.session else None
-            auth_url = start_live_verification_url(code, data, uid=uid)
-            if auth_url:
-                await self._show_qr_verification(auth_url, title="人脸认证")
-            else:
-                await self._show_text_dialog("人脸认证", "本次开播需要人脸认证，但当前会话缺少 DedeUserID。")
-            self.set_status("本次开播需要人脸认证，完成后请重新点击开始直播。", error=True)
-            return
-
-        self.set_status(f"开始直播失败: {message or 'Unknown Error'} ({code})", error=True)
+        message = outcome.error.message if outcome.error is not None else "开始直播失败。"
+        self.set_status(self._with_start_notice(outcome, message), error=True)
 
     @staticmethod
-    def _extract_qr_url(data: dict[str, Any]) -> str:
-        return extract_qr_url(data)
+    def _with_start_notice(outcome: StartLiveOutcome, message: str) -> str:
+        """Preserve non-fatal room-sync notices alongside the final start result."""
+        return f"{outcome.notice}\n{message}" if outcome.notice else message
 
     @pyqtSlot()
     def handle_stop_live(self) -> asyncio.Task[None] | None:
@@ -988,8 +867,7 @@ class LiveControlDialog(QDialog):
     async def _handle_stop_live(self) -> None:
         if self._shutting_down:
             return
-        session = self.session
-        if not session:
+        if self.live_control_service.state.session.status is SessionStatus.CLOSED:
             return
         action_generation = self._begin_action()
         room_id = self._room_id()
@@ -999,35 +877,27 @@ class LiveControlDialog(QDialog):
 
         self._set_busy(True, "正在停止直播...")
         try:
-            await stop_live(session, room_id)
-            if not self._is_current_action(action_generation, session):
+            self._save_form_config()
+            outcome = await self.live_control_service.stop_live(room_id, self._obs_settings())
+            if not self._is_current_action(action_generation):
                 return
-            self._clear_credentials()
-            self._set_live_active(False)
-            obs_streaming = await self._current_obs_streaming()
-            should_stop_obs, obs_state = obs_cleanup_after_stop_state(obs_streaming)
-            obs_stopped = True
-            if should_stop_obs:
-                obs_stopped = await self.stop_obs_stream(auto=True)
-                if not self._is_current_action(action_generation, session):
-                    return
-            self._obs_streaming_started = False
-            if should_stop_obs and obs_stopped:
+            self._apply_service_state(outcome.state)
+            if outcome.status is StopLiveStatus.STOPPED and outcome.obs_stopped:
                 self.set_status("直播已停止，OBS 推流已停止。")
-            elif obs_state == "unknown" or (should_stop_obs and not obs_stopped):
-                self.set_status("直播已停止；OBS 推流未能自动确认/停止，请在 OBS 中手动确认。", error=True)
-            else:
+            elif outcome.status is StopLiveStatus.STOPPED:
                 self.set_status("直播已停止。")
+            else:
+                self.set_status(
+                    outcome.error.message if outcome.error is not None else "停止直播失败。",
+                    error=True,
+                )
         except Exception as exc:
-            if self._is_current_action(action_generation, session):
+            if self._is_current_action(action_generation):
                 logger.exception("Failed to stop live")
                 self.set_status(f"停止直播失败: {exc}", error=True)
         finally:
-            if self._is_current_action(action_generation, session):
+            if self._is_current_action(action_generation):
                 self._set_busy(False)
-
-    async def _write_obs_after_start(self) -> None:
-        await self.start_obs_stream(auto=True)
 
     async def _confirm_switch_obs_stream(self) -> bool:
         loop = asyncio.get_running_loop()
@@ -1050,26 +920,21 @@ class LiveControlDialog(QDialog):
         return await future
 
     async def stop_obs_stream(self, auto: bool = False) -> bool:
-        client = self._obs_client()
-        if client is None:
-            return False
-
         self._save_form_config()
         self._obs_busy = True
         self._update_action_state()
         if not auto:
             self.set_status("正在停止 OBS 推流...")
         try:
-            await client.stop_stream()
-            self._obs_streaming_started = False
+            outcome = await self.live_control_service.stop_obs_stream(self._obs_settings())
+            self._apply_service_state(self.live_control_service.state)
+            if not outcome.success:
+                if not auto and outcome.error is not None:
+                    self.set_status(outcome.error.message, error=True)
+                return False
             if not auto:
                 self.set_status("OBS 推流已停止。", success=True)
             return True
-        except ObsApiError as exc:
-            logger.info("Failed to stop OBS stream: %s", exc)
-            if not auto:
-                self.set_status(f"停止 OBS 推流失败: {exc}", error=True)
-            return False
         except Exception as exc:
             logger.exception("Unexpected OBS stop failure")
             if not auto:
@@ -1089,8 +954,9 @@ class LiveControlDialog(QDialog):
     async def _handle_check_obs(self) -> None:
         if self._shutting_down:
             return
-        client = self._obs_client()
-        if client is None:
+        settings = self._obs_settings()
+        if settings is None:
+            self.set_status("OBS 端口无效。", error=True)
             return
 
         self._save_form_config()
@@ -1098,41 +964,24 @@ class LiveControlDialog(QDialog):
         self._update_action_state()
         self.set_status("正在检查 OBS WebSocket...")
         try:
-            try:
-                await client.check_connection()
-            except ObsApiError as exc:
-                logger.info("OBS WebSocket check failed: %s", exc)
-                self._obs_connected = False
-            else:
-                self._obs_connected = True
+            outcome = await self.live_control_service.check_obs(settings)
+            self._apply_service_state(self.live_control_service.state)
+            if outcome.connected:
                 self.set_status("OBS 已启动并且 WebSocket 可连接。点击“开始直播”会自动推流。", success=True)
                 return
-
-            try:
-                if is_obs_process_running():
-                    self._obs_connected = False
-                    self.set_status("OBS 已启动，但 WebSocket 无法连接。请检查 OBS WebSocket 设置。", error=True)
-                    return
-                launch_obs()
-                self._obs_connected = False
+            if outcome.launched:
                 self.set_status("已启动 OBS。请等待 OBS 完成加载，然后点击“开始直播”。", success=True)
-            except ObsApiError as exc:
-                self.set_status(f"启动 OBS 失败: {exc}", error=True)
-            except Exception as exc:
-                logger.exception("Unexpected OBS launch failure")
-                self.set_status(f"启动 OBS 失败: {exc}", error=True)
+            elif outcome.error is not None:
+                self.set_status(outcome.error.message, error=True)
         finally:
             self._obs_busy = False
             self._update_action_state()
 
     async def start_obs_stream(self, auto: bool = False) -> None:
-        credential = pick_primary_credential(self.credentials)
-        if credential is None:
+        settings = self._obs_settings()
+        if settings is None:
             if not auto:
-                self.set_status("没有可用于启动 OBS 推流的凭证。", error=True)
-            return
-        client = self._obs_client()
-        if client is None:
+                self.set_status("OBS 端口无效。", error=True)
             return
 
         self._save_form_config()
@@ -1141,21 +990,15 @@ class LiveControlDialog(QDialog):
         if not auto:
             self.set_status("正在填入 OBS 推流设置并启动推流...")
         try:
-            try:
-                obs_streaming = await client.is_streaming()
-            except ObsApiError as exc:
-                logger.info("Failed to query existing OBS stream before switch: %s", exc)
-            else:
-                if obs_streaming:
-                    await client.stop_stream()
-            await client.set_stream_service_settings_and_start(credential)
-            self._obs_streaming_started = True
-            self.set_status(f"已将 {credential.label.upper()} 填入 OBS 并启动推流。", success=True)
-        except ObsApiError as exc:
-            logger.info("Failed to write OBS stream settings: %s", exc)
-            if not auto:
-                self.set_status(f"启动 OBS 推流失败: {exc}", error=True)
-            elif self.credentials:
+            outcome = await self.live_control_service.start_obs_stream(settings)
+            self._apply_service_state(self.live_control_service.state)
+            if outcome.success:
+                credential = self.credentials[0] if self.credentials else None
+                label = credential.label.upper() if credential is not None else "RTMP"
+                self.set_status(f"已将 {label} 填入 OBS 并启动推流。", success=True)
+            elif not auto and outcome.error is not None:
+                self.set_status(outcome.error.message, error=True)
+            elif auto and self.credentials:
                 self.set_status("直播已开始，RTMP 凭证已生成；OBS 自动推流失败，可手动复制地址和密钥。", error=True)
         except Exception as exc:
             logger.exception("Unexpected OBS write failure")
@@ -1267,7 +1110,7 @@ class LiveControlDialog(QDialog):
         prompt.setWordWrap(True)
         layout.addWidget(prompt)
 
-        bio = self.auth_service.generate_qr_image(url)
+        bio = self.live_control_service.generate_qr_image(url)
         if bio:
             image = QImage.fromData(bio.getvalue())
             label = QLabel()

--- a/src/bilihud/live_control_ports.py
+++ b/src/bilihud/live_control_ports.py
@@ -1,0 +1,129 @@
+"""Ports separating live-control application logic from infrastructure."""
+
+from __future__ import annotations
+
+from io import BytesIO
+from typing import Protocol
+
+from .domain.live_control import (
+    LiveAreaGroup,
+    LiveSessionInfo,
+    LiveStartResponse,
+    LiveVersion,
+    ObsSettings,
+    RoomInfo,
+    StreamCredential,
+)
+
+
+class LiveControlApiError(RuntimeError):
+    """Normalized failure raised by a Bilibili live-control adapter."""
+
+    def __init__(self, message: str, code: int | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class ObsAdapterError(RuntimeError):
+    """Normalized failure raised by an OBS adapter."""
+
+
+class LiveControlApi(Protocol):
+    """Bilibili capability required by ``LiveControlService``."""
+
+    async def open_session(self) -> LiveSessionInfo:
+        """Open an application-owned authenticated or anonymous session."""
+        ...
+
+    async def close_session(self) -> None:
+        """Close the current session and release its network resources."""
+        ...
+
+    async def load_area_groups(self) -> tuple[LiveAreaGroup, ...]:
+        """Load normalized live parent areas and sub-areas."""
+        ...
+
+    async def get_room_info(self, room_id: int) -> RoomInfo:
+        """Load normalized information for one room."""
+        ...
+
+    async def update_room_title(self, room_id: int, title: str) -> None:
+        """Update one room title through Bilibili."""
+        ...
+
+    async def update_room_area(self, room_id: int, area_id: str) -> None:
+        """Update one room area through Bilibili."""
+        ...
+
+    async def get_live_version(self) -> LiveVersion:
+        """Load the version metadata required by the start-live endpoint."""
+        ...
+
+    async def start_live(self, room_id: int, area_id: str, version: LiveVersion) -> LiveStartResponse:
+        """Start one live room and normalize credentials or verification data."""
+        ...
+
+    async def stop_live(self, room_id: int) -> None:
+        """Stop one live room through Bilibili."""
+        ...
+
+
+class ObsAdapter(Protocol):
+    """OBS capability required by the live-control application service."""
+
+    async def check_connection(self, settings: ObsSettings) -> None:
+        """Verify that OBS WebSocket accepts the supplied settings."""
+        ...
+
+    async def is_streaming(self, settings: ObsSettings) -> bool:
+        """Return the current OBS streaming state."""
+        ...
+
+    async def stop_stream(self, settings: ObsSettings) -> None:
+        """Stop the current OBS stream."""
+        ...
+
+    async def set_stream_service_settings_and_start(
+        self,
+        settings: ObsSettings,
+        credential: StreamCredential,
+    ) -> None:
+        """Write a stream credential to OBS and start streaming."""
+        ...
+
+    def is_process_running(self) -> bool:
+        """Return whether an OBS process is currently running."""
+        ...
+
+    def launch(self) -> None:
+        """Launch OBS and return after the process has been handed off."""
+        ...
+
+
+class LiveControlSecrets(Protocol):
+    """Secure and presentation-neutral capabilities used by live control."""
+
+    def load_obs_password(self) -> str | None:
+        """Load the OBS password from secure storage."""
+        ...
+
+    def save_obs_password(self, password: str) -> bool:
+        """Save the OBS password to secure storage."""
+        ...
+
+    def clear_obs_password(self) -> None:
+        """Remove the OBS password from secure storage."""
+        ...
+
+    def generate_qr_image(self, url: str) -> BytesIO | None:
+        """Generate QR image bytes for a verification URL."""
+        ...
+
+
+__all__ = (
+    "LiveControlApi",
+    "LiveControlApiError",
+    "LiveControlSecrets",
+    "ObsAdapter",
+    "ObsAdapterError",
+)

--- a/src/bilihud/live_control_service.py
+++ b/src/bilihud/live_control_service.py
@@ -1,0 +1,786 @@
+"""Application orchestration for Bilibili live-room and OBS controls."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import replace
+from io import BytesIO
+
+from .config import ConfigStore
+from .domain.live_control import (
+    LiveControlError,
+    LiveControlErrorCode,
+    LiveControlOperationResult,
+    LiveControlSettings,
+    LiveControlState,
+    LiveSessionInfo,
+    ObsCheckOutcome,
+    ObsSettings,
+    ObsStreamOutcome,
+    RoomInfo,
+    SessionStatus,
+    SettingsSaveOutcome,
+    StartLiveOutcome,
+    StartLiveStatus,
+    StopLiveOutcome,
+    StopLiveStatus,
+    obs_cleanup_after_stop_state,
+    pick_primary_credential,
+    room_area_needs_update,
+    room_title_needs_update,
+    start_live_confirmation_needed,
+)
+from .helpers import validate_room_id
+from .live_control_ports import (
+    LiveControlApi,
+    LiveControlApiError,
+    LiveControlSecrets,
+    ObsAdapter,
+    ObsAdapterError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class LiveControlService:
+    """Own live-control session lifecycle and coordinate typed external ports."""
+
+    def __init__(
+        self,
+        *,
+        api: LiveControlApi,
+        obs: ObsAdapter,
+        config_store: ConfigStore,
+        secrets: LiveControlSecrets,
+    ) -> None:
+        """Create a service whose network, OBS, and secret ownership is explicit."""
+        self._api = api
+        self._obs = obs
+        self._config_store = config_store
+        self._secrets = secrets
+        self._state = LiveControlState()
+        self._generation = 0
+        self._operation_gate = asyncio.Lock()
+        self._active_operation: str | None = None
+        self._operation_finished = asyncio.Event()
+        self._operation_finished.set()
+        self._close_gate = asyncio.Lock()
+        self._close_finished = asyncio.Event()
+        self._close_finished.set()
+        self._closing = False
+        self._shutting_down = False
+        self._shutdown_complete = False
+
+    @property
+    def state(self) -> LiveControlState:
+        """Return the latest immutable state snapshot for presentation binding."""
+        return self._state
+
+    def load_settings(self) -> LiveControlSettings:
+        """Load typed form defaults and the OBS password through their boundaries."""
+        config = self._config_store.load()
+        password = self._secrets.load_obs_password()
+        return LiveControlSettings(
+            room_id=config.room_id,
+            live_title=config.live_title,
+            live_parent_area_id=config.live_parent_area_id,
+            live_area_id=config.live_area_id,
+            obs_host=config.obs_host,
+            obs_port=config.obs_port,
+            obs_password=password if password is not None else "",
+        )
+
+    def save_settings(self, settings: LiveControlSettings) -> SettingsSaveOutcome:
+        """Persist form settings and the OBS password, reporting partial failures."""
+        current = self._config_store.load()
+        config = replace(
+            current,
+            room_id=settings.room_id,
+            live_title=settings.live_title,
+            live_parent_area_id=settings.live_parent_area_id,
+            live_area_id=settings.live_area_id,
+            obs_host=settings.obs_host,
+            obs_port=settings.obs_port,
+        )
+        config_saved = self._config_store.save(config)
+        if settings.obs_password:
+            secret_saved = self._secrets.save_obs_password(settings.obs_password)
+        else:
+            self._secrets.clear_obs_password()
+            secret_saved = True
+        if config_saved and secret_saved:
+            return SettingsSaveOutcome(success=True)
+        return SettingsSaveOutcome(
+            success=False,
+            error=LiveControlError(
+                LiveControlErrorCode.PERSISTENCE_FAILURE,
+                "直播控制设置保存失败。",
+            ),
+        )
+
+    def generate_qr_image(self, url: str) -> BytesIO | None:
+        """Generate verification QR bytes through the injected secret boundary."""
+        return self._secrets.generate_qr_image(url)
+
+    async def initialize(self, room_id: int | None) -> LiveControlOperationResult:
+        """Open the session, load areas, and optionally load the selected room."""
+        operation_error = await self._claim_operation("initialize")
+        if operation_error is not None:
+            return LiveControlOperationResult(self._state, operation_error)
+
+        generation = self._begin_generation()
+        try:
+            session_info = await self._api.open_session()
+            if not self._is_current(generation):
+                return LiveControlOperationResult(self._state)
+            self._state = replace(
+                self._state,
+                session=session_info,
+                areas=(),
+                room_info=None,
+                credentials=(),
+                obs_connected=False,
+                obs_streaming=None,
+            )
+
+            areas = await self._api.load_area_groups()
+            if not self._is_current(generation):
+                return LiveControlOperationResult(self._state)
+            self._state = replace(self._state, areas=areas)
+
+            if room_id is not None and not validate_room_id(room_id):
+                return LiveControlOperationResult(
+                    self._state,
+                    LiveControlError(LiveControlErrorCode.INVALID_ROOM, "房间号无效。"),
+                )
+            if room_id is not None:
+                result = await self._load_room_info(generation, room_id)
+                if result.error is not None:
+                    return result
+            return LiveControlOperationResult(self._state)
+        except asyncio.CancelledError:
+            raise
+        except LiveControlApiError as exc:
+            return LiveControlOperationResult(self._state, self._api_error(exc))
+        finally:
+            await self._release_operation("initialize")
+
+    async def load_room_info(self, room_id: int | None) -> LiveControlOperationResult:
+        """Load room metadata while invalidating stale concurrent loads."""
+        operation_error = await self._claim_operation("load-room-info")
+        if operation_error is not None:
+            return LiveControlOperationResult(self._state, operation_error)
+
+        generation = self._begin_generation()
+        try:
+            if room_id is None or not validate_room_id(room_id):
+                self._state = replace(self._state, room_info=None, credentials=())
+                return LiveControlOperationResult(
+                    self._state,
+                    LiveControlError(LiveControlErrorCode.INVALID_ROOM, "房间号无效。"),
+                )
+            return await self._load_room_info(generation, room_id)
+        except asyncio.CancelledError:
+            raise
+        except LiveControlApiError as exc:
+            self._state = replace(self._state, room_info=None, credentials=())
+            return LiveControlOperationResult(self._state, self._api_error(exc))
+        finally:
+            await self._release_operation("load-room-info")
+
+    async def update_title(self, room_id: int | None, title: str) -> LiveControlOperationResult:
+        """Update a room title and reflect it in the service state."""
+        operation_error = await self._claim_operation("update-title")
+        if operation_error is not None:
+            return LiveControlOperationResult(self._state, operation_error)
+
+        generation = self._begin_generation()
+        try:
+            validation_error = self._validate_authenticated_room(room_id, title=title)
+            if validation_error is not None:
+                return LiveControlOperationResult(self._state, validation_error)
+            if room_id is None:
+                return LiveControlOperationResult(
+                    self._state,
+                    LiveControlError(LiveControlErrorCode.INVALID_ROOM, "房间号无效。"),
+                )
+            await self._api.update_room_title(room_id, title.strip())
+            if not self._is_current(generation):
+                return LiveControlOperationResult(self._state)
+            current = self._state.room_info
+            self._state = replace(
+                self._state,
+                room_info=RoomInfo(
+                    room_id=room_id,
+                    title=title.strip(),
+                    parent_area_id=current.parent_area_id if current and current.room_id == room_id else "",
+                    area_id=current.area_id if current and current.room_id == room_id else "",
+                    is_live=current.is_live if current and current.room_id == room_id else False,
+                ),
+            )
+            return LiveControlOperationResult(self._state)
+        except asyncio.CancelledError:
+            raise
+        except LiveControlApiError as exc:
+            return LiveControlOperationResult(self._state, self._api_error(exc))
+        finally:
+            await self._release_operation("update-title")
+
+    async def update_area(self, room_id: int | None, area_id: str) -> LiveControlOperationResult:
+        """Update a room area and reflect it in the service state."""
+        operation_error = await self._claim_operation("update-area")
+        if operation_error is not None:
+            return LiveControlOperationResult(self._state, operation_error)
+
+        generation = self._begin_generation()
+        try:
+            validation_error = self._validate_authenticated_room(room_id, area_id=area_id)
+            if validation_error is not None:
+                return LiveControlOperationResult(self._state, validation_error)
+            if room_id is None:
+                return LiveControlOperationResult(
+                    self._state,
+                    LiveControlError(LiveControlErrorCode.INVALID_ROOM, "房间号无效。"),
+                )
+            await self._api.update_room_area(room_id, area_id)
+            if not self._is_current(generation):
+                return LiveControlOperationResult(self._state)
+            current = self._state.room_info
+            self._state = replace(
+                self._state,
+                room_info=RoomInfo(
+                    room_id=room_id,
+                    title=current.title if current and current.room_id == room_id else "",
+                    parent_area_id=self._parent_area_for(area_id),
+                    area_id=area_id,
+                    is_live=current.is_live if current and current.room_id == room_id else False,
+                ),
+            )
+            return LiveControlOperationResult(self._state)
+        except asyncio.CancelledError:
+            raise
+        except LiveControlApiError as exc:
+            return LiveControlOperationResult(self._state, self._api_error(exc))
+        finally:
+            await self._release_operation("update-area")
+
+    async def start_live(
+        self,
+        room_id: int | None,
+        title: str,
+        area_id: str,
+        obs_settings: ObsSettings | None,
+        *,
+        allow_obs_switch: bool = False,
+    ) -> StartLiveOutcome:
+        """Run the complete start-live workflow without touching HUD ownership."""
+        operation_error = await self._claim_operation("start-live")
+        if operation_error is not None:
+            return self._start_failure(StartLiveStatus.FAILED, operation_error)
+
+        generation = self._begin_generation()
+        try:
+            validation_error = self._validate_authenticated_room(room_id, title=title, area_id=area_id)
+            if validation_error is not None:
+                return self._start_failure(StartLiveStatus.FAILED, validation_error)
+            if room_id is None:
+                return self._start_failure(
+                    StartLiveStatus.FAILED,
+                    LiveControlError(LiveControlErrorCode.INVALID_ROOM, "房间号无效。"),
+                )
+            current = self._state.room_info
+            if current is not None and current.room_id == room_id and current.is_live:
+                error = LiveControlError(LiveControlErrorCode.ALREADY_LIVE, "当前直播间已经在直播。")
+                return self._start_failure(StartLiveStatus.ALREADY_LIVE, error)
+
+            obs_streaming = await self._read_obs_state(obs_settings, generation)
+            if not self._is_current(generation):
+                return self._stale_start_result()
+            if start_live_confirmation_needed(obs_streaming):
+                if not allow_obs_switch:
+                    error = LiveControlError(
+                        LiveControlErrorCode.OBS_SWITCH_REQUIRED,
+                        "OBS 当前正在推流，需要确认后才能切换。",
+                    )
+                    return StartLiveOutcome(
+                        StartLiveStatus.OBS_SWITCH_REQUIRED,
+                        self._state,
+                        error=error,
+                    )
+                if obs_settings is not None:
+                    try:
+                        await self._obs.stop_stream(obs_settings)
+                    except ObsAdapterError as exc:
+                        return self._start_failure(
+                            StartLiveStatus.FAILED,
+                            LiveControlError(LiveControlErrorCode.OBS_FAILURE, f"停止 OBS 推流失败: {exc}"),
+                        )
+
+            notice = await self._sync_room_before_start(room_id, title, area_id, generation)
+            if not self._is_current(generation):
+                return self._stale_start_result()
+            version = await self._api.get_live_version()
+            if not self._is_current(generation):
+                return self._stale_start_result()
+            response = await self._api.start_live(room_id, area_id, version)
+            if not self._is_current(generation):
+                return self._stale_start_result()
+            if response.code == 60024 or response.code == 60043:
+                error = LiveControlError(
+                    LiveControlErrorCode.VERIFICATION_REQUIRED,
+                    response.message or "本次开播需要验证。",
+                )
+                return StartLiveOutcome(
+                    StartLiveStatus.VERIFICATION_REQUIRED,
+                    self._state,
+                    error=error,
+                    verification_url=response.verification_url,
+                    notice=notice,
+                )
+            if response.code != 0:
+                return self._start_failure(
+                    StartLiveStatus.FAILED,
+                    LiveControlError(
+                        LiveControlErrorCode.API_FAILURE,
+                        f"开始直播失败: {response.message or 'Unknown Error'} ({response.code})",
+                    ),
+                )
+
+            self._state = replace(
+                self._state,
+                room_info=RoomInfo(
+                    room_id=room_id,
+                    title=title.strip(),
+                    parent_area_id=self._parent_area_for(area_id),
+                    area_id=area_id,
+                    is_live=True,
+                ),
+                credentials=response.credentials,
+            )
+            credentials_error: LiveControlError | None = None
+            if not response.credentials:
+                credentials_error = LiveControlError(
+                    LiveControlErrorCode.CREDENTIALS_MISSING,
+                    "直播已开始，但接口未返回可识别的推流凭证。",
+                )
+
+            obs_started = False
+            obs_error: LiveControlError | None = None
+            primary = pick_primary_credential(response.credentials)
+            if primary is not None and obs_settings is not None and obs_settings.is_valid:
+                try:
+                    await self._obs.set_stream_service_settings_and_start(obs_settings, primary)
+                except ObsAdapterError as exc:
+                    obs_error = LiveControlError(LiveControlErrorCode.OBS_FAILURE, f"启动 OBS 推流失败: {exc}")
+                    self._state = replace(self._state, obs_connected=False, obs_streaming=None)
+                else:
+                    obs_started = True
+                    self._state = replace(self._state, obs_connected=True, obs_streaming=True)
+
+            error = credentials_error if credentials_error is not None else obs_error
+            status = (
+                StartLiveStatus.STARTED_WITHOUT_CREDENTIALS
+                if credentials_error is not None
+                else StartLiveStatus.STARTED
+            )
+            return StartLiveOutcome(
+                status,
+                self._state,
+                error=error,
+                obs_started=obs_started,
+                notice=notice,
+            )
+        except asyncio.CancelledError:
+            raise
+        except LiveControlApiError as exc:
+            return self._start_failure(StartLiveStatus.FAILED, self._api_error(exc))
+        finally:
+            await self._release_operation("start-live")
+
+    async def stop_live(self, room_id: int | None, obs_settings: ObsSettings | None) -> StopLiveOutcome:
+        """Stop Bilibili live and best-effort clean up a known OBS stream."""
+        operation_error = await self._claim_operation("stop-live")
+        if operation_error is not None:
+            return StopLiveOutcome(StopLiveStatus.FAILED, self._state, operation_error)
+
+        generation = self._begin_generation()
+        try:
+            validation_error = self._validate_authenticated_room(room_id)
+            if validation_error is not None:
+                return StopLiveOutcome(StopLiveStatus.FAILED, self._state, validation_error)
+            if room_id is None:
+                return StopLiveOutcome(
+                    StopLiveStatus.FAILED,
+                    self._state,
+                    LiveControlError(LiveControlErrorCode.INVALID_ROOM, "房间号无效。"),
+                )
+            current = self._state.room_info
+            if current is not None and current.room_id == room_id and not current.is_live:
+                return StopLiveOutcome(
+                    StopLiveStatus.NOT_LIVE,
+                    self._state,
+                    LiveControlError(LiveControlErrorCode.NOT_LIVE, "当前直播间没有在直播。"),
+                )
+            await self._api.stop_live(room_id)
+            if not self._is_current(generation):
+                return StopLiveOutcome(StopLiveStatus.STOPPED, self._state)
+
+            self._state = replace(
+                self._state,
+                room_info=(
+                    replace(current, is_live=False)
+                    if current is not None and current.room_id == room_id
+                    else current
+                ),
+                credentials=(),
+            )
+            obs_streaming = await self._read_obs_state(obs_settings, generation)
+            should_stop_obs, obs_state = obs_cleanup_after_stop_state(obs_streaming)
+            if not should_stop_obs or obs_settings is None:
+                if obs_state == "unknown":
+                    error = LiveControlError(
+                        LiveControlErrorCode.OBS_FAILURE,
+                        "直播已停止；OBS 推流未能自动确认，请在 OBS 中手动确认。",
+                    )
+                    return StopLiveOutcome(
+                        StopLiveStatus.STOPPED_WITH_OBS_FAILURE,
+                        self._state,
+                        error=error,
+                        obs_was_streaming=obs_streaming,
+                    )
+                return StopLiveOutcome(StopLiveStatus.STOPPED, self._state, obs_was_streaming=obs_streaming)
+
+            try:
+                await self._obs.stop_stream(obs_settings)
+            except ObsAdapterError as exc:
+                error = LiveControlError(LiveControlErrorCode.OBS_FAILURE, f"停止 OBS 推流失败: {exc}")
+                return StopLiveOutcome(
+                    StopLiveStatus.STOPPED_WITH_OBS_FAILURE,
+                    self._state,
+                    error=error,
+                    obs_was_streaming=obs_streaming,
+                )
+            self._state = replace(self._state, obs_streaming=False, obs_connected=True)
+            return StopLiveOutcome(
+                StopLiveStatus.STOPPED,
+                self._state,
+                obs_was_streaming=obs_streaming,
+                obs_stopped=True,
+            )
+        except asyncio.CancelledError:
+            raise
+        except LiveControlApiError as exc:
+            return StopLiveOutcome(StopLiveStatus.FAILED, self._state, self._api_error(exc))
+        finally:
+            await self._release_operation("stop-live")
+
+    async def check_obs(self, settings: ObsSettings | None) -> ObsCheckOutcome:
+        """Check OBS and launch it when absent, without exposing process APIs to UI."""
+        if settings is None or not settings.is_valid:
+            return ObsCheckOutcome(
+                connected=False,
+                process_running=False,
+                error=LiveControlError(LiveControlErrorCode.INVALID_INPUT, "OBS 设置无效。"),
+            )
+        operation_error = await self._claim_operation("check-obs")
+        if operation_error is not None:
+            return ObsCheckOutcome(False, False, error=operation_error)
+        try:
+            try:
+                await self._obs.check_connection(settings)
+            except ObsAdapterError as exc:
+                self._state = replace(self._state, obs_connected=False, obs_streaming=None)
+                try:
+                    running = self._obs.is_process_running()
+                except ObsAdapterError as process_exc:
+                    return ObsCheckOutcome(
+                        False,
+                        False,
+                        error=LiveControlError(LiveControlErrorCode.OBS_FAILURE, str(process_exc)),
+                    )
+                if running:
+                    return ObsCheckOutcome(
+                        False,
+                        True,
+                        error=LiveControlError(
+                            LiveControlErrorCode.OBS_FAILURE,
+                            f"OBS 已启动，但 WebSocket 无法连接: {exc}",
+                        ),
+                    )
+                try:
+                    self._obs.launch()
+                except ObsAdapterError as launch_exc:
+                    return ObsCheckOutcome(
+                        False,
+                        False,
+                        error=LiveControlError(LiveControlErrorCode.OBS_FAILURE, f"启动 OBS 失败: {launch_exc}"),
+                    )
+                return ObsCheckOutcome(False, True, launched=True)
+            else:
+                self._state = replace(self._state, obs_connected=True)
+                return ObsCheckOutcome(True, True)
+        finally:
+            await self._release_operation("check-obs")
+
+    async def start_obs_stream(self, settings: ObsSettings | None) -> ObsStreamOutcome:
+        """Start OBS with the currently stored primary stream credential."""
+        if settings is None or not settings.is_valid:
+            return ObsStreamOutcome(
+                False,
+                LiveControlError(LiveControlErrorCode.INVALID_INPUT, "OBS 设置无效。"),
+            )
+        credential = pick_primary_credential(self._state.credentials)
+        if credential is None:
+            return ObsStreamOutcome(
+                False,
+                LiveControlError(LiveControlErrorCode.CREDENTIALS_MISSING, "没有可用于启动 OBS 推流的凭证。"),
+            )
+        operation_error = await self._claim_operation("start-obs")
+        if operation_error is not None:
+            return ObsStreamOutcome(False, operation_error)
+        try:
+            await self._obs.set_stream_service_settings_and_start(settings, credential)
+            self._state = replace(self._state, obs_connected=True, obs_streaming=True)
+            return ObsStreamOutcome(True)
+        except asyncio.CancelledError:
+            raise
+        except ObsAdapterError as exc:
+            self._state = replace(self._state, obs_connected=False, obs_streaming=None)
+            return ObsStreamOutcome(
+                False,
+                LiveControlError(LiveControlErrorCode.OBS_FAILURE, f"启动 OBS 推流失败: {exc}"),
+            )
+        finally:
+            await self._release_operation("start-obs")
+
+    async def stop_obs_stream(self, settings: ObsSettings | None) -> ObsStreamOutcome:
+        """Stop OBS through the injected adapter and report its result."""
+        if settings is None or not settings.is_valid:
+            return ObsStreamOutcome(
+                False,
+                LiveControlError(LiveControlErrorCode.INVALID_INPUT, "OBS 设置无效。"),
+            )
+        operation_error = await self._claim_operation("stop-obs")
+        if operation_error is not None:
+            return ObsStreamOutcome(False, operation_error)
+        try:
+            await self._obs.stop_stream(settings)
+            self._state = replace(self._state, obs_connected=True, obs_streaming=False)
+            return ObsStreamOutcome(True)
+        except asyncio.CancelledError:
+            raise
+        except ObsAdapterError as exc:
+            return ObsStreamOutcome(
+                False,
+                LiveControlError(LiveControlErrorCode.OBS_FAILURE, f"停止 OBS 推流失败: {exc}"),
+            )
+        finally:
+            await self._release_operation("stop-obs")
+
+    async def close(self) -> None:
+        """Invalidate in-flight work and close the service-owned API session."""
+        async with self._close_gate:
+            self._begin_generation()
+            self._closing = True
+            self._close_finished.clear()
+            try:
+                await self._operation_finished.wait()
+                await self._api.close_session()
+                self._state = replace(
+                    self._state,
+                    session=LiveSessionInfo(),
+                    room_info=None,
+                    credentials=(),
+                    obs_connected=False,
+                    obs_streaming=None,
+                )
+            finally:
+                self._closing = False
+                self._close_finished.set()
+
+    async def shutdown(self) -> None:
+        """Close the service permanently and make repeated shutdown calls harmless."""
+        if self._shutdown_complete:
+            return
+        self._shutting_down = True
+        await self.close()
+        self._shutdown_complete = True
+
+    async def _load_room_info(self, generation: int, room_id: int) -> LiveControlOperationResult:
+        """Load a room for an already claimed operation and guard stale responses."""
+        try:
+            room_info = await self._api.get_room_info(room_id)
+        except LiveControlApiError as exc:
+            self._state = replace(self._state, room_info=None, credentials=())
+            return LiveControlOperationResult(self._state, self._api_error(exc))
+        if not self._is_current(generation):
+            return LiveControlOperationResult(
+                self._state,
+                LiveControlError(LiveControlErrorCode.STALE, "直播间信息已过期。"),
+            )
+        self._state = replace(self._state, room_info=room_info, credentials=())
+        return LiveControlOperationResult(self._state)
+
+    async def _sync_room_before_start(
+        self,
+        room_id: int,
+        title: str,
+        area_id: str,
+        generation: int,
+    ) -> str:
+        """Synchronize changed room fields while preserving the rate-limit behavior."""
+        notice = ""
+        current = self._state.room_info
+        if room_title_needs_update(current, room_id, title):
+            try:
+                await self._api.update_room_title(room_id, title.strip())
+            except LiveControlApiError as exc:
+                if not _is_rate_limited(exc):
+                    raise
+                logger.info("Room title update skipped because Bilibili rate limited it: %s", exc)
+                notice = "直播间信息刚更新过，已跳过重复同步并继续开播..."
+            if self._is_current(generation) and not notice:
+                current = self._state.room_info
+                self._state = replace(
+                    self._state,
+                    room_info=RoomInfo(
+                        room_id=room_id,
+                        title=title.strip(),
+                        parent_area_id=current.parent_area_id if current and current.room_id == room_id else "",
+                        area_id=current.area_id if current and current.room_id == room_id else "",
+                        is_live=current.is_live if current and current.room_id == room_id else False,
+                    ),
+                )
+
+        current = self._state.room_info
+        if room_area_needs_update(current, room_id, area_id):
+            try:
+                await self._api.update_room_area(room_id, area_id)
+            except LiveControlApiError as exc:
+                if not _is_rate_limited(exc):
+                    raise
+                logger.info("Room area update skipped because Bilibili rate limited it: %s", exc)
+                notice = "直播间信息刚更新过，已跳过重复同步并继续开播..."
+            if self._is_current(generation) and not notice:
+                current = self._state.room_info
+                self._state = replace(
+                    self._state,
+                    room_info=RoomInfo(
+                        room_id=room_id,
+                        title=current.title if current and current.room_id == room_id else title.strip(),
+                        parent_area_id=self._parent_area_for(area_id),
+                        area_id=area_id,
+                        is_live=current.is_live if current and current.room_id == room_id else False,
+                    ),
+                )
+        return notice
+
+    async def _read_obs_state(self, settings: ObsSettings | None, generation: int) -> bool | None:
+        """Read OBS state without turning an unavailable optional integration into API failure."""
+        if settings is None or not settings.is_valid:
+            return None
+        try:
+            streaming = await self._obs.is_streaming(settings)
+        except ObsAdapterError as exc:
+            logger.info("Failed to query OBS stream status: %s", exc)
+            if self._is_current(generation):
+                self._state = replace(self._state, obs_connected=False, obs_streaming=None)
+            return None
+        if self._is_current(generation):
+            self._state = replace(self._state, obs_connected=True, obs_streaming=streaming)
+        return streaming
+
+    def _validate_authenticated_room(
+        self,
+        room_id: int | None,
+        *,
+        title: str | None = None,
+        area_id: str | None = None,
+    ) -> LiveControlError | None:
+        """Validate common room inputs and turn missing login into an explicit result."""
+        if room_id is None or not validate_room_id(room_id):
+            return LiveControlError(LiveControlErrorCode.INVALID_ROOM, "房间号无效。")
+        if title is not None and not title.strip():
+            return LiveControlError(LiveControlErrorCode.INVALID_INPUT, "直播标题不能为空。")
+        if area_id is not None and not area_id.strip():
+            return LiveControlError(LiveControlErrorCode.INVALID_INPUT, "直播分区不能为空。")
+        if self._state.session.status is SessionStatus.AUTHENTICATED:
+            return None
+        code = (
+            LiveControlErrorCode.LOGIN_EXPIRED
+            if self._state.session.from_saved_session
+            else LiveControlErrorCode.AUTHENTICATION_REQUIRED
+        )
+        message = (
+            "保存的登录状态已过期，请先重新扫码登录。"
+            if code is LiveControlErrorCode.LOGIN_EXPIRED
+            else "请先通过托盘菜单扫码登录。"
+        )
+        return LiveControlError(code, message)
+
+    def _parent_area_for(self, area_id: str) -> str:
+        """Find the normalized parent ID for a selected sub-area."""
+        for group in self._state.areas:
+            for area in group.areas:
+                if area.area_id == area_id:
+                    return group.parent_area_id
+        return ""
+
+    def _api_error(self, exc: LiveControlApiError) -> LiveControlError:
+        """Convert an infrastructure API error into the application error contract."""
+        return LiveControlError(LiveControlErrorCode.API_FAILURE, str(exc))
+
+    def _start_failure(self, status: StartLiveStatus, error: LiveControlError) -> StartLiveOutcome:
+        """Build a failed start result using the current immutable state."""
+        return StartLiveOutcome(status, self._state, error=error)
+
+    def _stale_start_result(self) -> StartLiveOutcome:
+        """Build a result for a start request invalidated by close or a newer operation."""
+        return self._start_failure(
+            StartLiveStatus.FAILED,
+            LiveControlError(LiveControlErrorCode.STALE, "开始直播操作已过期。"),
+        )
+
+    def _begin_generation(self) -> int:
+        """Invalidate callbacks from all previous workflows and return the new token."""
+        self._generation += 1
+        return self._generation
+
+    def _is_current(self, generation: int) -> bool:
+        """Return whether a workflow still owns the current generation."""
+        return generation == self._generation and not self._shutting_down
+
+    async def _claim_operation(self, name: str) -> LiveControlError | None:
+        """Claim one operation slot so duplicate requests return a typed result."""
+        while True:
+            async with self._operation_gate:
+                if self._shutting_down or self._shutdown_complete:
+                    return LiveControlError(LiveControlErrorCode.CLOSED, "直播控制服务已关闭。")
+                if self._closing:
+                    close_finished = self._close_finished
+                else:
+                    if self._active_operation is not None:
+                        return LiveControlError(
+                            LiveControlErrorCode.OPERATION_IN_PROGRESS,
+                            "已有直播控制操作正在进行，请稍候。",
+                        )
+                    self._active_operation = name
+                    self._operation_finished.clear()
+                    return None
+            await close_finished.wait()
+
+    async def _release_operation(self, name: str) -> None:
+        """Release the operation slot only when it is still owned by this workflow."""
+        async with self._operation_gate:
+            if self._active_operation == name:
+                self._active_operation = None
+                self._operation_finished.set()
+
+
+def _is_rate_limited(exc: LiveControlApiError) -> bool:
+    """Recognize Bilibili's duplicate room-update response at the adapter boundary."""
+    return exc.code == -1 and "操作太频繁" in str(exc)
+
+
+__all__ = ("LiveControlService",)

--- a/src/bilihud/obs_api.py
+++ b/src/bilihud/obs_api.py
@@ -9,7 +9,15 @@ from typing import Any
 
 import aiohttp
 
-from .live_api import StreamCredential
+from .domain.live_control import (
+    StreamCredential,
+)
+from .domain.live_control import (
+    obs_check_button_state as _obs_check_button_state,
+)
+from .domain.live_control import (
+    pick_primary_credential as _pick_primary_credential,
+)
 
 OBS_WEBSOCKET_RPC_VERSION = 1
 
@@ -24,9 +32,8 @@ def is_obs_process_name(command: str) -> bool:
 
 
 def obs_check_button_state(port_valid: bool, checking: bool, connected: bool) -> tuple[bool, str]:
-    if checking:
-        return False, "检查中"
-    return port_valid, "重新检查" if connected else "检查 OBS"
+    """Keep the historical OBS helper name while delegating pure domain logic."""
+    return _obs_check_button_state(port_valid, checking, connected)
 
 
 def is_obs_process_running(proc_root: str = "/proc") -> bool:
@@ -119,13 +126,8 @@ def obs_start_stream_requests(credential: StreamCredential) -> list[dict[str, An
 
 
 def pick_primary_credential(credentials: Sequence[StreamCredential]) -> StreamCredential | None:
-    for credential in credentials:
-        if credential.label == "rtmp-1":
-            return credential
-    for credential in credentials:
-        if credential.label.lower().startswith("rtmp"):
-            return credential
-    return credentials[0] if credentials else None
+    """Keep the historical OBS helper name while delegating pure domain logic."""
+    return _pick_primary_credential(credentials)
 
 
 class ObsWebSocketClient:

--- a/src/bilihud/services.py
+++ b/src/bilihud/services.py
@@ -8,6 +8,8 @@ from .config import ConfigStore, JsonConfigStore
 from .config_compat import LegacyConfigMigrator
 from .danmaku_client import DanmakuClient
 from .hud_ports import HudClientFactory
+from .infrastructure.live_control import BilibiliLiveControlApi, ObsWebSocketAdapter
+from .live_control_service import LiveControlService
 
 
 @dataclass(frozen=True, slots=True)
@@ -17,6 +19,7 @@ class AppServices:
     config_store: ConfigStore  # Shared typed settings boundary for all UI workflows.
     auth_service: AuthenticationService  # Shared authentication and secure-secret boundary.
     hud_client_factory: HudClientFactory  # Concrete HUD network adapter factory.
+    live_control_service: LiveControlService  # Live-control application workflow owner.
 
 
 def create_default_hud_client(
@@ -31,11 +34,19 @@ def create_default_hud_client(
 def create_default_services(config_path: Path | None = None) -> AppServices:
     """Build production adapters that share one secure session store instance."""
     session_store: SessionStore = KeyringSessionStore()
+    config_store = JsonConfigStore(
+        config_path,
+        migrator=LegacyConfigMigrator(session_store),
+    )
+    auth_service: AuthenticationService = BilibiliAuthService(session_store)
     return AppServices(
-        config_store=JsonConfigStore(
-            config_path,
-            migrator=LegacyConfigMigrator(session_store),
-        ),
-        auth_service=BilibiliAuthService(session_store),
+        config_store=config_store,
+        auth_service=auth_service,
         hud_client_factory=create_default_hud_client,
+        live_control_service=LiveControlService(
+            api=BilibiliLiveControlApi(auth_service),
+            obs=ObsWebSocketAdapter(),
+            config_store=config_store,
+            secrets=auth_service,
+        ),
     )

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -16,7 +16,11 @@ MESSAGE_CONSUMER_MODULE_NAMES: Final[tuple[str, ...]] = (
     "mirror_state",
     "mock_messages",
 )
-APPLICATION_MODULE_NAMES: Final[tuple[str, ...]] = ("hud_controller", "hud_ports")
+APPLICATION_MODULE_NAMES: Final[tuple[str, ...]] = (
+    "hud_controller",
+    "hud_ports",
+    "live_control_service",
+)
 
 
 @dataclass(frozen=True)
@@ -120,7 +124,7 @@ def test_message_consumers_do_not_import_blivedm_models() -> None:
 
 
 def test_presentation_uses_configuration_and_authentication_boundaries() -> None:
-    forbidden_modules = {"keyring"}
+    forbidden_modules = {"aiohttp", "keyring", "bilihud.live_api", "bilihud.obs_api"}
     forbidden_names = {"AuthManager", "KeyringSessionStore", "load_config", "save_config"}
     violations: list[str] = []
 
@@ -158,6 +162,26 @@ def test_hud_controller_keeps_presentation_and_concrete_network_outside_applicat
         for module in _imported_modules(path):
             if _is_forbidden(module, forbidden_prefixes):
                 violations.append(f"{name} imports {module}")
+
+    assert violations == []
+
+
+def test_live_control_service_keeps_concrete_network_and_presentation_outside_application() -> None:
+    forbidden_prefixes = frozenset(
+        {
+            "PyQt5",
+            "PyQt6",
+            "aiohttp",
+            "bilihud.auth",
+            "bilihud.live_api",
+            "bilihud.obs_api",
+        }
+    )
+    violations: list[str] = []
+    path = SOURCE_ROOT / "live_control_service.py"
+    for module in _imported_modules(path):
+        if _is_forbidden(module, forbidden_prefixes):
+            violations.append(f"live_control_service imports {module}")
 
     assert violations == []
 

--- a/tests/test_live_control_service.py
+++ b/tests/test_live_control_service.py
@@ -1,0 +1,231 @@
+import asyncio
+from collections.abc import Coroutine
+from io import BytesIO
+from typing import Any
+
+from bilihud.config import AppConfig
+from bilihud.domain.live_control import (
+    LiveArea,
+    LiveAreaGroup,
+    LiveControlErrorCode,
+    LiveSessionInfo,
+    LiveStartResponse,
+    LiveVersion,
+    ObsSettings,
+    RoomInfo,
+    SessionStatus,
+    StartLiveStatus,
+    StreamCredential,
+)
+from bilihud.live_control_service import LiveControlService
+
+
+class FakeLiveApi:
+    def __init__(
+        self,
+        *,
+        session: LiveSessionInfo | None = None,
+        room_info: RoomInfo | None = None,
+        start_response: LiveStartResponse | None = None,
+    ) -> None:
+        self.session = session if session is not None else LiveSessionInfo(SessionStatus.AUTHENTICATED)
+        self.room_info = room_info if room_info is not None else RoomInfo(7450109, "旧标题", "9", "371")
+        self.start_response = start_response if start_response is not None else LiveStartResponse(0, "ok")
+        self.start_calls = 0
+        self.updated_titles: list[str] = []
+        self.updated_areas: list[str] = []
+        self.version_started: asyncio.Event | None = None
+        self.version_release: asyncio.Event | None = None
+        self.closed = False
+
+    async def open_session(self) -> LiveSessionInfo:
+        return self.session
+
+    async def close_session(self) -> None:
+        self.closed = True
+
+    async def load_area_groups(self) -> tuple[LiveAreaGroup, ...]:
+        return (LiveAreaGroup("9", "游戏", (LiveArea("371", "主机游戏"),)),)
+
+    async def get_room_info(self, room_id: int) -> RoomInfo:
+        return self.room_info
+
+    async def update_room_title(self, room_id: int, title: str) -> None:
+        self.updated_titles.append(title)
+
+    async def update_room_area(self, room_id: int, area_id: str) -> None:
+        self.updated_areas.append(area_id)
+
+    async def get_live_version(self) -> LiveVersion:
+        if self.version_started is not None:
+            self.version_started.set()
+        if self.version_release is not None:
+            await self.version_release.wait()
+        return LiveVersion("1.0", 1)
+
+    async def start_live(self, room_id: int, area_id: str, version: LiveVersion) -> LiveStartResponse:
+        self.start_calls += 1
+        return self.start_response
+
+    async def stop_live(self, room_id: int) -> None:
+        return None
+
+
+class FakeObs:
+    def __init__(self, streaming: bool = False) -> None:
+        self.streaming = streaming
+        self.start_calls: list[StreamCredential] = []
+        self.stop_calls = 0
+
+    async def check_connection(self, settings: ObsSettings) -> None:
+        return None
+
+    async def is_streaming(self, settings: ObsSettings) -> bool:
+        return self.streaming
+
+    async def stop_stream(self, settings: ObsSettings) -> None:
+        self.stop_calls += 1
+        self.streaming = False
+
+    async def set_stream_service_settings_and_start(
+        self,
+        settings: ObsSettings,
+        credential: StreamCredential,
+    ) -> None:
+        self.start_calls.append(credential)
+        self.streaming = True
+
+    def is_process_running(self) -> bool:
+        return False
+
+    def launch(self) -> None:
+        return None
+
+
+class FakeConfigStore:
+    def __init__(self) -> None:
+        self.config = AppConfig()
+
+    def load(self) -> AppConfig:
+        return self.config
+
+    def save(self, config: AppConfig) -> bool:
+        self.config = config
+        return True
+
+
+class FakeSecrets:
+    def __init__(self) -> None:
+        self.password: str | None = None
+
+    def load_obs_password(self) -> str | None:
+        return self.password
+
+    def save_obs_password(self, password: str) -> bool:
+        self.password = password
+        return True
+
+    def clear_obs_password(self) -> None:
+        self.password = None
+
+    def generate_qr_image(self, url: str) -> BytesIO | None:
+        return None
+
+
+def make_service(api: FakeLiveApi, obs: FakeObs) -> LiveControlService:
+    return LiveControlService(
+        api=api,
+        obs=obs,
+        config_store=FakeConfigStore(),
+        secrets=FakeSecrets(),
+    )
+
+
+def run(coroutine: Coroutine[Any, Any, object]) -> object:
+    return asyncio.run(coroutine)
+
+
+def test_start_live_syncs_room_starts_obs_and_returns_credentials_without_qt() -> None:
+    credential = StreamCredential("rtmp-1", "rtmp://server", "key")
+    api = FakeLiveApi(start_response=LiveStartResponse(0, "ok", (credential,)))
+    obs = FakeObs()
+    service = make_service(api, obs)
+
+    async def scenario() -> None:
+        await service.initialize(7450109)
+        outcome = await service.start_live(
+            7450109,
+            "新标题",
+            "372",
+            ObsSettings("127.0.0.1", 4455, ""),
+        )
+
+        assert outcome.status is StartLiveStatus.STARTED
+        assert outcome.success
+        assert outcome.obs_started
+
+    run(scenario())
+    assert api.updated_titles == ["新标题"]
+    assert api.updated_areas == ["372"]
+    assert api.start_calls == 1
+    assert obs.start_calls == [credential]
+    assert service.state.room_info is not None
+    assert service.state.room_info.is_live
+
+
+def test_start_live_reports_missing_credentials_after_bilibili_accepts_request() -> None:
+    api = FakeLiveApi(start_response=LiveStartResponse(0, "ok", ()))
+    service = make_service(api, FakeObs())
+
+    async def scenario() -> None:
+        await service.initialize(7450109)
+        outcome = await service.start_live(7450109, "标题", "371", None)
+
+        assert outcome.status is StartLiveStatus.STARTED_WITHOUT_CREDENTIALS
+        assert outcome.success
+        assert outcome.error is not None
+        assert outcome.error.code is LiveControlErrorCode.CREDENTIALS_MISSING
+
+    run(scenario())
+    assert api.start_calls == 1
+
+
+def test_expired_saved_login_blocks_start_before_api_mutation() -> None:
+    api = FakeLiveApi(
+        session=LiveSessionInfo(SessionStatus.ANONYMOUS, from_saved_session=True),
+    )
+    service = make_service(api, FakeObs())
+
+    async def scenario() -> None:
+        await service.initialize(7450109)
+        outcome = await service.start_live(7450109, "标题", "371", None)
+
+        assert outcome.error is not None
+        assert outcome.error.code is LiveControlErrorCode.LOGIN_EXPIRED
+
+    run(scenario())
+    assert api.start_calls == 0
+
+
+def test_duplicate_start_returns_operation_in_progress_without_second_api_call() -> None:
+    api = FakeLiveApi()
+    api.version_started = asyncio.Event()
+    api.version_release = asyncio.Event()
+    service = make_service(api, FakeObs())
+
+    async def scenario() -> None:
+        await service.initialize(7450109)
+        first = asyncio.create_task(service.start_live(7450109, "标题", "371", None))
+        assert api.version_started is not None
+        await api.version_started.wait()
+
+        second = await service.start_live(7450109, "标题", "371", None)
+
+        assert second.error is not None
+        assert second.error.code is LiveControlErrorCode.OPERATION_IN_PROGRESS
+        assert api.version_release is not None
+        api.version_release.set()
+        await first
+
+    run(scenario())
+    assert api.start_calls == 1


### PR DESCRIPTION
## Summary

- Extract typed LiveControlService for live-room and OBS orchestration.
- Keep network, authentication, and OBS implementations behind adapters; keep the dialog focused on form binding and result presentation.
- Preserve session generation and stale-response protection, with explicit authentication, duplicate-operation, missing-credential, verification, and OBS outcomes.
- Add Qt-free service behavior tests and architecture import guards.

## Verification

- uv run pytest -q: 163 passed
- uv run ruff check --select=E9,F63,F7,F82 src/
- Targeted Ruff and ty checks for the changed service, adapters, domain models, and tests
- git diff --check
- uv build

## Risks

- Full-repository Ruff and ty still report pre-existing diagnostics in legacy Qt and third-party typing code; changed modules and fast Ruff checks pass.
- Runtime behavior still depends on existing Bilibili and OBS endpoints; adapter failure paths are covered by typed fakes.

Closes #26