### PR TITLE
refactor(platform): isolate overlay window backends

### DIFF
--- a/docs/architecture/module-boundaries.md
+++ b/docs/architecture/module-boundaries.md
@@ -34,6 +34,22 @@ stable design rule, not a list of current migration tasks.
   capability without importing the concrete server into application code.
 - `mirror_server` only serves coordinator-owned state and applies the image
   proxy allowlist, DNS address checks, redirect policy, and response limits.
+- `overlay_ports` owns toolkit-neutral window geometry, capability, result, and
+  drag-strategy contracts; it must not import Qt, ctypes, or desktop APIs.
+- `qt_window_host` is the presentation-side Qt binding for those contracts;
+  `infrastructure.window_platform` owns capability-provider selection,
+  `infrastructure.qt_window_platform` owns the portable Qt window baseline,
+  and `infrastructure.layer_shell` and `infrastructure.x11` isolate optional
+  native enhancements.
+- Layer Shell drag behavior is selected through an infrastructure strategy
+  registry: the existing KDE-compatible local-anchor strategy remains the
+  default, while niri uses global pointer deltas and output-bound clamping for
+  asynchronous compositor configure feedback.
+- `danmaku_widget` binds the `OverlayPlatform` capability snapshot and forwards
+  window gestures; desktop names and native handles do not appear in its
+  workflow logic. A new desktop-specific drag behavior, such as a Layer Shell
+  compositor-specific strategy, is added as a provider or strategy, not as a
+  desktop-name branch in the widget.
 - Presentation code binds state and commands; it does not own business workflows.
 - Application code owns use-case lifecycles and coordinates infrastructure through ports.
 - Domain code remains deterministic and independently testable whenever practical.

--- a/src/bilihud/danmaku_widget.py
+++ b/src/bilihud/danmaku_widget.py
@@ -1,14 +1,10 @@
 import asyncio
-import ctypes
 import html
 import logging
 import os
-import sys
 from collections.abc import Coroutine
-from ctypes import c_int, c_ulong, c_void_p
 from typing import Any
 
-import PyQt6.sip as sip
 from PyQt6.QtCore import QPoint, QSize, Qt, QTimer, QUrl, pyqtSignal, pyqtSlot
 from PyQt6.QtGui import (
     QAction,
@@ -16,7 +12,6 @@ from PyQt6.QtGui import (
     QCloseEvent,
     QColor,
     QFont,
-    QGuiApplication,
     QIcon,
     QImage,
     QPainter,
@@ -76,12 +71,6 @@ from .domain.messages import (
     make_system_message,
 )
 from .hud_controller import HudController
-from .layer_shell_loader import (
-    LAYER_SHELL_LIBRARY_NAME,
-    find_layer_shell_library,
-    gaming_mode_available,
-    should_disable_layer_shell,
-)
 from .lifecycle import TaskScope, TaskSupervisor
 from .live_api import get_anchor_live_room_id
 from .live_control_dialog import LiveControlDialog
@@ -89,7 +78,9 @@ from .live_emoticons import LiveEmoticon, LiveEmoticonPackage
 from .mirror_coordinator import MirrorCoordinator, MirrorOperationResult
 from .mirror_settings_dialog import MirrorSettingsDialog
 from .mock_messages import mock_message_batch
+from .overlay_ports import DragMode, OverlayOperationResult, OverlayPlatform, WindowPoint
 from .qr_login_dialog import QRLoginDialog
+from .qt_window_host import QtWindowHost
 from .services import AppServices, create_default_services
 
 logger = logging.getLogger(__name__)
@@ -421,67 +412,6 @@ class DanmakuInputDialog(QDialog):
             self.hide()
         super().keyPressEvent(event)
 
-class X11Helper:
-    """X11辅助类，用于直接调用XShape扩展实现点击穿透"""
-    _x11 = None
-    _xext = None
-
-    @classmethod
-    def init(cls):
-        if cls._x11: return
-        try:
-            cls._x11 = ctypes.cdll.LoadLibrary('libX11.so.6')
-            cls._xext = ctypes.cdll.LoadLibrary('libXext.so.6')
-
-            cls._x11.XOpenDisplay.restype = c_void_p
-            cls._x11.XOpenDisplay.argtypes = [c_void_p]
-            cls._x11.XFlush.argtypes = [c_void_p]
-            cls._x11.XCloseDisplay.argtypes = [c_void_p]
-
-            # XShapeCombineRectangles(display, dest, dest_kind, x_off, y_off, rectangles, n_rects, op, ordering)
-            cls._xext.XShapeCombineRectangles.argtypes = [
-                c_void_p, c_ulong, c_int, c_int, c_int, c_void_p, c_int, c_int, c_int
-            ]
-
-            # XShapeCombineMask(display, dest, dest_kind, x_off, y_off, src, op)
-            cls._xext.XShapeCombineMask.argtypes = [
-                c_void_p, c_ulong, c_int, c_int, c_int, c_void_p, c_int
-            ]
-        except Exception as e:
-            print(f"X11 init failed: {e}")
-
-    @classmethod
-    def set_click_through(cls, win_id, enabled):
-        """设置窗口是否通过Input Shape完全穿透"""
-        if sys.platform != 'linux': return
-
-        cls.init()
-        if not cls._x11 or not cls._xext: return
-
-        display = cls._x11.XOpenDisplay(None)
-        if not display:
-            print("Failed to open X Display")
-            return
-
-        ShapeInput = 2
-        ShapeSet = 0
-
-        try:
-            if enabled:
-                # 设置输入形状为空（0个矩形），使窗口对输入事件完全透明
-                cls._xext.XShapeCombineRectangles(
-                    display, win_id, ShapeInput, 0, 0, None, 0, ShapeSet, 0
-                )
-            else:
-                # 恢复默认输入形状（重置为None Mask），允许接收输入
-                cls._xext.XShapeCombineMask(
-                    display, win_id, ShapeInput, 0, 0, None, ShapeSet
-                )
-            cls._x11.XFlush(display)
-        finally:
-            cls._x11.XCloseDisplay(display)
-
-
 class DanmakuDelegate(QStyledItemDelegate):
     """
     High-performance delegate with Caching.
@@ -763,21 +693,19 @@ class DanmakuWidget(QWidget):
         self._mirror_settings_dialog: MirrorSettingsDialog | None = None  # Reused Mirror settings owner.
         self._qr_login_dialog: QRLoginDialog | None = None  # Active modal QR-login dialog, if any.
         self.is_gaming_mode = False
-        self.layer_shell_lib = None
-        self.layer_shell_disabled_reason = ""
+        self._window_host: QtWindowHost = QtWindowHost(self)
+        self.overlay_platform: OverlayPlatform = self.services.overlay_platform_factory(self._window_host)
+        prepare_result = self.overlay_platform.prepare()
+        if not prepare_result.succeeded:
+            logger.warning("Platform window preparation failed: %s", prepare_result.reason)
         config = self.config_store.load()
         self.mirror_coordinator.apply_config(config)
-        # Track Layer Shell position manually because Qt frameGeometry() is unreliable (returns 0,0)
-        self.layer_pos = QPoint(0, 0)
 
         # [Performance] Resize Debounce Timer
         self._resize_timer = QTimer(self)
         self._resize_timer.setSingleShot(True)
         self._resize_timer.setInterval(30) # 30ms Debounce
         self._resize_timer.timeout.connect(self._delayed_adjust_height)
-
-        # Load Layer Shell Library
-        self.load_layer_shell_lib()
 
         self.setup_window_properties()
         self.init_ui()
@@ -848,76 +776,13 @@ class DanmakuWidget(QWidget):
              # With Delegate + ResizeMode.Adjust, we just need to poke the layout
              self.danmaku_list.scheduleDelayedItemsLayout()
 
-    def load_layer_shell_lib(self):
-        try:
-            platform_name = QGuiApplication.platformName()
-            current_desktop = os.environ.get("XDG_CURRENT_DESKTOP", "")
-            if should_disable_layer_shell(platform_name, current_desktop):
-                self.layer_shell_disabled_reason = (
-                    "GNOME/Mutter Wayland does not support wlr-layer-shell; fullscreen overlay is unsupported."
-                )
-                print(f"Layer Shell disabled: {self.layer_shell_disabled_reason}")
-                return
-
-            package_dir = os.path.dirname(__file__)
-            lib_path = find_layer_shell_library(package_dir)
-            if lib_path:
-                self.layer_shell_lib = ctypes.CDLL(lib_path)
-
-                # Define argument types for safety
-                self.layer_shell_lib.make_overlay.argtypes = [ctypes.c_void_p]
-                self.layer_shell_lib.set_passthrough.argtypes = [ctypes.c_void_p, ctypes.c_bool]
-                self.layer_shell_lib.set_anchor_position.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_int]
-
-                # Check if new function exists (for backward compatibility during dev)
-                if hasattr(self.layer_shell_lib, 'set_keyboard_interactivity'):
-                    self.layer_shell_lib.set_keyboard_interactivity.argtypes = [ctypes.c_void_p, ctypes.c_bool]
-            else:
-                print(f"Layer Shell library not found at: {os.path.join(package_dir, LAYER_SHELL_LIBRARY_NAME)}")
-        except OSError as e:
-            err_msg = str(e)
-            if "version" in err_msg and "Qt" in err_msg and "not found" in err_msg:
-                print("\n" + "="*60)
-                print("CRITICAL ERROR: Qt Version Mismatch Detected!")
-                print(f"Error details: {e}")
-                print("-" * 60)
-                print("It seems you are using a pip-installed PyQt6 which conflicts with the system LayerShellQt library.")
-                print("Solution: Please use the system's PyQt6 package instead.")
-                print("  Fedora: sudo dnf install python3-pyqt6")
-                print("  Ubuntu/Debian: sudo apt install python3-pyqt6")
-                print("  Arch: sudo pacman -S python-pyqt6")
-                print("Then recreate your venv with: python3 -m venv --system-site-packages .venv")
-                print("="*60 + "\n")
-            else:
-                print(f"Failed to load Layer Shell library: {e}")
-        except Exception as e:
-            print(f"Failed to load Layer Shell library: {e}")
-
-    def activate_layer_shell(self):
-        """Invoke C++ bridge to promote window to Layer Shell Overlay"""
-        if self.layer_shell_lib:
-            try:
-                self.winId() # Ensure handle created
-                handle = self.windowHandle()
-                if handle:
-                    cpp_ptr = sip.unwrapinstance(handle)
-                    self.layer_shell_lib.make_overlay(ctypes.c_void_p(cpp_ptr))
-
-                    # Ensure interactivity is enabled by default (for Normal Mode)
-                    if hasattr(self.layer_shell_lib, 'set_keyboard_interactivity'):
-                        self.layer_shell_lib.set_keyboard_interactivity(ctypes.c_void_p(cpp_ptr), True)
-
-
-                    # [Fix] Sync initial position to bridge immediately
-                    # Because setAnchor(Top|Left) defaults to 0,0 margins if we don't set them
-                    if hasattr(self.layer_shell_lib, 'set_anchor_position'):
-                        # Important: layer_pos is relative to the screen we are on.
-                        # We assume initial setup put us on primary screen consistent with layer_pos
-                        self.layer_shell_lib.set_anchor_position(ctypes.c_void_p(cpp_ptr), self.layer_pos.x(), self.layer_pos.y())
-
-
-            except Exception as e:
-                print(f"Error activating Layer Shell: {e}")
+    def activate_layer_shell(self) -> OverlayOperationResult:
+        """Activate the injected platform adapter after the Qt surface is mapped."""
+        result = self.overlay_platform.activate()
+        self.update_gaming_mode_availability()
+        if not result.succeeded:
+            logger.warning("Platform window activation failed: %s", result.reason)
+        return result
 
     def setup_window_properties(self):
         """设置基本的窗口属性"""
@@ -929,22 +794,9 @@ class DanmakuWidget(QWidget):
         initial_x = screen_geo.width() - 330
         initial_y = 100
 
-        # Qt move expects global coordinates
-        self.move(
-            screen_geo.x() + initial_x,
-            screen_geo.y() + initial_y
-        )
-        self.layer_pos = QPoint(initial_x, initial_y)
+        # Qt move expects global coordinates.
+        self._window_host.move_window(WindowPoint(screen_geo.x() + initial_x, screen_geo.y() + initial_y))
         self.setWindowTitle("Danmaku Overlay")
-
-        # 基础无边框和置顶设置
-        flags = (
-            Qt.WindowType.FramelessWindowHint |
-            Qt.WindowType.WindowStaysOnTopHint |
-            Qt.WindowType.Window
-        )
-
-        self.setWindowFlags(flags)
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
 
     def paintEvent(self, event):
@@ -1240,13 +1092,11 @@ class DanmakuWidget(QWidget):
         self.add_message(make_system_message(message, level))
 
     def is_gaming_mode_available(self) -> bool:
-        return gaming_mode_available(
-            QGuiApplication.platformName(),
-            has_layer_shell=self.layer_shell_lib is not None,
-            layer_shell_disabled=bool(self.layer_shell_disabled_reason),
-        )
+        """Return whether the selected platform can provide gaming mode."""
+        return self.overlay_platform.capabilities.gaming_mode
 
-    def update_gaming_mode_availability(self):
+    def update_gaming_mode_availability(self) -> None:
+        """Bind platform capability state to both the window and tray controls."""
         available = self.is_gaming_mode_available()
         self.gaming_mode_btn.setEnabled(available)
         self.tray_gaming_action.setEnabled(available)
@@ -1254,8 +1104,12 @@ class DanmakuWidget(QWidget):
             self.gaming_mode_btn.setText("穿透不可用")
             self.gaming_mode_btn.setChecked(False)
             self.tray_gaming_action.setChecked(False)
-            self.gaming_mode_btn.setToolTip("GNOME Wayland 不支持全屏浮窗/锁定穿透，也不保证普通窗口置顶")
-            self.tray_gaming_action.setToolTip("GNOME Wayland 不支持全屏浮窗/锁定穿透，也不保证普通窗口置顶")
+            reason = self.overlay_platform.capabilities.unavailable_reason
+            if reason is None:
+                reason = "当前平台不支持"
+            tooltip = f"游戏模式不可用: {reason}\n当前仍可使用普通窗口模式。"
+            self.gaming_mode_btn.setToolTip(tooltip)
+            self.tray_gaming_action.setToolTip(tooltip)
 
     async def _send_danmaku_task(self, text: str):
         """Execute a text-send command through the application controller."""
@@ -1428,55 +1282,39 @@ class DanmakuWidget(QWidget):
 
         self.set_gaming_mode(new_state)
 
-    def show_gaming_mode_unavailable_message(self):
+    def show_gaming_mode_unavailable_message(self, reason: str | None = None) -> None:
+        """Explain a platform capability limitation without preventing normal use."""
+        limitation = reason
+        if limitation is None:
+            limitation = self.overlay_platform.capabilities.unavailable_reason
+        if limitation is None:
+            limitation = "当前平台不支持游戏模式"
         self.tray_icon.showMessage(
             "Danmaku Overlay",
-            "GNOME Wayland 不支持全屏浮窗/锁定穿透，也不保证普通窗口置顶。\n当前仅支持普通窗口移动。",
+            f"{limitation}\n当前仍可使用普通窗口模式。",
             QSystemTrayIcon.MessageIcon.Warning,
             3000,
         )
 
-    def set_gaming_mode(self, enabled: bool):
+    def set_gaming_mode(self, enabled: bool) -> OverlayOperationResult:
+        """Apply a platform mode transition and then update the presentation state."""
+        previous_state = self.is_gaming_mode
+        result = self.overlay_platform.set_gaming_mode(enabled)
+        if not result.succeeded:
+            self.gaming_mode_btn.setChecked(previous_state)
+            self.tray_gaming_action.setChecked(previous_state)
+            logger.warning("Gaming mode transition failed: %s", result.reason)
+            self.show_gaming_mode_unavailable_message(result.reason)
+            return result
+
         self.is_gaming_mode = enabled
-
-        # 保存当前位置和大小
-        current_geo = self.geometry()
-
-        # 同步各按钮状态
         self.tray_gaming_action.setChecked(enabled)
         self.gaming_mode_btn.setChecked(enabled)
 
-        # [Critical Fix] 重新构建Flags
-        flags = Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnTopHint | Qt.WindowType.Window
-
-        # Check if we are using Layer Shell
-        has_layer_shell = (self.layer_shell_lib is not None)
-
         if enabled:
-            # --- 开启穿透模式 (Gaming Mode) ---
-
-            # 1. 穿透模式核心Flags
-            # X11BypassWindowManagerHint: 绕过WM，确保能在全屏游戏之上显示
-            # ONLY use this if NOT using Layer Shell (i.e. on X11)
-            # AND strictly ensure we are NOT on Wayland (setting this on Wayland causes crash)
-            is_wayland = QGuiApplication.platformName().startswith('wayland')
-            if not has_layer_shell and not is_wayland:
-                flags |= Qt.WindowType.X11BypassWindowManagerHint
-
-            # WindowTransparentForInput: 输入事件穿透 (配合XShape)
-            # On Wayland with LayerShell, we use the bridge to set mask.
-            # On X11, we use XShape.
-            flags |= Qt.WindowType.WindowTransparentForInput
-            # WindowDoesNotAcceptFocus: 拒绝焦点，防止抢占游戏输入
-            flags |= Qt.WindowType.WindowDoesNotAcceptFocus
-
-            # For Layer Shell, we rely on setLayer(Overlay) which is done in activate_layer_shell
-
-            # 2. UI调整
             self.header_widget.hide()
             self.input_area.hide()
             self.danmaku_list.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-
             self.danmaku_list.setStyleSheet("""
                 QListWidget {
                     background: transparent;
@@ -1484,156 +1322,46 @@ class DanmakuWidget(QWidget):
                     border-radius: 8px;
                 }
             """)
-
-            # 3. 属性设置
-            self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
-            self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating, True) # 防止show()时触发activate导致日志警告
-
             self.tray_icon.showMessage(
                 "Danmaku Overlay",
                 "已进入穿透模式 (游戏覆盖)\n弹幕将显示在最顶层，鼠标操作将穿透。",
                 QSystemTrayIcon.MessageIcon.Information,
-                2000
+                2000,
             )
         else:
-            # --- 关闭穿透模式 (Normal Mode) ---
-
-            # 1. Normal Mode Flags
-            # 不需要 X11Bypass，也不需要 TransparentForInput
-            # 普通无边框窗口；在 GNOME Wayland 上，置顶 hint 可能被 compositor 忽略。
-
-            # 2. UI调整
             self.header_widget.show()
             self.input_area.show()
             self.danmaku_list.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
             self.danmaku_list.setStyleSheet("background: transparent; border: none;")
 
-            self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, False)
-            self.setAttribute(Qt.WidgetAttribute.WA_ShowWithoutActivating, False)
-
-        if has_layer_shell:
-            # --- Wayland Layer Shell Mode ---
-            # Do NOT call setWindowFlags or hide() as it recreates the window surface
-            # and breaks the Layer Shell integration.
-
-            # Apply native input region changes
-            try:
-                cpp_ptr = sip.unwrapinstance(self.windowHandle())
-                self.layer_shell_lib.set_passthrough(ctypes.c_void_p(cpp_ptr), enabled)
-
-                # Toggle keyboard interactivity
-                # Enabled (Gaming Mode) -> No keyboard
-                # Disabled (Normal Mode) -> OnDemand keyboard
-                if hasattr(self.layer_shell_lib, 'set_keyboard_interactivity'):
-                   self.layer_shell_lib.set_keyboard_interactivity(ctypes.c_void_p(cpp_ptr), not enabled)
-
-                # Force visual update since we skipped setWindowFlags/hide/show
-                # This ensures the dashed border stylesheet and layout changes (hidden header) are applied immediately
-                self.layout().activate()
-                self.danmaku_list.update()
-                self.update()
-
-            except Exception as e:
-                print(f"Failed to set Wayland passthrough: {e}")
-
-        else:
-            # --- X11 / Standard Mode ---
-            # Recreate window to apply flags (necessary for X11Bypass etc on XCB)
-            self.hide()
-            self.setWindowFlags(flags)
-
-            # 延迟执行显示操作
-            # 切换 BypassWindowManagerHint 会导致 Native Window 销毁重建
-            # 如果同步执行 show()，可能导致 X11 状态未同步而无法映射窗口
-            def restore_window_state():
-                # 恢复位置 (在窗口重建后应用)
-                self.setGeometry(current_geo)
-
-                # 显示并置顶
-                self.show()
-                self.raise_()
-
-                if not enabled:
-                    self.activateWindow()
-
-                # 平台相关穿透逻辑 (X11)
-                try:
-                    if QGuiApplication.platformName() == 'xcb':
-                        wid = int(self.winId())
-                        if wid > 0:
-                            X11Helper.set_click_through(wid, enabled)
-                except Exception as e:
-                    print(f"Failed to set platform settings: {e}")
-
-            # 这里的延时是必须的
-            QTimer.singleShot(50, restore_window_state)
-
         self._sync_audience_visibility()
+        return result
 
-    # --- 鼠标拖拽移动窗口逻辑 (Simple & Robust) ---
-    def mousePressEvent(self, event):
+    # --- 鼠标拖拽移动窗口逻辑 ---
+    def mousePressEvent(self, event) -> None:
         if not self.is_gaming_mode and event.button() == Qt.MouseButton.LeftButton:
-            if self.layer_shell_lib is None and QGuiApplication.platformName().startswith("wayland"):
-                handle = self.windowHandle()
-                if handle and hasattr(handle, "startSystemMove") and handle.startSystemMove():
-                    event.accept()
-                    return
-
-            self._dragging = True
-            # [Simple Local Drag]
-            # Just track the local position. 1:1 feel.
-            self._drag_local_pos = event.position().toPoint()
+            local_position = event.position().toPoint()
+            global_position = event.globalPosition().toPoint()
+            result = self.overlay_platform.begin_drag(
+                WindowPoint(local_position.x(), local_position.y()),
+                WindowPoint(global_position.x(), global_position.y()),
+            )
+            if result.mode is DragMode.UNAVAILABLE:
+                logger.warning("Window drag unavailable: %s", result.reason)
+                return
+            self._dragging = result.mode is DragMode.MANUAL
             event.accept()
 
-    def mouseMoveEvent(self, event):
+    def mouseMoveEvent(self, event) -> None:
         if self._dragging:
-            # Local Drag
-            local_pos = event.position().toPoint()
-            diff = local_pos - self._drag_local_pos
-
-            # [Spike Filter]
-            # Ignore massive jumps > 100px.
-            #if diff.manhattanLength() > 100:
-            #    return
-
-            has_layer_shell = (self.layer_shell_lib is not None)
-
-            if has_layer_shell:
-                try:
-                    cpp_ptr = sip.unwrapinstance(self.windowHandle())
-
-                    current_pos = self.layer_pos
-                    target_pos = current_pos + diff
-
-                    # [Screen Bounds Clamping]
-                    current_screen = self.windowHandle().screen()
-                    if current_screen:
-                        s_geo = current_screen.geometry()
-
-                        min_x = s_geo.x() - self.width() + 50
-                        max_x = s_geo.x() + s_geo.width() - 50
-                        min_y = s_geo.y() - 50
-                        max_y = s_geo.y() + s_geo.height() - 50
-
-                        clamped_x = max(min_x, min(target_pos.x(), max_x))
-                        clamped_y = max(min_y, min(target_pos.y(), max_y))
-
-                        target_pos = QPoint(clamped_x, clamped_y)
-
-                    self.layer_pos = target_pos
-
-                    self.layer_shell_lib.set_anchor_position(
-                        ctypes.c_void_p(cpp_ptr),
-                        self.layer_pos.x(),
-                        self.layer_pos.y()
-                    )
-
-                except Exception as e:
-                    print(f"Wayland drag error: {e}")
-            else:
-                new_pos = event.globalPosition().toPoint() - self._drag_local_pos
-                self.move(new_pos)
-
+            local_position = event.position().toPoint()
+            global_position = event.globalPosition().toPoint()
+            result = self.overlay_platform.update_drag(
+                WindowPoint(local_position.x(), local_position.y()),
+                WindowPoint(global_position.x(), global_position.y()),
+            )
+            if not result.succeeded:
+                logger.warning("Window drag update failed: %s", result.reason)
             event.accept()
 
     def resizeEvent(self, event):
@@ -1650,7 +1378,8 @@ class DanmakuWidget(QWidget):
         if not self.is_gaming_mode:
             self._resize_timer.start()
 
-    def mouseReleaseEvent(self, event):
+    def mouseReleaseEvent(self, event) -> None:
+        self.overlay_platform.end_drag()
         self._dragging = False
 
         # [Message Buffering]

--- a/src/bilihud/infrastructure/layer_shell.py
+++ b/src/bilihud/infrastructure/layer_shell.py
@@ -1,0 +1,486 @@
+"""Layer Shell bridge, platform adapter, and replaceable anchor drag strategy."""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from ..overlay_ports import (
+    DragMode,
+    DragStartResult,
+    OverlayCapabilities,
+    OverlayDragStrategy,
+    OverlayOperationResult,
+    OverlayPlatform,
+    WindowHost,
+    WindowPoint,
+    WindowPolicy,
+    WindowRectangle,
+)
+from .layer_shell_loader import find_layer_shell_library
+from .native import NativeFunction, load_native_function
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class _LayerShellBindings:
+    """Typed wrapper around the compiled Layer Shell bridge symbols."""
+
+    make_overlay: NativeFunction
+    set_passthrough: NativeFunction
+    set_anchor_position: NativeFunction
+    set_keyboard_interactivity: NativeFunction | None
+
+    @classmethod
+    def load(cls, package_dir: Path) -> tuple[_LayerShellBindings | None, str | None]:
+        """Load the bridge and validate required symbols without failing application startup."""
+        library_path = find_layer_shell_library(package_dir)
+        if library_path is None:
+            logger.info("Layer Shell bridge not found in %s", package_dir)
+            return None, "Layer Shell bridge library is not installed"
+
+        logger.info("Loading Layer Shell bridge: %s", library_path)
+        try:
+            library = ctypes.CDLL(library_path)
+            make_overlay = load_native_function(
+                library,
+                "make_overlay",
+                [ctypes.c_void_p],
+            )
+            set_passthrough = load_native_function(
+                library,
+                "set_passthrough",
+                [ctypes.c_void_p, ctypes.c_bool],
+            )
+            set_anchor_position = load_native_function(
+                library,
+                "set_anchor_position",
+                [ctypes.c_void_p, ctypes.c_int, ctypes.c_int],
+            )
+            set_keyboard_interactivity = load_native_function(
+                library,
+                "set_keyboard_interactivity",
+                [ctypes.c_void_p, ctypes.c_bool],
+            )
+        except OSError as exc:
+            logger.info("Layer Shell bridge load failed: %s", exc)
+            return None, f"Layer Shell bridge could not be loaded: {exc}"
+
+        if make_overlay is None:
+            logger.info("Layer Shell bridge missing required symbol: make_overlay")
+            return None, "Layer Shell bridge is missing symbol: make_overlay"
+        if set_passthrough is None:
+            logger.info("Layer Shell bridge missing required symbol: set_passthrough")
+            return None, "Layer Shell bridge is missing symbol: set_passthrough"
+        if set_anchor_position is None:
+            logger.info("Layer Shell bridge missing required symbol: set_anchor_position")
+            return None, "Layer Shell bridge is missing symbol: set_anchor_position"
+
+        logger.info(
+            "Layer Shell bridge loaded: keyboard_interactivity=%s",
+            set_keyboard_interactivity is not None,
+        )
+        return cls(
+            make_overlay=make_overlay,
+            set_passthrough=set_passthrough,
+            set_anchor_position=set_anchor_position,
+            set_keyboard_interactivity=set_keyboard_interactivity,
+        ), None
+
+
+class LayerShellBridge(Protocol):
+    """Native Layer Shell operations expressed without ctypes or Qt types."""
+
+    def make_overlay(self, window_pointer: int) -> None:
+        """Promote a mapped Qt window to the compositor overlay layer."""
+
+    def set_passthrough(self, window_pointer: int, enabled: bool) -> None:
+        """Set the native input region to empty or default."""
+
+    def set_anchor_position(self, window_pointer: int, x: int, y: int) -> None:
+        """Commit top-left Layer Shell margins."""
+
+    def set_keyboard_interactivity(self, window_pointer: int, enabled: bool) -> None:
+        """Set whether the overlay may receive keyboard focus on demand."""
+
+
+class _CtypesLayerShellBridge:
+    """Translate the compiled bridge's ctypes ABI into the platform strategy port."""
+
+    def __init__(self, bindings: _LayerShellBindings) -> None:
+        self._bindings = bindings
+
+    def make_overlay(self, window_pointer: int) -> None:
+        """Invoke the native overlay promotion function."""
+        self._bindings.make_overlay(ctypes.c_void_p(window_pointer))
+
+    def set_passthrough(self, window_pointer: int, enabled: bool) -> None:
+        """Invoke the native input-region function."""
+        self._bindings.set_passthrough(ctypes.c_void_p(window_pointer), enabled)
+
+    def set_anchor_position(self, window_pointer: int, x: int, y: int) -> None:
+        """Invoke the native margin function."""
+        self._bindings.set_anchor_position(ctypes.c_void_p(window_pointer), x, y)
+
+    def set_keyboard_interactivity(self, window_pointer: int, enabled: bool) -> None:
+        """Invoke the optional keyboard function when the installed bridge supports it."""
+        function = self._bindings.set_keyboard_interactivity
+        if function is not None:
+            function(ctypes.c_void_p(window_pointer), enabled)
+
+
+def load_layer_shell_bridge(package_dir: Path) -> tuple[LayerShellBridge | None, str | None]:
+    """Load a typed Layer Shell bridge while keeping ctypes private to this module."""
+    bindings, reason = _LayerShellBindings.load(package_dir)
+    if bindings is None:
+        return None, reason
+    return _CtypesLayerShellBridge(bindings), None
+
+
+def _initial_layer_position(
+    host: WindowHost,
+) -> tuple[WindowPoint, WindowRectangle | None]:
+    """Resolve one trusted screen-relative position and bind it to its output."""
+    known_position = host.window_position()
+    if known_position is None:
+        geometry = host.geometry()
+        known_position = WindowPoint(geometry.x, geometry.y)
+    screen = host.screen_geometry()
+    if screen is None:
+        return known_position, None
+    return WindowPoint(known_position.x - screen.x, known_position.y - screen.y), screen
+
+
+def _commit_layer_position(
+    host: WindowHost,
+    bridge: LayerShellBridge,
+    position: WindowPoint,
+) -> OverlayOperationResult:
+    """Commit one screen-relative position through the typed Layer Shell bridge."""
+    pointer = host.native_window_pointer()
+    if pointer is None:
+        return OverlayOperationResult.failure("Layer Shell 窗口句柄不可用")
+    try:
+        bridge.set_anchor_position(pointer, position.x, position.y)
+    except (OSError, RuntimeError, ctypes.ArgumentError) as exc:
+        return OverlayOperationResult.failure(f"Layer Shell 位置更新失败: {exc}")
+    return OverlayOperationResult.success()
+
+
+def _clamp_layer_position(
+    host: WindowHost,
+    screen: WindowRectangle | None,
+    position: WindowPoint,
+) -> WindowPoint:
+    """Keep a Layer Shell surface reachable within its bound output."""
+    active_screen = screen
+    if active_screen is None:
+        active_screen = host.screen_geometry()
+    if active_screen is None:
+        return position
+    geometry = host.geometry()
+    min_x = -geometry.width + 50
+    max_x = active_screen.width - 50
+    min_y = -50
+    max_y = active_screen.height - 50
+    return WindowPoint(
+        x=max(min_x, min(position.x, max_x)),
+        y=max(min_y, min(position.y, max_y)),
+    )
+
+
+class LayerShellAnchorDragStrategy:
+    """Keep the existing KDE-friendly margin drag behavior behind a replaceable strategy."""
+
+    def __init__(self, host: WindowHost, bridge: LayerShellBridge) -> None:
+        self._host = host
+        self._bridge = bridge
+        self._position = WindowPoint(0, 0)
+        self._drag_origin: WindowPoint | None = None
+        self._position_synchronized = False
+
+    def synchronize_position(self) -> OverlayOperationResult:
+        """Derive the initial Layer Shell margin from the host's trusted position."""
+        if self._position_synchronized:
+            return _commit_layer_position(self._host, self._bridge, self._position)
+        self._position, _screen = _initial_layer_position(self._host)
+        result = _commit_layer_position(self._host, self._bridge, self._position)
+        if result.succeeded:
+            self._position_synchronized = True
+        return result
+
+    def begin_drag(
+        self,
+        local_position: WindowPoint,
+        global_position: WindowPoint,
+    ) -> DragStartResult:
+        """Start anchor movement from the fixed local coordinate used by KDE."""
+        del global_position
+        self._drag_origin = local_position
+        return DragStartResult(DragMode.MANUAL)
+
+    def update_drag(
+        self,
+        local_position: WindowPoint,
+        global_position: WindowPoint,
+    ) -> OverlayOperationResult:
+        """Apply the press-relative pointer delta and clamp the overlay to its screen."""
+        del global_position
+        drag_origin = self._drag_origin
+        if drag_origin is None:
+            return OverlayOperationResult.failure("Layer Shell 拖动尚未开始")
+
+        # The compositor moves the Layer Shell surface while Qt keeps its local
+        # event origin stable. Preserve the existing KDE anchor semantics.
+        delta = local_position.difference(drag_origin)
+        target = _clamp_layer_position(self._host, None, self._position.offset(delta.x, delta.y))
+        result = _commit_layer_position(self._host, self._bridge, target)
+        if result.succeeded:
+            self._position = target
+        return result
+
+    def end_drag(self) -> None:
+        """Release the local pointer anchor."""
+        self._drag_origin = None
+
+
+
+class NiriLayerShellDragStrategy:
+    """Use global pointer deltas for compositors with asynchronous configure feedback."""
+
+    def __init__(self, host: WindowHost, bridge: LayerShellBridge) -> None:
+        self._host = host
+        self._bridge = bridge
+        self._position = WindowPoint(0, 0)
+        self._last_global_position: WindowPoint | None = None
+        self._screen: WindowRectangle | None = None
+        self._position_synchronized = False
+
+    def synchronize_position(self) -> OverlayOperationResult:
+        """Synchronize the anchor and bind future clamping to the same output."""
+        if self._position_synchronized:
+            return _commit_layer_position(self._host, self._bridge, self._position)
+        self._position, self._screen = _initial_layer_position(self._host)
+        result = _commit_layer_position(self._host, self._bridge, self._position)
+        if result.succeeded:
+            self._position_synchronized = True
+        return result
+
+    def begin_drag(
+        self,
+        local_position: WindowPoint,
+        global_position: WindowPoint,
+    ) -> DragStartResult:
+        """Start integrating global pointer motion independently from local surface feedback."""
+        del local_position
+        self._last_global_position = global_position
+        return DragStartResult(DragMode.MANUAL)
+
+    def update_drag(
+        self,
+        local_position: WindowPoint,
+        global_position: WindowPoint,
+    ) -> OverlayOperationResult:
+        """Apply one global delta and discard overdrag at the output edge."""
+        del local_position
+        previous_global_position = self._last_global_position
+        if previous_global_position is None:
+            return OverlayOperationResult.failure("niri Layer Shell 拖动尚未开始")
+
+        delta = global_position.difference(previous_global_position)
+        target = _clamp_layer_position(self._host, self._screen, self._position.offset(delta.x, delta.y))
+        result = _commit_layer_position(self._host, self._bridge, target)
+        if result.succeeded:
+            self._position = target
+            self._last_global_position = global_position
+        return result
+
+    def end_drag(self) -> None:
+        """Release the global pointer anchor."""
+        self._last_global_position = None
+
+
+class LayerShellWindowPlatform(OverlayPlatform):
+    """Layer Shell adapter whose drag implementation can be replaced independently."""
+
+    def __init__(
+        self,
+        host: WindowHost,
+        bridge: LayerShellBridge,
+        drag_strategy: OverlayDragStrategy | None = None,
+        fallback_factory: Callable[[str], OverlayPlatform] | None = None,
+    ) -> None:
+        self._host = host
+        self._bridge = bridge
+        if drag_strategy is None:
+            self._drag_strategy: OverlayDragStrategy = LayerShellAnchorDragStrategy(host, bridge)
+        else:
+            self._drag_strategy = drag_strategy
+        self._fallback_factory = fallback_factory
+        self._fallback_platform: OverlayPlatform | None = None
+        self._fallback_reason: str | None = None
+        self._activation_logged = False
+        self._gaming_mode = False
+        self._capabilities = OverlayCapabilities(
+            layer_shell=True,
+            gaming_mode=True,
+            click_through=True,
+            drag=True,
+        )
+
+    @property
+    def capabilities(self) -> OverlayCapabilities:
+        """Return Layer Shell capabilities."""
+        return self._capabilities
+
+    def prepare(self) -> OverlayOperationResult:
+        """Apply the base flags before Layer Shell takes ownership of the surface."""
+        try:
+            self._host.apply_window_policy(WindowPolicy(recreate_surface=True))
+        except RuntimeError as exc:
+            reason = f"Layer Shell 窗口初始化失败: {exc}"
+            self._mark_layer_shell_unavailable(reason)
+            return OverlayOperationResult.failure(reason)
+        return OverlayOperationResult.success()
+
+    def activate(self) -> OverlayOperationResult:
+        """Promote the mapped Qt window and synchronize its initial anchor position."""
+        if self._fallback_platform is not None:
+            return OverlayOperationResult.success()
+        if self._fallback_reason is not None:
+            return self._activate_fallback(self._fallback_reason)
+
+        pointer = self._host.native_window_pointer()
+        if pointer is None:
+            return self._activate_fallback("Layer Shell 窗口句柄不可用")
+        try:
+            self._bridge.make_overlay(pointer)
+            self._bridge.set_keyboard_interactivity(pointer, True)
+        except (OSError, RuntimeError, ctypes.ArgumentError) as exc:
+            return self._activate_fallback(f"Layer Shell 激活失败: {exc}")
+
+        result = self._drag_strategy.synchronize_position()
+        if not result.succeeded:
+            return self._activate_fallback(result.reason or "Layer Shell 初始位置同步失败")
+        if not self._activation_logged:
+            logger.info(
+                "Layer Shell overlay activated: drag_strategy=%s",
+                type(self._drag_strategy).__name__,
+            )
+            self._activation_logged = True
+        return OverlayOperationResult.success()
+
+    def _mark_layer_shell_unavailable(self, reason: str) -> None:
+        """Record a native failure before the widget has enough state to fall back."""
+        self._fallback_reason = reason
+        self._capabilities = OverlayCapabilities(
+            layer_shell=False,
+            gaming_mode=False,
+            click_through=False,
+            drag=True,
+            unavailable_reason=reason,
+        )
+
+    def _activate_fallback(self, reason: str) -> OverlayOperationResult:
+        """Replace failed Layer Shell activation with an ordinary Wayland window."""
+        self._mark_layer_shell_unavailable(reason)
+        fallback_factory = self._fallback_factory
+        if fallback_factory is None:
+            return OverlayOperationResult.failure(reason)
+
+        logger.warning("Layer Shell unavailable; falling back to an ordinary window: %s", reason)
+        geometry = self._host.geometry()
+        try:
+            fallback = fallback_factory(reason)
+            prepare_result = fallback.prepare()
+            if not prepare_result.succeeded:
+                fallback_reason = prepare_result.reason or "普通窗口初始化失败"
+                return OverlayOperationResult.failure(
+                    f"{reason}; 普通窗口降级失败: {fallback_reason}"
+                )
+            self._host.set_geometry(geometry)
+            self._host.show_window()
+            self._host.raise_window()
+            activate_result = fallback.activate()
+        except RuntimeError as exc:
+            return OverlayOperationResult.failure(f"{reason}; 普通窗口降级失败: {exc}")
+
+        if not activate_result.succeeded:
+            fallback_reason = activate_result.reason or "普通窗口激活失败"
+            return OverlayOperationResult.failure(
+                f"{reason}; 普通窗口降级失败: {fallback_reason}"
+            )
+        self._fallback_platform = fallback
+        self._capabilities = fallback.capabilities
+        return OverlayOperationResult.success()
+
+    def set_gaming_mode(self, enabled: bool) -> OverlayOperationResult:
+        """Toggle Layer Shell input and keyboard interactivity without recreating the surface."""
+        fallback_platform = self._fallback_platform
+        if fallback_platform is not None:
+            return fallback_platform.set_gaming_mode(enabled)
+        if self._fallback_reason is not None:
+            return OverlayOperationResult.failure(self._fallback_reason)
+
+        pointer = self._host.native_window_pointer()
+        if pointer is None:
+            return OverlayOperationResult.failure("Layer Shell 窗口句柄不可用")
+
+        try:
+            self._host.apply_window_policy(
+                WindowPolicy(
+                    does_not_accept_focus=enabled,
+                    show_without_activating=enabled,
+                    mouse_events_transparent=enabled,
+                    recreate_surface=False,
+                )
+            )
+            self._bridge.set_passthrough(pointer, enabled)
+            self._bridge.set_keyboard_interactivity(pointer, not enabled)
+            self._host.refresh()
+        except (OSError, RuntimeError, ctypes.ArgumentError) as exc:
+            return OverlayOperationResult.failure(f"Layer Shell 穿透模式切换失败: {exc}")
+
+        self._gaming_mode = enabled
+        return OverlayOperationResult.success()
+
+    def begin_drag(
+        self,
+        local_position: WindowPoint,
+        global_position: WindowPoint,
+    ) -> DragStartResult:
+        """Start the injected Layer Shell drag strategy in normal mode."""
+        fallback_platform = self._fallback_platform
+        if fallback_platform is not None:
+            return fallback_platform.begin_drag(local_position, global_position)
+        if self._fallback_reason is not None:
+            return DragStartResult(DragMode.UNAVAILABLE, self._fallback_reason)
+        if self._gaming_mode:
+            return DragStartResult(DragMode.UNAVAILABLE, "游戏模式下窗口不接受输入")
+        return self._drag_strategy.begin_drag(local_position, global_position)
+
+    def update_drag(
+        self,
+        local_position: WindowPoint,
+        global_position: WindowPoint,
+    ) -> OverlayOperationResult:
+        """Forward Layer Shell pointer motion to its selected strategy."""
+        fallback_platform = self._fallback_platform
+        if fallback_platform is not None:
+            return fallback_platform.update_drag(local_position, global_position)
+        if self._fallback_reason is not None:
+            return OverlayOperationResult.failure(self._fallback_reason)
+        return self._drag_strategy.update_drag(local_position, global_position)
+
+    def end_drag(self) -> None:
+        """Release Layer Shell drag state."""
+        fallback_platform = self._fallback_platform
+        if fallback_platform is not None:
+            fallback_platform.end_drag()
+            return
+        self._drag_strategy.end_drag()

--- a/src/bilihud/infrastructure/layer_shell_loader.py
+++ b/src/bilihud/infrastructure/layer_shell_loader.py
@@ -10,10 +10,6 @@ def should_disable_layer_shell(platform_name: str, current_desktop: str) -> bool
     return platform_name.startswith("wayland") and "gnome" in desktops
 
 
-def gaming_mode_available(platform_name: str, has_layer_shell: bool, layer_shell_disabled: bool) -> bool:
-    return has_layer_shell or not (platform_name.startswith("wayland") and layer_shell_disabled)
-
-
 def find_layer_shell_library(package_dir: str | Path) -> str | None:
     package_path = Path(package_dir)
     exact_path = package_path / LAYER_SHELL_LIBRARY_NAME

--- a/src/bilihud/infrastructure/native.py
+++ b/src/bilihud/infrastructure/native.py
@@ -1,0 +1,31 @@
+"""Small typed helpers for loading optional native-library symbols."""
+
+from __future__ import annotations
+
+import ctypes
+from typing import Protocol
+
+
+class NativeFunction(Protocol):
+    """Minimal typed view of a ctypes function pointer at the native boundary."""
+
+    argtypes: list[object] | None
+    restype: object | None
+
+    def __call__(self, *arguments: object) -> object:
+        """Invoke the configured native symbol."""
+
+
+def load_native_function(
+    library: ctypes.CDLL,
+    symbol: str,
+    argument_types: list[object],
+    return_type: object | None = None,
+) -> NativeFunction | None:
+    """Resolve and type one required or optional symbol at the native boundary."""
+    candidate: NativeFunction | None = getattr(library, symbol, None)
+    if candidate is None or not callable(candidate):
+        return None
+    candidate.argtypes = argument_types
+    candidate.restype = return_type
+    return candidate

--- a/src/bilihud/infrastructure/qt_window_platform.py
+++ b/src/bilihud/infrastructure/qt_window_platform.py
@@ -1,0 +1,243 @@
+"""Portable Qt window behavior shared by platform providers and fallbacks."""
+
+from __future__ import annotations
+
+import logging
+
+from PyQt6.QtCore import QTimer
+
+from ..overlay_ports import (
+    DragMode,
+    DragStartResult,
+    OverlayCapabilities,
+    OverlayOperationResult,
+    OverlayPlatform,
+    WindowHost,
+    WindowPoint,
+    WindowPolicy,
+    WindowRectangle,
+)
+from .x11 import X11InputShape
+
+logger = logging.getLogger(__name__)
+
+
+class _ManualWindowDragStrategy:
+    """Move a normal Qt window from a pointer anchor when system move is unavailable."""
+
+    def __init__(self, host: WindowHost, *, prefer_system_move: bool) -> None:
+        self._host = host
+        self._prefer_system_move = prefer_system_move
+        self._drag_local_position: WindowPoint | None = None
+
+    def begin_drag(
+        self,
+        local_position: WindowPoint,
+        global_position: WindowPoint,
+    ) -> DragStartResult:
+        """Prefer compositor-owned movement, then retain a manual fallback."""
+        del global_position
+        if self._prefer_system_move and self._host.start_system_move():
+            return DragStartResult(DragMode.SYSTEM)
+        self._drag_local_position = local_position
+        return DragStartResult(DragMode.MANUAL)
+
+    def update_drag(
+        self,
+        local_position: WindowPoint,
+        global_position: WindowPoint,
+    ) -> OverlayOperationResult:
+        """Move the window using the original local pointer anchor."""
+        del local_position
+        drag_local_position = self._drag_local_position
+        if drag_local_position is None:
+            return OverlayOperationResult.failure("普通窗口拖动尚未开始")
+        self._host.move_window(
+            global_position.offset(-drag_local_position.x, -drag_local_position.y)
+        )
+        return OverlayOperationResult.success()
+
+    def end_drag(self) -> None:
+        """Release the manual drag anchor."""
+        self._drag_local_position = None
+
+
+def _normal_window_policy() -> WindowPolicy:
+    """Return the stable policy used by every normal Qt window."""
+    return WindowPolicy(recreate_surface=True)
+
+
+def _gaming_window_policy(*, bypass_window_manager: bool) -> WindowPolicy:
+    """Return the Qt policy for a topmost, input-transparent window."""
+    return WindowPolicy(
+        bypass_window_manager=bypass_window_manager,
+        transparent_for_input=True,
+        does_not_accept_focus=True,
+        show_without_activating=True,
+        mouse_events_transparent=True,
+        recreate_surface=True,
+    )
+
+
+class QtWindowPlatform(OverlayPlatform):
+    """Provide portable Qt window behavior with optional native enhancements."""
+
+    def __init__(
+        self,
+        host: WindowHost,
+        *,
+        gaming_mode_supported: bool,
+        gaming_mode_reason: str | None,
+        bypass_window_manager: bool,
+        click_through: X11InputShape | None,
+        click_through_supported: bool,
+        prefer_system_move: bool,
+        restore_delay_ms: int = 0,
+    ) -> None:
+        self._host = host
+        self._gaming_mode_supported = gaming_mode_supported
+        self._gaming_mode_reason = gaming_mode_reason
+        self._bypass_window_manager = bypass_window_manager
+        self._click_through = click_through
+        self._gaming_mode = False
+        self._restore_delay_ms = restore_delay_ms
+        self._restore_generation = 0
+        self._drag_strategy = _ManualWindowDragStrategy(
+            host,
+            prefer_system_move=prefer_system_move,
+        )
+        self._capabilities = OverlayCapabilities(
+            layer_shell=False,
+            gaming_mode=gaming_mode_supported,
+            click_through=click_through_supported,
+            drag=True,
+            unavailable_reason=gaming_mode_reason if not gaming_mode_supported else None,
+        )
+
+    @property
+    def capabilities(self) -> OverlayCapabilities:
+        """Return the portable Qt capabilities and any unavailable feature reason."""
+        return self._capabilities
+
+    def prepare(self) -> OverlayOperationResult:
+        """Apply the normal window policy before the Qt surface is shown."""
+        try:
+            self._host.apply_window_policy(_normal_window_policy())
+        except RuntimeError as exc:
+            return OverlayOperationResult.failure(f"窗口初始化失败: {exc}")
+        return OverlayOperationResult.success()
+
+    def activate(self) -> OverlayOperationResult:
+        """Complete portable activation after the Qt surface has been mapped."""
+        return OverlayOperationResult.success()
+
+    def set_gaming_mode(self, enabled: bool) -> OverlayOperationResult:
+        """Recreate a normal Qt surface with the requested input policy."""
+        if not self._gaming_mode_supported:
+            reason = self._gaming_mode_reason
+            if reason is None:
+                reason = "当前平台不支持游戏模式"
+            return OverlayOperationResult.failure(reason)
+
+        geometry = self._host.geometry()
+        previous_mode = self._gaming_mode
+        try:
+            self._host.hide_window()
+            policy = (
+                _gaming_window_policy(bypass_window_manager=self._bypass_window_manager)
+                if enabled
+                else _normal_window_policy()
+            )
+            self._host.apply_window_policy(policy)
+        except RuntimeError as exc:
+            return OverlayOperationResult.failure(f"窗口模式切换失败: {exc}")
+
+        self._gaming_mode = enabled
+        self._restore_generation += 1
+        generation = self._restore_generation
+        if self._restore_delay_ms > 0:
+            # X11 may recreate the native surface when flags change. Wait for
+            # the new surface to be mapped before restoring geometry and shape.
+            def restore_window_state() -> None:
+                if generation != self._restore_generation:
+                    return
+                result = self._restore_window_state(geometry, enabled)
+                if not result.succeeded:
+                    self._gaming_mode = previous_mode
+                    logger.warning("窗口模式延迟恢复失败: %s", result.reason)
+
+            QTimer.singleShot(self._restore_delay_ms, restore_window_state)
+            return OverlayOperationResult.success()
+
+        result = self._restore_window_state(geometry, enabled)
+        if not result.succeeded:
+            self._gaming_mode = previous_mode
+            return result
+        return OverlayOperationResult.success()
+
+    def _restore_window_state(
+        self,
+        geometry: WindowRectangle,
+        enabled: bool,
+    ) -> OverlayOperationResult:
+        """Restore a recreated surface and apply its optional native input shape."""
+        try:
+            self._host.set_geometry(geometry)
+            self._host.show_window()
+            self._host.raise_window()
+            if not enabled:
+                self._host.activate_window()
+        except RuntimeError as exc:
+            return OverlayOperationResult.failure(f"窗口状态恢复失败: {exc}")
+
+        self._apply_optional_click_through(enabled)
+        self._host.refresh()
+        return OverlayOperationResult.success()
+
+    def _apply_optional_click_through(self, enabled: bool) -> None:
+        """Apply XShape when available while retaining Qt's portable input policy."""
+        click_through = self._click_through
+        if click_through is None:
+            return
+        window_id = self._host.native_window_id()
+        if window_id is None:
+            logger.warning("X11 click-through enhancement skipped: window id unavailable")
+            return
+        result = click_through.set_click_through(window_id, enabled)
+        if not result.succeeded:
+            logger.warning("X11 click-through enhancement failed: %s", result.reason)
+
+    def begin_drag(
+        self,
+        local_position: WindowPoint,
+        global_position: WindowPoint,
+    ) -> DragStartResult:
+        """Start the portable Qt drag strategy unless gaming mode is active."""
+        if self._gaming_mode:
+            return DragStartResult(DragMode.UNAVAILABLE, "游戏模式下窗口不接受输入")
+        return self._drag_strategy.begin_drag(local_position, global_position)
+
+    def update_drag(
+        self,
+        local_position: WindowPoint,
+        global_position: WindowPoint,
+    ) -> OverlayOperationResult:
+        """Forward pointer movement to the selected normal-window strategy."""
+        return self._drag_strategy.update_drag(local_position, global_position)
+
+    def end_drag(self) -> None:
+        """Release the portable drag strategy."""
+        self._drag_strategy.end_drag()
+
+
+def create_wayland_fallback_platform(host: WindowHost, reason: str) -> QtWindowPlatform:
+    """Build the ordinary-window fallback used when Layer Shell activation fails."""
+    return QtWindowPlatform(
+        host,
+        gaming_mode_supported=False,
+        gaming_mode_reason=reason,
+        bypass_window_manager=False,
+        click_through=None,
+        click_through_supported=False,
+        prefer_system_move=True,
+    )

--- a/src/bilihud/infrastructure/window_platform.py
+++ b/src/bilihud/infrastructure/window_platform.py
@@ -1,0 +1,299 @@
+"""Platform providers for overlay windows and normal-window dragging."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from PyQt6.QtGui import QGuiApplication
+
+from ..overlay_ports import (
+    OverlayDragStrategy,
+    OverlayPlatform,
+    WindowHost,
+)
+from .layer_shell import (
+    LayerShellAnchorDragStrategy,
+    LayerShellBridge,
+    LayerShellWindowPlatform,
+    NiriLayerShellDragStrategy,
+    load_layer_shell_bridge,
+)
+from .layer_shell_loader import should_disable_layer_shell
+from .qt_window_platform import QtWindowPlatform, create_wayland_fallback_platform
+from .x11 import X11InputShape
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class _PlatformContext:
+    """External platform facts shared by capability providers."""
+
+    platform_name: str
+    current_desktop: str
+    package_dir: Path
+
+    @property
+    def is_wayland(self) -> bool:
+        """Return whether Qt selected a Wayland backend."""
+        return self.platform_name.startswith("wayland")
+
+
+class _PlatformProvider(Protocol):
+    """Provider that claims a window backend when its capability is available."""
+
+    def select(
+        self,
+        context: _PlatformContext,
+        host: WindowHost,
+    ) -> tuple[OverlayPlatform | None, str | None]:
+        """Return an adapter and an optional diagnostic for this backend."""
+
+
+class _LayerShellDragProvider(Protocol):
+    """Create a drag strategy when a Layer Shell backend matches its behavior."""
+
+    def create(
+        self,
+        context: _PlatformContext,
+        host: WindowHost,
+        bridge: LayerShellBridge,
+    ) -> OverlayDragStrategy | None:
+        """Return a strategy or leave selection to the next provider."""
+
+
+class _NiriLayerShellDragProvider:
+    """Select the global-delta strategy for niri's asynchronous configure model."""
+
+    def create(
+        self,
+        context: _PlatformContext,
+        host: WindowHost,
+        bridge: LayerShellBridge,
+    ) -> OverlayDragStrategy | None:
+        """Claim desktops advertising niri without changing other Wayland desktops."""
+        desktops = {part.strip().lower() for part in context.current_desktop.split(":")}
+        if "niri" not in desktops:
+            return None
+        return NiriLayerShellDragStrategy(host, bridge)
+
+
+class _DefaultLayerShellDragProvider:
+    """Keep the existing KDE-compatible local-anchor strategy as the baseline."""
+
+    def create(
+        self,
+        context: _PlatformContext,
+        host: WindowHost,
+        bridge: LayerShellBridge,
+    ) -> OverlayDragStrategy | None:
+        """Provide the baseline strategy for every unclaimed Layer Shell desktop."""
+        del context
+        return LayerShellAnchorDragStrategy(host, bridge)
+
+
+class _LayerShellProvider:
+    """Select the existing KDE-friendly Layer Shell implementation when possible."""
+
+    def __init__(self, drag_providers: tuple[_LayerShellDragProvider, ...] | None = None) -> None:
+        """Build an ordered Layer Shell drag-strategy registry."""
+        if drag_providers is None:
+            drag_providers = (
+                _NiriLayerShellDragProvider(),
+                _DefaultLayerShellDragProvider(),
+            )
+        self._drag_providers = drag_providers
+
+    def select(
+        self,
+        context: _PlatformContext,
+        host: WindowHost,
+    ) -> tuple[OverlayPlatform | None, str | None]:
+        """Claim Wayland surfaces with a usable Layer Shell bridge."""
+        if not context.is_wayland:
+            return None, None
+        if should_disable_layer_shell(context.platform_name, context.current_desktop):
+            logger.info(
+                "Layer Shell provider skipped: compositor is not compatible (%s, desktop=%s)",
+                context.platform_name,
+                context.current_desktop or "unknown",
+            )
+            return None, "Wayland compositor does not provide the Layer Shell overlay capability"
+
+        bridge, reason = load_layer_shell_bridge(context.package_dir)
+        if bridge is None:
+            if reason is None:
+                reason = "Layer Shell overlay capability is unavailable"
+            logger.info("Layer Shell provider unavailable: %s", reason)
+            return None, reason
+
+        def fallback_factory(failure_reason: str) -> OverlayPlatform:
+            return create_wayland_fallback_platform(host, failure_reason)
+
+        for provider in self._drag_providers:
+            drag_strategy = provider.create(context, host, bridge)
+            if drag_strategy is not None:
+                logger.info(
+                    "Layer Shell provider selected: drag_strategy=%s",
+                    type(drag_strategy).__name__,
+                )
+                return (
+                    LayerShellWindowPlatform(
+                        host,
+                        bridge,
+                        drag_strategy,
+                        fallback_factory=fallback_factory,
+                    ),
+                    None,
+                )
+        return LayerShellWindowPlatform(host, bridge, fallback_factory=fallback_factory), None
+
+
+class _X11Provider:
+    """Select Qt/X11 behavior and add XShape as an optional input enhancement."""
+
+    def select(
+        self,
+        context: _PlatformContext,
+        host: WindowHost,
+    ) -> tuple[OverlayPlatform | None, str | None]:
+        """Claim the XCB backend without making XShape a startup requirement."""
+        if context.platform_name != "xcb":
+            return None, None
+
+        click_through, reason = X11InputShape.load()
+        if click_through is None:
+            logger.info("X11 provider selected without XShape enhancement: %s", reason)
+        else:
+            logger.info("X11 provider selected with XShape click-through enhancement")
+        return (
+            QtWindowPlatform(
+                host,
+                gaming_mode_supported=True,
+                gaming_mode_reason=None,
+                bypass_window_manager=True,
+                click_through=click_through,
+                click_through_supported=True,
+                prefer_system_move=False,
+                restore_delay_ms=50,
+            ),
+            reason,
+        )
+
+
+class _WaylandFallbackProvider:
+    """Keep ordinary window behavior on Wayland without compositor overlay support."""
+
+    def select(
+        self,
+        context: _PlatformContext,
+        host: WindowHost,
+    ) -> tuple[OverlayPlatform | None, str | None]:
+        """Claim unsupported Wayland backends with safe, non-overlay capabilities."""
+        if not context.is_wayland:
+            return None, None
+        reason = "Wayland compositor does not provide the Layer Shell overlay capability"
+        logger.info("Wayland fallback provider selected: %s", reason)
+        return (
+            create_wayland_fallback_platform(host, reason),
+            reason,
+        )
+
+
+class _GenericFallbackProvider:
+    """Provide the Qt capability baseline for macOS, Windows, and future backends."""
+
+    def select(
+        self,
+        context: _PlatformContext,
+        host: WindowHost,
+    ) -> tuple[OverlayPlatform | None, str | None]:
+        """Claim any backend not requiring a specialized native integration."""
+        del context
+        logger.info("Generic Qt provider selected")
+        return (
+            QtWindowPlatform(
+                host,
+                gaming_mode_supported=True,
+                gaming_mode_reason=None,
+                bypass_window_manager=False,
+                click_through=None,
+                click_through_supported=True,
+                prefer_system_move=False,
+            ),
+            None,
+        )
+
+
+class DefaultOverlayPlatformFactory:
+    """Select an overlay adapter through ordered capability providers."""
+
+    def __init__(self, providers: tuple[_PlatformProvider, ...] | None = None) -> None:
+        """Build a provider registry that can be replaced by tests or future backends."""
+        if providers is None:
+            providers = (
+                _LayerShellProvider(),
+                _X11Provider(),
+                _WaylandFallbackProvider(),
+                _GenericFallbackProvider(),
+            )
+        self._providers = providers
+
+    def __call__(self, host: WindowHost) -> OverlayPlatform:
+        """Create the selected adapter for one Qt window host."""
+        return self.create(host)
+
+    def create(self, host: WindowHost) -> OverlayPlatform:
+        """Probe external platform facts once and select the first claiming provider."""
+        context = _PlatformContext(
+            platform_name=QGuiApplication.platformName(),
+            current_desktop=self._current_desktop(),
+            package_dir=Path(__file__).resolve().parent.parent,
+        )
+        logger.info(
+            "Overlay platform probe: qt_platform=%s desktop=%s package_dir=%s",
+            context.platform_name,
+            context.current_desktop or "unknown",
+            context.package_dir,
+        )
+        last_reason: str | None = None
+        for provider in self._providers:
+            platform, reason = provider.select(context, host)
+            if reason is not None:
+                last_reason = reason
+                logger.info("Overlay provider diagnostic: %s", reason)
+            if platform is not None:
+                logger.info(
+                    "Overlay platform selected: %s capabilities=%s",
+                    type(platform).__name__,
+                    platform.capabilities,
+                )
+                return platform
+
+        fallback, fallback_reason = _GenericFallbackProvider().select(context, host)
+        if fallback is not None:
+            return fallback
+        reason = fallback_reason
+        if reason is None:
+            reason = last_reason
+        if reason is None:
+            reason = "没有可用的窗口平台实现"
+        raise RuntimeError(reason)
+
+    @staticmethod
+    def _current_desktop() -> str:
+        """Combine desktop environment hints used by the Layer Shell policy."""
+        values = (
+            os.environ.get("XDG_CURRENT_DESKTOP", ""),
+            os.environ.get("XDG_SESSION_DESKTOP", ""),
+        )
+        return ":".join(value for value in values if value)
+
+
+def create_default_overlay_platform(host: WindowHost) -> OverlayPlatform:
+    """Create the production overlay adapter through the default provider registry."""
+    return DefaultOverlayPlatformFactory().create(host)

--- a/src/bilihud/infrastructure/x11.py
+++ b/src/bilihud/infrastructure/x11.py
@@ -1,0 +1,134 @@
+"""X11 input-shape adapter isolated from the window presentation."""
+
+from __future__ import annotations
+
+import ctypes
+
+from ..overlay_ports import OverlayOperationResult
+from .native import NativeFunction, load_native_function
+
+
+class X11InputShape:
+    """Isolate XShape input-region calls from the presentation and application layers."""
+
+    def __init__(
+        self,
+        x11_open_display: NativeFunction,
+        x11_flush: NativeFunction,
+        x11_close_display: NativeFunction,
+        shape_rectangles: NativeFunction,
+        shape_mask: NativeFunction,
+    ) -> None:
+        self._x11_open_display = x11_open_display
+        self._x11_flush = x11_flush
+        self._x11_close_display = x11_close_display
+        self._shape_rectangles = shape_rectangles
+        self._shape_mask = shape_mask
+
+    @classmethod
+    def load(cls) -> tuple[X11InputShape | None, str | None]:
+        """Load X11 and XShape symbols, returning a reason when the capability is absent."""
+        try:
+            x11 = ctypes.CDLL("libX11.so.6")
+            xext = ctypes.CDLL("libXext.so.6")
+            x11_open_display = load_native_function(
+                x11,
+                "XOpenDisplay",
+                [ctypes.c_void_p],
+                ctypes.c_void_p,
+            )
+            x11_flush = load_native_function(x11, "XFlush", [ctypes.c_void_p])
+            x11_close_display = load_native_function(x11, "XCloseDisplay", [ctypes.c_void_p])
+            shape_rectangles = load_native_function(
+                xext,
+                "XShapeCombineRectangles",
+                [
+                    ctypes.c_void_p,
+                    ctypes.c_ulong,
+                    ctypes.c_int,
+                    ctypes.c_int,
+                    ctypes.c_int,
+                    ctypes.c_void_p,
+                    ctypes.c_int,
+                    ctypes.c_int,
+                    ctypes.c_int,
+                ],
+            )
+            shape_mask = load_native_function(
+                xext,
+                "XShapeCombineMask",
+                [
+                    ctypes.c_void_p,
+                    ctypes.c_ulong,
+                    ctypes.c_int,
+                    ctypes.c_int,
+                    ctypes.c_int,
+                    ctypes.c_void_p,
+                    ctypes.c_int,
+                ],
+            )
+        except OSError as exc:
+            return None, f"X11 click-through support is unavailable: {exc}"
+
+        if x11_open_display is None:
+            return None, "X11 click-through support is missing symbol: XOpenDisplay"
+        if x11_flush is None:
+            return None, "X11 click-through support is missing symbol: XFlush"
+        if x11_close_display is None:
+            return None, "X11 click-through support is missing symbol: XCloseDisplay"
+        if shape_rectangles is None:
+            return None, "X11 click-through support is missing symbol: XShapeCombineRectangles"
+        if shape_mask is None:
+            return None, "X11 click-through support is missing symbol: XShapeCombineMask"
+
+        return cls(
+            x11_open_display=x11_open_display,
+            x11_flush=x11_flush,
+            x11_close_display=x11_close_display,
+            shape_rectangles=shape_rectangles,
+            shape_mask=shape_mask,
+        ), None
+
+    def set_click_through(self, window_id: int, enabled: bool) -> OverlayOperationResult:
+        """Set or clear an XShape input region for one X11 window."""
+        display = self._x11_open_display(None)
+        if not display:
+            return OverlayOperationResult.failure("X11 display could not be opened")
+
+        result = OverlayOperationResult.success()
+        try:
+            shape_input = 2
+            shape_set = 0
+            if enabled:
+                self._shape_rectangles(
+                    display,
+                    window_id,
+                    shape_input,
+                    0,
+                    0,
+                    None,
+                    0,
+                    shape_set,
+                    0,
+                )
+            else:
+                self._shape_mask(
+                    display,
+                    window_id,
+                    shape_input,
+                    0,
+                    0,
+                    None,
+                    shape_set,
+                )
+            self._x11_flush(display)
+        except (OSError, RuntimeError, ctypes.ArgumentError) as exc:
+            result = OverlayOperationResult.failure(f"X11 click-through update failed: {exc}")
+
+        try:
+            self._x11_close_display(display)
+        except (OSError, RuntimeError, ctypes.ArgumentError) as exc:
+            if result.succeeded:
+                result = OverlayOperationResult.failure(f"X11 display close failed: {exc}")
+
+        return result

--- a/src/bilihud/main.py
+++ b/src/bilihud/main.py
@@ -8,6 +8,7 @@ sys.modules["PyQt5"] = None
 os.environ["QT_API"] = "pyqt6"
 
 import asyncio
+import logging
 import signal
 from collections.abc import Iterable
 from typing import Any
@@ -19,6 +20,20 @@ from PyQt6.QtWidgets import QApplication
 from .danmaku_widget import DanmakuWidget
 from .lifecycle import TaskSupervisor
 from .services import AppServices, create_default_services
+
+
+def configure_logging() -> None:
+    """Send application diagnostics to the terminal without enabling noisy modules."""
+    logging.basicConfig(
+        level=logging.WARNING,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        stream=sys.stdout,
+    )
+    for logger_name in (
+        "bilihud.infrastructure.window_platform",
+        "bilihud.infrastructure.layer_shell",
+    ):
+        logging.getLogger(logger_name).setLevel(logging.INFO)
 
 
 class ApplicationRuntime:
@@ -115,6 +130,7 @@ async def cancel_pending_tasks(
 
 def entry_point():
     """Parse CLI options, start the Qt/asyncio event loop, and shut it down cleanly."""
+    configure_logging()
     import argparse
 
     parser = argparse.ArgumentParser(description="B station Danmaku Reader")

--- a/src/bilihud/overlay_ports.py
+++ b/src/bilihud/overlay_ports.py
@@ -1,0 +1,213 @@
+"""Typed contracts for the platform-specific overlay window boundary."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class WindowPoint:
+    """A screen or window-local point without a GUI toolkit dependency."""
+
+    x: int
+    y: int
+
+    def offset(self, dx: int, dy: int) -> WindowPoint:
+        """Return a point translated by the supplied integer delta."""
+        return WindowPoint(self.x + dx, self.y + dy)
+
+    def difference(self, other: WindowPoint) -> WindowPoint:
+        """Return the vector from ``other`` to this point."""
+        return WindowPoint(self.x - other.x, self.y - other.y)
+
+
+@dataclass(frozen=True, slots=True)
+class WindowRectangle:
+    """A rectangle used for geometry and screen-bound calculations."""
+
+    x: int
+    y: int
+    width: int
+    height: int
+
+
+@dataclass(frozen=True, slots=True)
+class WindowPolicy:
+    """Toolkit-neutral window flags and input attributes for one mode."""
+
+    bypass_window_manager: bool = False
+    transparent_for_input: bool = False
+    does_not_accept_focus: bool = False
+    show_without_activating: bool = False
+    mouse_events_transparent: bool = False
+    recreate_surface: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class OverlayCapabilities:
+    """Capabilities exposed by the selected platform adapter."""
+
+    layer_shell: bool
+    gaming_mode: bool
+    click_through: bool
+    drag: bool
+    unavailable_reason: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class OverlayOperationResult:
+    """Result of a platform operation, including an actionable failure reason."""
+
+    succeeded: bool
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.succeeded and self.reason is not None:
+            raise ValueError("成功结果不能包含失败原因")
+        if not self.succeeded and not self.reason:
+            raise ValueError("失败结果必须包含原因")
+
+    @classmethod
+    def success(cls) -> OverlayOperationResult:
+        """Create a successful operation result."""
+        return cls(succeeded=True)
+
+    @classmethod
+    def failure(cls, reason: str) -> OverlayOperationResult:
+        """Create a failed operation result with a user-facing diagnostic."""
+        return cls(succeeded=False, reason=reason)
+
+
+class DragMode(Enum):
+    """The movement mechanism selected for one press gesture."""
+
+    SYSTEM = "system"
+    MANUAL = "manual"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True, slots=True)
+class DragStartResult:
+    """Result of starting a drag and the strategy that owns subsequent motion."""
+
+    mode: DragMode
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.mode is DragMode.UNAVAILABLE and not self.reason:
+            raise ValueError("不可用的拖动结果必须包含原因")
+        if self.mode is not DragMode.UNAVAILABLE and self.reason is not None:
+            raise ValueError("可用的拖动结果不能包含失败原因")
+
+
+class WindowHost(Protocol):
+    """Small presentation-owned surface used by platform infrastructure."""
+
+    def apply_window_policy(self, policy: WindowPolicy) -> None:
+        """Apply abstract window flags and input attributes to the GUI surface."""
+
+    def native_window_pointer(self) -> int | None:
+        """Return an opaque toolkit window pointer for native adapters."""
+
+    def native_window_id(self) -> int | None:
+        """Return the platform window id when the backend exposes one."""
+
+    def geometry(self) -> WindowRectangle:
+        """Return the current top-left and size of the window."""
+
+    def window_position(self) -> WindowPoint | None:
+        """Return the best-known global position when toolkit geometry is unreliable."""
+
+    def screen_geometry(self) -> WindowRectangle | None:
+        """Return the geometry of the window's current screen, if known."""
+
+    def set_geometry(self, geometry: WindowRectangle) -> None:
+        """Restore a window geometry after a toolkit surface recreation."""
+
+    def move_window(self, position: WindowPoint) -> None:
+        """Move a normal window to a global position."""
+
+    def show_window(self) -> None:
+        """Show the window."""
+
+    def hide_window(self) -> None:
+        """Hide the window while changing recreation-sensitive flags."""
+
+    def raise_window(self) -> None:
+        """Raise the window above sibling windows when supported."""
+
+    def activate_window(self) -> None:
+        """Request input focus for normal mode when supported."""
+
+    def start_system_move(self) -> bool:
+        """Ask the compositor to own the current pointer move gesture."""
+
+    def refresh(self) -> None:
+        """Request a repaint after a non-recreating native surface update."""
+
+
+class OverlayDragStrategy(Protocol):
+    """Pluggable drag behavior for a selected desktop/window backend."""
+
+    def begin_drag(
+        self,
+        local_position: WindowPoint,
+        global_position: WindowPoint,
+    ) -> DragStartResult:
+        """Start a gesture and choose system or manual movement."""
+
+    def update_drag(
+        self,
+        local_position: WindowPoint,
+        global_position: WindowPoint,
+    ) -> OverlayOperationResult:
+        """Apply one pointer update for the active gesture."""
+
+    def end_drag(self) -> None:
+        """Release strategy-owned drag state."""
+
+    def synchronize_position(self) -> OverlayOperationResult:
+        """Synchronize backend position after the native surface is mapped."""
+
+
+class OverlayPlatform(Protocol):
+    """Platform capability and lifecycle port used by the presentation widget."""
+
+    @property
+    def capabilities(self) -> OverlayCapabilities:
+        """Return immutable capabilities and the reason for unavailable features."""
+
+    def prepare(self) -> OverlayOperationResult:
+        """Apply the initial normal-window policy before the window is shown."""
+
+    def activate(self) -> OverlayOperationResult:
+        """Activate native overlay integration after the window is mapped."""
+
+    def set_gaming_mode(self, enabled: bool) -> OverlayOperationResult:
+        """Toggle pass-through/overlay behavior while preserving window geometry."""
+
+    def begin_drag(
+        self,
+        local_position: WindowPoint,
+        global_position: WindowPoint,
+    ) -> DragStartResult:
+        """Start a normal-mode drag through the selected backend strategy."""
+
+    def update_drag(
+        self,
+        local_position: WindowPoint,
+        global_position: WindowPoint,
+    ) -> OverlayOperationResult:
+        """Forward one normal-mode pointer update to the active strategy."""
+
+    def end_drag(self) -> None:
+        """End the current drag and release backend state."""
+
+
+class OverlayPlatformFactory(Protocol):
+    """Callable composition-root factory for a platform adapter bound to one Qt surface."""
+
+    def __call__(self, host: WindowHost) -> OverlayPlatform:
+        """Create an adapter for one presentation-owned window host."""

--- a/src/bilihud/qt_window_host.py
+++ b/src/bilihud/qt_window_host.py
@@ -1,0 +1,141 @@
+"""Qt presentation adapter for the toolkit-neutral overlay window port."""
+
+from __future__ import annotations
+
+import PyQt6.sip as sip
+from PyQt6.QtCore import QRect, Qt
+from PyQt6.QtWidgets import QApplication, QWidget
+
+from .overlay_ports import WindowHost, WindowPoint, WindowPolicy, WindowRectangle
+
+
+class QtWindowHost(WindowHost):
+    """Translate abstract window operations to one top-level Qt widget."""
+
+    def __init__(self, widget: QWidget) -> None:
+        """Bind the host to an existing widget without creating native resources."""
+        self._widget = widget
+        self._known_position: WindowPoint | None = None
+
+    def apply_window_policy(self, policy: WindowPolicy) -> None:
+        """Map platform-selected flags and attributes to Qt."""
+        if policy.recreate_surface:
+            self._widget.setWindowFlags(self._base_window_flags(policy))
+
+        self._widget.setAttribute(
+            Qt.WidgetAttribute.WA_TransparentForMouseEvents,
+            policy.mouse_events_transparent,
+        )
+        self._widget.setAttribute(
+            Qt.WidgetAttribute.WA_ShowWithoutActivating,
+            policy.show_without_activating,
+        )
+
+    def _base_window_flags(self, policy: WindowPolicy) -> Qt.WindowType:
+        """Build the Qt flags that correspond to one abstract policy."""
+        flags = (
+            Qt.WindowType.FramelessWindowHint
+            | Qt.WindowType.WindowStaysOnTopHint
+            | Qt.WindowType.Window
+        )
+        if policy.bypass_window_manager:
+            flags |= Qt.WindowType.X11BypassWindowManagerHint
+        if policy.transparent_for_input:
+            flags |= Qt.WindowType.WindowTransparentForInput
+        if policy.does_not_accept_focus:
+            flags |= Qt.WindowType.WindowDoesNotAcceptFocus
+        return flags
+
+    def native_window_pointer(self) -> int | None:
+        """Return the opaque QWindow pointer used only inside platform infrastructure."""
+        self._widget.winId()
+        handle = self._widget.windowHandle()
+        if handle is None:
+            return None
+        try:
+            pointer = sip.unwrapinstance(handle)
+        except (RuntimeError, TypeError):
+            return None
+        if pointer is None:
+            return None
+        return int(pointer)
+
+    def native_window_id(self) -> int | None:
+        """Return the X11 window id when Qt exposes one."""
+        try:
+            return int(self._widget.winId())
+        except RuntimeError:
+            return None
+
+    def geometry(self) -> WindowRectangle:
+        """Return the widget geometry using global top-level coordinates."""
+        geometry = self._widget.geometry()
+        return self._rectangle(geometry)
+
+    def window_position(self) -> WindowPoint | None:
+        """Return an explicit move position before falling back to Qt geometry."""
+        if self._known_position is not None:
+            return self._known_position
+        geometry = self._widget.geometry()
+        return WindowPoint(geometry.x(), geometry.y())
+
+    def screen_geometry(self) -> WindowRectangle | None:
+        """Return the current screen geometry, falling back to the primary screen."""
+        handle = self._widget.windowHandle()
+        screen = handle.screen() if handle is not None else QApplication.primaryScreen()
+        if screen is None:
+            return None
+        return self._rectangle(screen.geometry())
+
+    def set_geometry(self, geometry: WindowRectangle) -> None:
+        """Restore a geometry after Qt recreates a native surface."""
+        self._known_position = WindowPoint(geometry.x, geometry.y)
+        self._widget.setGeometry(
+            QRect(geometry.x, geometry.y, geometry.width, geometry.height)
+        )
+
+    def move_window(self, position: WindowPoint) -> None:
+        """Move the widget using global coordinates."""
+        self._known_position = position
+        self._widget.move(position.x, position.y)
+
+    def show_window(self) -> None:
+        """Show the bound widget."""
+        self._widget.show()
+
+    def hide_window(self) -> None:
+        """Hide the bound widget."""
+        self._widget.hide()
+
+    def raise_window(self) -> None:
+        """Raise the bound widget."""
+        self._widget.raise_()
+
+    def activate_window(self) -> None:
+        """Request focus for the bound widget."""
+        self._widget.activateWindow()
+
+    def start_system_move(self) -> bool:
+        """Ask Qt/Wayland to run the compositor-owned move gesture."""
+        handle = self._widget.windowHandle()
+        if handle is None:
+            return False
+        try:
+            # Qt versions without this Wayland capability raise AttributeError here.
+            return bool(handle.startSystemMove())
+        except (AttributeError, RuntimeError):
+            return False
+
+    def refresh(self) -> None:
+        """Request a repaint after a native policy update."""
+        self._widget.update()
+
+    @staticmethod
+    def _rectangle(rectangle: QRect) -> WindowRectangle:
+        """Convert a Qt rectangle at the presentation boundary."""
+        return WindowRectangle(
+            x=rectangle.x(),
+            y=rectangle.y(),
+            width=rectangle.width(),
+            height=rectangle.height(),
+        )

--- a/src/bilihud/services.py
+++ b/src/bilihud/services.py
@@ -9,10 +9,12 @@ from .config_compat import LegacyConfigMigrator
 from .danmaku_client import DanmakuClient
 from .hud_ports import HudClientFactory
 from .infrastructure.live_control import BilibiliLiveControlApi, ObsWebSocketAdapter
+from .infrastructure.window_platform import create_default_overlay_platform
 from .live_control_service import LiveControlService
 from .mirror_coordinator import MirrorCoordinator
 from .mirror_server import MirrorServer
 from .mirror_state import MirrorState
+from .overlay_ports import OverlayPlatformFactory
 
 
 @dataclass(frozen=True, slots=True)
@@ -24,6 +26,7 @@ class AppServices:
     hud_client_factory: HudClientFactory  # Concrete HUD network adapter factory.
     live_control_service: LiveControlService  # Live-control application workflow owner.
     mirror_coordinator: MirrorCoordinator  # Mirror configuration and server lifecycle owner.
+    overlay_platform_factory: OverlayPlatformFactory  # Platform window capability boundary.
 
 
 def create_default_hud_client(
@@ -62,4 +65,5 @@ def create_default_services(config_path: Path | None = None) -> AppServices:
             config_store=config_store,
             server_factory=create_default_mirror_server,
         ),
+        overlay_platform_factory=create_default_overlay_platform,
     )

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -9,6 +9,7 @@ PRESENTATION_MODULE_NAMES: Final[tuple[str, ...]] = (
     "danmaku_widget",
     "live_control_dialog",
     "qr_login_dialog",
+    "qt_window_host",
 )
 MESSAGE_CONSUMER_MODULE_NAMES: Final[tuple[str, ...]] = (
     "danmaku_format",
@@ -212,3 +213,19 @@ def test_danmaku_widget_uses_hud_controller_instead_of_concrete_client() -> None
 
     assert "bilihud.hud_controller" in modules
     assert "bilihud.danmaku_client" not in modules
+
+
+def test_danmaku_widget_uses_overlay_port_instead_of_platform_implementation() -> None:
+    modules = _imported_modules(SOURCE_ROOT / "danmaku_widget.py")
+
+    assert "bilihud.overlay_ports" in modules
+    assert "bilihud.infrastructure.window_platform" not in modules
+    assert "bilihud.layer_shell_loader" not in modules
+    assert "ctypes" not in modules
+    assert "PyQt6.sip" not in modules
+
+
+def test_overlay_ports_do_not_import_toolkits_or_native_libraries() -> None:
+    modules = _imported_modules(SOURCE_ROOT / "overlay_ports.py")
+
+    assert all(module not in {"PyQt5", "PyQt6", "ctypes"} for module in modules)

--- a/tests/test_danmaku_widget.py
+++ b/tests/test_danmaku_widget.py
@@ -1,8 +1,9 @@
 import asyncio
 import os
+from dataclasses import replace
 
 import pytest
-from PyQt6.QtCore import QEvent, QPoint
+from PyQt6.QtCore import QEvent
 from PyQt6.QtGui import QFont
 from PyQt6.QtWidgets import QApplication, QLabel, QWidget
 
@@ -19,8 +20,18 @@ from bilihud.domain.messages import (
     TextSegment,
     make_system_message,
 )
+from bilihud.infrastructure.layer_shell import LayerShellAnchorDragStrategy
 from bilihud.live_emoticons import LiveEmoticon, LiveEmoticonPackage
 from bilihud.mirror_coordinator import MirrorCoordinatorState, MirrorOperationResult
+from bilihud.overlay_ports import (
+    DragMode,
+    DragStartResult,
+    OverlayCapabilities,
+    OverlayOperationResult,
+    WindowPoint,
+    WindowRectangle,
+)
+from bilihud.services import create_default_services
 
 _QT_APP = None
 
@@ -32,63 +43,93 @@ def _app():
     return _QT_APP
 
 
-def test_layer_shell_drag_updates_anchor_position(monkeypatch):
-    class FakeGeometry:
-        def x(self):
-            return 0
+def test_layer_shell_drag_updates_anchor_position():
+    class FakeHost:
+        def native_window_pointer(self) -> int:
+            return 123
 
-        def y(self):
-            return 0
+        def window_position(self) -> WindowPoint:
+            return WindowPoint(100, 100)
 
-        def width(self):
-            return 1920
+        def geometry(self) -> WindowRectangle:
+            return WindowRectangle(x=100, y=100, width=300, height=450)
 
-        def height(self):
-            return 1080
-
-    class FakeScreen:
-        def geometry(self):
-            return FakeGeometry()
-
-    class FakeWindow:
-        def screen(self):
-            return FakeScreen()
+        def screen_geometry(self) -> WindowRectangle:
+            return WindowRectangle(x=0, y=0, width=1920, height=1080)
 
     class FakeLayerShell:
-        def __init__(self):
-            self.calls = []
+        def __init__(self) -> None:
+            self.calls: list[tuple[int, int, int]] = []
 
-        def set_anchor_position(self, pointer, x, y):
+        def set_anchor_position(self, pointer: int, x: int, y: int) -> None:
             self.calls.append((pointer, x, y))
 
-    class FakePosition:
-        def toPoint(self):
-            return QPoint(20, 20)
+    layer_shell = FakeLayerShell()
+    strategy = LayerShellAnchorDragStrategy(FakeHost(), layer_shell)
 
-    class FakeEvent:
-        def position(self):
-            return FakePosition()
+    assert strategy.synchronize_position().succeeded is True
+    assert strategy.begin_drag(WindowPoint(10, 10), WindowPoint(110, 110)).mode is DragMode.MANUAL
+    assert strategy.update_drag(WindowPoint(20, 20), WindowPoint(120, 120)).succeeded is True
+    assert strategy.update_drag(WindowPoint(20, 20), WindowPoint(130, 130)).succeeded is True
 
-        def accept(self):
+    assert layer_shell.calls == [(123, 100, 100), (123, 110, 110), (123, 120, 120)]
+
+
+def test_danmaku_widget_keeps_game_mode_controls_in_sync_with_fake_platform(tmp_path):
+    class FakePlatform:
+        capabilities = OverlayCapabilities(
+            layer_shell=False,
+            gaming_mode=True,
+            click_through=True,
+            drag=True,
+        )
+
+        def __init__(self) -> None:
+            self.mode_calls: list[bool] = []
+
+        def prepare(self) -> OverlayOperationResult:
+            return OverlayOperationResult.success()
+
+        def activate(self) -> OverlayOperationResult:
+            return OverlayOperationResult.success()
+
+        def set_gaming_mode(self, enabled: bool) -> OverlayOperationResult:
+            self.mode_calls.append(enabled)
+            return OverlayOperationResult.success()
+
+        def begin_drag(self, _local_position: WindowPoint, _global_position: WindowPoint) -> DragStartResult:
+            return DragStartResult(DragMode.MANUAL)
+
+        def update_drag(
+            self,
+            _local_position: WindowPoint,
+            _global_position: WindowPoint,
+        ) -> OverlayOperationResult:
+            return OverlayOperationResult.success()
+
+        def end_drag(self) -> None:
             pass
 
-    layer_shell = FakeLayerShell()
-    widget = danmaku_widget.DanmakuWidget.__new__(danmaku_widget.DanmakuWidget)
-    widget._dragging = True
-    widget._drag_local_pos = QPoint(10, 10)
-    widget.layer_pos = QPoint(100, 100)
-    widget.layer_shell_lib = layer_shell
+    _app()
+    platform = FakePlatform()
+    services = replace(
+        create_default_services(tmp_path / "config.json"),
+        overlay_platform_factory=lambda _host: platform,
+    )
+    widget = danmaku_widget.DanmakuWidget(services=services)
+    try:
+        assert widget.set_gaming_mode(True).succeeded is True
+        assert widget.is_gaming_mode is True
+        assert widget.gaming_mode_btn.isChecked() is True
+        assert widget.tray_gaming_action.isChecked() is True
 
-    monkeypatch.setattr(danmaku_widget.sip, "unwrapinstance", lambda _window: 123)
-    monkeypatch.setattr(danmaku_widget.DanmakuWidget, "windowHandle", lambda _self: FakeWindow())
-    monkeypatch.setattr(danmaku_widget.DanmakuWidget, "width", lambda _self: 300)
-
-    danmaku_widget.DanmakuWidget.mouseMoveEvent(widget, FakeEvent())
-
-    assert widget.layer_pos == QPoint(110, 110)
-    pointer, x, y = layer_shell.calls[0]
-    assert pointer.value == 123
-    assert (x, y) == (110, 110)
+        assert widget.set_gaming_mode(False).succeeded is True
+        assert widget.is_gaming_mode is False
+        assert widget.gaming_mode_btn.isChecked() is False
+        assert widget.tray_gaming_action.isChecked() is False
+        assert platform.mode_calls == [True, False]
+    finally:
+        asyncio.run(widget.shutdown())
 
 
 def test_danmaku_widget_exposes_bilihud_mirror_tray_action(monkeypatch):

--- a/tests/test_layer_shell_loader.py
+++ b/tests/test_layer_shell_loader.py
@@ -1,4 +1,7 @@
-from bilihud.layer_shell_loader import find_layer_shell_library, gaming_mode_available, should_disable_layer_shell
+from bilihud.infrastructure.layer_shell_loader import (
+    find_layer_shell_library,
+    should_disable_layer_shell,
+)
 
 
 def test_find_layer_shell_library_prefers_unsuffixed_name(tmp_path):
@@ -31,15 +34,3 @@ def test_should_not_disable_layer_shell_on_kde_wayland():
 
 def test_should_not_disable_layer_shell_on_x11():
     assert should_disable_layer_shell("xcb", "GNOME") is False
-
-
-def test_gaming_mode_unavailable_when_layer_shell_is_disabled_on_wayland():
-    assert gaming_mode_available("wayland", has_layer_shell=False, layer_shell_disabled=True) is False
-
-
-def test_gaming_mode_available_with_layer_shell():
-    assert gaming_mode_available("wayland", has_layer_shell=True, layer_shell_disabled=False) is True
-
-
-def test_gaming_mode_available_on_x11_without_layer_shell():
-    assert gaming_mode_available("xcb", has_layer_shell=False, layer_shell_disabled=False) is True

--- a/tests/test_window_platform.py
+++ b/tests/test_window_platform.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+
+import pytest
+from PyQt6.QtWidgets import QApplication
+
+from bilihud.infrastructure import qt_window_platform, window_platform
+from bilihud.overlay_ports import (
+    DragMode,
+    OverlayOperationResult,
+    WindowPoint,
+    WindowPolicy,
+    WindowRectangle,
+)
+
+
+def _app() -> QApplication:
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+class FakeWindowHost:
+    """Minimal host for testing provider selection and compositor-owned drag."""
+
+    def __init__(self) -> None:
+        self.system_move_available = True
+        self.native_pointer: int | None = None
+        self.policies: list[WindowPolicy] = []
+        self.moved_positions: list[WindowPoint] = []
+        self.set_geometry_calls: list[WindowRectangle] = []
+        self.actions: list[str] = []
+
+    def apply_window_policy(self, policy: WindowPolicy) -> None:
+        self.policies.append(policy)
+
+    def native_window_pointer(self) -> int | None:
+        return self.native_pointer
+
+    def native_window_id(self) -> int | None:
+        return None
+
+    def window_position(self) -> WindowPoint:
+        return WindowPoint(0, 0)
+
+    def geometry(self) -> WindowRectangle:
+        return WindowRectangle(0, 0, 300, 450)
+
+    def screen_geometry(self) -> WindowRectangle | None:
+        return WindowRectangle(0, 0, 1920, 1080)
+
+    def set_geometry(self, geometry: WindowRectangle) -> None:
+        self.set_geometry_calls.append(geometry)
+
+    def move_window(self, position: WindowPoint) -> None:
+        self.moved_positions.append(position)
+
+    def show_window(self) -> None:
+        self.actions.append("show")
+
+    def hide_window(self) -> None:
+        self.actions.append("hide")
+
+    def raise_window(self) -> None:
+        self.actions.append("raise")
+
+    def activate_window(self) -> None:
+        self.actions.append("activate")
+
+    def start_system_move(self) -> bool:
+        return self.system_move_available
+
+    def refresh(self) -> None:
+        pass
+
+
+class FakeLayerShellBridge:
+    """Native-free Layer Shell fake for strategy-provider integration tests."""
+
+    def __init__(self) -> None:
+        self.anchor_positions: list[tuple[int, int, int]] = []
+
+    def make_overlay(self, _window_pointer: int) -> None:
+        pass
+
+    def set_passthrough(self, _window_pointer: int, _enabled: bool) -> None:
+        pass
+
+    def set_anchor_position(self, window_pointer: int, x: int, y: int) -> None:
+        self.anchor_positions.append((window_pointer, x, y))
+
+    def set_keyboard_interactivity(self, _window_pointer: int, _enabled: bool) -> None:
+        pass
+
+
+@pytest.mark.parametrize("desktop", ["niri", "GNOME"])
+def test_wayland_without_layer_shell_keeps_normal_window_drag_available(
+    monkeypatch,
+    desktop: str,
+) -> None:
+    """A compositor without the overlay protocol must still provide ordinary movement."""
+    _app()
+    monkeypatch.setattr(window_platform.QGuiApplication, "platformName", lambda: "wayland")
+    monkeypatch.setenv("XDG_CURRENT_DESKTOP", desktop)
+    monkeypatch.delenv("XDG_SESSION_DESKTOP", raising=False)
+    monkeypatch.setattr(
+        window_platform,
+        "load_layer_shell_bridge",
+        lambda _package_dir: (None, "test bridge unavailable"),
+    )
+
+    host = FakeWindowHost()
+    platform = window_platform.DefaultOverlayPlatformFactory()(host)
+
+    assert platform.capabilities.layer_shell is False
+    assert platform.capabilities.gaming_mode is False
+    assert platform.capabilities.drag is True
+    assert platform.capabilities.unavailable_reason == (
+        "Wayland compositor does not provide the Layer Shell overlay capability"
+    )
+    assert platform.prepare() == OverlayOperationResult.success()
+    assert platform.activate() == OverlayOperationResult.success()
+
+    drag = platform.begin_drag(WindowPoint(20, 20), WindowPoint(100, 100))
+    assert drag.mode is DragMode.SYSTEM
+
+
+def test_wayland_manual_drag_is_the_fallback_when_system_move_is_rejected(monkeypatch) -> None:
+    """The normal-window adapter retains a manual path for compositors rejecting system move."""
+    _app()
+    monkeypatch.setattr(window_platform.QGuiApplication, "platformName", lambda: "wayland")
+    monkeypatch.setenv("XDG_CURRENT_DESKTOP", "niri")
+    monkeypatch.setattr(
+        window_platform,
+        "load_layer_shell_bridge",
+        lambda _package_dir: (None, "test bridge unavailable"),
+    )
+
+    host = FakeWindowHost()
+    host.system_move_available = False
+    platform = window_platform.DefaultOverlayPlatformFactory()(host)
+
+    drag = platform.begin_drag(WindowPoint(20, 20), WindowPoint(100, 100))
+    assert drag.mode is DragMode.MANUAL
+    assert platform.update_drag(WindowPoint(30, 30), WindowPoint(130, 140)) == OverlayOperationResult.success()
+    assert host.moved_positions == [WindowPoint(110, 120)]
+
+
+def test_layer_shell_activation_falls_back_to_an_ordinary_window(monkeypatch) -> None:
+    """A native activation failure must retain ordinary Wayland window behavior."""
+    _app()
+    monkeypatch.setattr(window_platform.QGuiApplication, "platformName", lambda: "wayland")
+    monkeypatch.setenv("XDG_CURRENT_DESKTOP", "KDE")
+
+    class FailingLayerShellBridge(FakeLayerShellBridge):
+        def make_overlay(self, _window_pointer: int) -> None:
+            raise RuntimeError("test activation failure")
+
+    bridge = FailingLayerShellBridge()
+    monkeypatch.setattr(window_platform, "load_layer_shell_bridge", lambda _package_dir: (bridge, None))
+
+    host = FakeWindowHost()
+    host.native_pointer = 123
+    platform = window_platform.DefaultOverlayPlatformFactory()(host)
+
+    assert platform.capabilities.layer_shell is True
+    assert platform.prepare() == OverlayOperationResult.success()
+    assert platform.activate() == OverlayOperationResult.success()
+    assert platform.capabilities.layer_shell is False
+    assert platform.capabilities.gaming_mode is False
+    assert platform.capabilities.drag is True
+    assert platform.capabilities.unavailable_reason == (
+        "Layer Shell 激活失败: test activation failure"
+    )
+    assert platform.begin_drag(WindowPoint(20, 20), WindowPoint(100, 100)).mode is DragMode.SYSTEM
+    assert platform.set_gaming_mode(True).succeeded is False
+
+
+def test_x11_surface_restore_waits_for_mapping_and_ignores_stale_toggle(monkeypatch) -> None:
+    """X11 restores geometry after remapping and never lets an old toggle win."""
+    _app()
+    monkeypatch.setattr(window_platform.QGuiApplication, "platformName", lambda: "xcb")
+    callbacks: list[tuple[int, Callable[[], None]]] = []
+    monkeypatch.setattr(
+        qt_window_platform.QTimer,
+        "singleShot",
+        lambda delay, callback: callbacks.append((delay, callback)),
+    )
+    monkeypatch.setattr(
+        window_platform.X11InputShape,
+        "load",
+        lambda: (None, "test XShape unavailable"),
+    )
+
+    host = FakeWindowHost()
+    platform = window_platform.DefaultOverlayPlatformFactory()(host)
+    geometry = host.geometry()
+
+    assert platform.set_gaming_mode(True) == OverlayOperationResult.success()
+    assert platform.set_gaming_mode(False) == OverlayOperationResult.success()
+    assert [delay for delay, _callback in callbacks] == [50, 50]
+    assert host.set_geometry_calls == []
+
+    callbacks[0][1]()
+    assert host.set_geometry_calls == []
+    callbacks[1][1]()
+    assert host.set_geometry_calls == [geometry]
+    assert host.actions[-3:] == ["show", "raise", "activate"]
+
+
+def test_niri_layer_shell_provider_uses_global_drag_deltas(monkeypatch) -> None:
+    """niri gets global-delta dragging while the Layer Shell contract stays shared."""
+    _app()
+    monkeypatch.setattr(window_platform.QGuiApplication, "platformName", lambda: "wayland")
+    monkeypatch.setenv("XDG_CURRENT_DESKTOP", "niri")
+    bridge = FakeLayerShellBridge()
+    monkeypatch.setattr(window_platform, "load_layer_shell_bridge", lambda _package_dir: (bridge, None))
+
+    host = FakeWindowHost()
+    host.native_pointer = 123
+    platform = window_platform.DefaultOverlayPlatformFactory()(host)
+
+    assert platform.capabilities.layer_shell is True
+    assert platform.prepare() == OverlayOperationResult.success()
+    assert platform.activate() == OverlayOperationResult.success()
+    assert platform.begin_drag(WindowPoint(30, 30), WindowPoint(100, 100)).mode is DragMode.MANUAL
+    assert platform.update_drag(WindowPoint(20, 20), WindowPoint(110, 100)) == OverlayOperationResult.success()
+    assert platform.update_drag(WindowPoint(20, 20), WindowPoint(120, 100)) == OverlayOperationResult.success()
+
+    assert bridge.anchor_positions == [(123, 0, 0), (123, 10, 0), (123, 20, 0)]
+
+    platform.end_drag()
+    assert platform.begin_drag(WindowPoint(20, 20), WindowPoint(0, 0)).mode is DragMode.MANUAL
+    assert platform.update_drag(WindowPoint(20, 20), WindowPoint(5000, 0)) == OverlayOperationResult.success()
+    assert platform.update_drag(WindowPoint(20, 20), WindowPoint(4999, 0)) == OverlayOperationResult.success()
+    assert bridge.anchor_positions[-2:] == [(123, 1870, 0), (123, 1869, 0)]
+
+
+@pytest.mark.parametrize("platform_name", ["cocoa", "windows"])
+def test_generic_qt_platform_keeps_gaming_mode_on_non_wayland(monkeypatch, platform_name: str) -> None:
+    """Qt's portable topmost/input policy remains available outside Linux Wayland."""
+    _app()
+    monkeypatch.setattr(window_platform.QGuiApplication, "platformName", lambda: platform_name)
+    monkeypatch.delenv("XDG_CURRENT_DESKTOP", raising=False)
+    monkeypatch.delenv("XDG_SESSION_DESKTOP", raising=False)
+
+    host = FakeWindowHost()
+    platform = window_platform.DefaultOverlayPlatformFactory()(host)
+
+    assert platform.capabilities.gaming_mode is True
+    assert platform.capabilities.click_through is True
+    assert platform.prepare() == OverlayOperationResult.success()
+    assert platform.set_gaming_mode(True) == OverlayOperationResult.success()
+    assert platform.set_gaming_mode(False) == OverlayOperationResult.success()
+
+    assert host.policies == [
+        WindowPolicy(),
+        WindowPolicy(
+            transparent_for_input=True,
+            does_not_accept_focus=True,
+            show_without_activating=True,
+            mouse_events_transparent=True,
+        ),
+        WindowPolicy(),
+    ]
+
+
+def test_platform_probe_logs_backend_and_selected_provider(monkeypatch, caplog) -> None:
+    """Startup diagnostics identify both the Qt backend and the selected provider."""
+    _app()
+    monkeypatch.setattr(window_platform.QGuiApplication, "platformName", lambda: "cocoa")
+    monkeypatch.delenv("XDG_CURRENT_DESKTOP", raising=False)
+    monkeypatch.delenv("XDG_SESSION_DESKTOP", raising=False)
+
+    with caplog.at_level(logging.INFO, logger="bilihud.infrastructure.window_platform"):
+        window_platform.DefaultOverlayPlatformFactory()(FakeWindowHost())
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("Overlay platform probe: qt_platform=cocoa" in message for message in messages)
+    assert any("Generic Qt provider selected" in message for message in messages)
+    assert any("Overlay platform selected: QtWindowPlatform" in message for message in messages)

--- a/tests/test_x11.py
+++ b/tests/test_x11.py
@@ -1,0 +1,36 @@
+from bilihud.infrastructure.x11 import X11InputShape
+
+
+def test_x11_display_cleanup_failure_stays_inside_operation_result() -> None:
+    """Optional XShape cleanup errors must not escape the platform boundary."""
+    calls: list[str] = []
+
+    def open_display(_display_name: object) -> object:
+        return object()
+
+    def flush(_display: object) -> None:
+        calls.append("flush")
+
+    def close_display(_display: object) -> None:
+        calls.append("close")
+        raise RuntimeError("test close failure")
+
+    def combine_rectangles(*_arguments: object) -> None:
+        calls.append("rectangles")
+
+    def combine_mask(*_arguments: object) -> None:
+        calls.append("mask")
+
+    adapter = X11InputShape(
+        x11_open_display=open_display,
+        x11_flush=flush,
+        x11_close_display=close_display,
+        shape_rectangles=combine_rectangles,
+        shape_mask=combine_mask,
+    )
+
+    result = adapter.set_click_through(123, enabled=True)
+
+    assert result.succeeded is False
+    assert result.reason == "X11 display close failed: test close failure"
+    assert calls == ["rectangles", "flush", "close"]


### PR DESCRIPTION
## Summary

- Add typed overlay window ports and provider-based platform selection.
- Preserve KDE-compatible Layer Shell dragging and select global-delta dragging for niri.
- Keep ordinary Wayland windows available when Layer Shell is unsupported or activation fails.
- Restore X11 remap timing and add startup diagnostics for backend and strategy selection.

## Verification

- uv run pytest -q (182 passed)
- Targeted Ruff and ty checks passed
- uv build passed

## Notes

The niri output binding and screen identity work remains future extension space as discussed. The current change keeps the strategy boundary ready for it.

Refs: #19
Closes #28