### PR TITLE
feat(platform): add cross-platform runtime adapters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,3 +80,32 @@ jobs:
     - name: Run tests
       run: |
         xvfb-run pytest
+
+  platform-adapters:
+    name: Platform adapters (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.13'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install ".[test]"
+
+    - name: Run pure Python platform checks
+      run: >-
+        python -m pytest -q
+        tests/config/test_config.py
+        tests/live/test_obs_api.py
+        tests/platform/test_paths.py
+        tests/platform/test_obs_process.py
+        tests/test_architecture.py

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ BiliHUD 的全屏浮窗能力依赖 compositor 支持 `wlr-layer-shell` 协议�
 * KDE Plasma Wayland / KWin：预期支持全屏应用上方浮窗。
 * wlroots 系 compositor：如 compositor 提供 `wlr-layer-shell`，预期可用。
 * GNOME Wayland / Mutter：不支持 `wlr-layer-shell`，因此不支持全屏应用上方浮窗，也不保证普通窗口置顶。BiliHUD 会回退为普通窗口，仍可在桌面环境中移动和使用。
+* macOS / Windows：不编译或加载 Linux Layer Shell bridge，使用通用 Qt 窗口 backend；这不提供 Linux compositor overlay 语义。
 
 ## 极速上手
 
@@ -158,6 +159,16 @@ Mirror 默认仅监听 `127.0.0.1`，用于本机浏览器源或本机浏览器�
 首次使用或本地会话失效时，请在托盘图标右键菜单中选择“扫码登录”。扫码获得的 Bilibili 会话凭证会保存到系统 keyring，后续启动会从 keyring 恢复。
 
 如果没有有效会话，BiliHUD 会提示重新扫码登录。会话凭证只用于访问 Bilibili API，不会写入项目配置文件或发送到第三方服务。
+
+### 配置位置
+
+普通配置只保存非敏感设置，OBS WebSocket 密码保存于系统 keyring。默认配置文件位置为：
+
+* Linux：`$XDG_CONFIG_HOME/bilihud/config.json`；未设置有效的 `XDG_CONFIG_HOME` 时使用 `~/.config/bilihud/config.json`
+* macOS：`~/Library/Application Support/bilihud/config.json`
+* Windows：`%APPDATA%/bilihud/config.json`；`APPDATA` 不可用时使用用户目录下的 `AppData/Roaming/bilihud/config.json`
+
+Windows 和 macOS 是新平台路径，不会读取 Linux 的 `~/.config/bilihud` 配置。
 
 
 

--- a/docs/architecture/module-boundaries.md
+++ b/docs/architecture/module-boundaries.md
@@ -18,7 +18,7 @@ bilihud/
   danmaku/         message contracts, formatting, blivedm adapter, client
   live/            live-room models, parsing, Bilibili/OBS adapters, validation
   mirror/          mirror state, serialization, and HTTP server
-  platform/        overlay contracts and desktop/native window adapters
+  platform/        overlay contracts, desktop/native adapters, and OS capabilities
   ui/              Qt presentation grouped by HUD, settings, auth, tray, and window hosting
   main.py          process entry point and Qt application composition
 ```
@@ -64,6 +64,11 @@ dependencies an explicit build error; `OFF` produces the generic Qt package
 without the Linux-only artifact. Unsupported platforms never enter the Linux
 dependency discovery path.
 
+At runtime, `platform.window_platform` selects Layer Shell only for a compatible
+Wayland compositor with a loadable bridge. Linux X11, macOS, and Windows use the
+generic Qt window adapter; a failed Layer Shell activation falls back to the
+ordinary Wayland adapter without changing the UI contract.
+
 ## Ownership Rules
 
 - `danmaku.messages` owns HUD message variants, author metadata, badges, and
@@ -94,8 +99,10 @@ dependency discovery path.
 - `platform.overlay_contracts` owns toolkit-neutral window geometry, capability,
   result, and drag-strategy contracts. `platform.window_platform`,
   `platform.qt_window_platform`, `platform.layer_shell`, `platform.x11`, and
-  `platform.native` isolate desktop integrations. `ui.window_host` is the Qt
-  presentation binding for those contracts.
+  `platform.native` isolate desktop integrations. `platform.system` captures
+  operating-system facts once, while `platform.paths` and
+  `platform.obs_process` own configuration-path and OBS-process adapters.
+  `ui.window_host` is the Qt presentation binding for overlay contracts.
 - `config.store` owns typed non-sensitive settings and `config.compat` owns
   legacy migration. `config.legacy` is a temporary caller facade; it must not
   become a second configuration model.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: Chinese (Simplified)",
     "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.13",

--- a/src/bilihud/app/obs_control.py
+++ b/src/bilihud/app/obs_control.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
+from pathlib import Path
 from typing import Protocol
 
 from ..live.models import ObsSettings, StreamCredential
@@ -9,6 +11,46 @@ from ..live.models import ObsSettings, StreamCredential
 
 class ObsAdapterError(RuntimeError):
     """Normalized failure raised by an OBS adapter."""
+
+    def __init__(self, message: str, *, process_code: ObsProcessFailureCode | None = None) -> None:
+        """Create an adapter error with an optional platform-process category."""
+        super().__init__(message)
+        self.process_code: ObsProcessFailureCode | None = process_code
+
+
+class ObsProcessFailureCode(StrEnum):
+    """Stable categories for platform-level OBS process failures."""
+
+    UNSUPPORTED_PLATFORM = "unsupported_platform"
+    PROCESS_QUERY_FAILED = "process_query_failed"
+    EXECUTABLE_NOT_FOUND = "executable_not_found"
+    PERMISSION_DENIED = "permission_denied"
+    LAUNCH_FAILED = "launch_failed"
+
+
+class ObsProcessError(RuntimeError):
+    """Typed failure raised by an OBS process adapter at the platform boundary."""
+
+    def __init__(self, code: ObsProcessFailureCode, message: str) -> None:
+        """Create a process failure with a stable category and diagnostic."""
+        super().__init__(message)
+        self.code: ObsProcessFailureCode = code
+
+
+class ObsProcess(Protocol):
+    """Capability for inspecting and handing off an OBS process."""
+
+    def find_executable(self) -> Path | None:
+        """Return the resolved OBS executable, if the platform can find one."""
+        ...
+
+    def is_running(self) -> bool:
+        """Return whether an OBS process is currently running."""
+        ...
+
+    def launch(self) -> None:
+        """Find and detach an OBS process, or raise a typed launch failure."""
+        ...
 
 
 class ObsAdapter(Protocol):
@@ -43,4 +85,10 @@ class ObsAdapter(Protocol):
         ...
 
 
-__all__ = ("ObsAdapter", "ObsAdapterError")
+__all__ = (
+    "ObsAdapter",
+    "ObsAdapterError",
+    "ObsProcess",
+    "ObsProcessError",
+    "ObsProcessFailureCode",
+)

--- a/src/bilihud/app/services.py
+++ b/src/bilihud/app/services.py
@@ -10,6 +10,7 @@ from ..danmaku.client import DanmakuClient
 from ..live.adapters import BilibiliLiveControlApi, ObsWebSocketAdapter
 from ..mirror.server import MirrorServer
 from ..mirror.state import MirrorState
+from ..platform.obs_process import create_obs_process
 from ..platform.overlay_contracts import OverlayPlatformFactory
 from ..platform.window_platform import create_default_overlay_platform
 from .hud_client import HudClientFactory
@@ -57,7 +58,7 @@ def create_default_services(config_path: Path | None = None) -> AppServices:
         hud_client_factory=create_default_hud_client,
         live_control_service=LiveControlService(
             api=BilibiliLiveControlApi(auth_service),
-            obs=ObsWebSocketAdapter(),
+            obs=ObsWebSocketAdapter(process=create_obs_process()),
             config_store=config_store,
             obs_password_store=auth_service,
             qr_image_generator=auth_service,

--- a/src/bilihud/config/legacy.py
+++ b/src/bilihud/config/legacy.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_config_path() -> Path:
-    """Return the XDG configuration path without creating it."""
+    """Return the current platform's canonical configuration path without creating it."""
     return default_config_path()
 
 

--- a/src/bilihud/config/store.py
+++ b/src/bilihud/config/store.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 from typing import Protocol
 
+from ..platform.paths import default_user_config_paths
 from .compat import ConfigMigrator, LegacyConfigMigrator
 
 logger = logging.getLogger(__name__)
@@ -100,12 +100,12 @@ class JsonConfigStore:
 
     def __init__(self, path: Path | None = None, migrator: ConfigMigrator | None = None) -> None:
         """Create a store using the supplied path and compatibility adapter."""
-        self.path = path or default_config_path()
+        self.path: Path = path if path is not None else default_config_path()
         if migrator is None:
             from ..auth.service import KeyringSessionStore
 
             migrator = LegacyConfigMigrator(KeyringSessionStore())
-        self.migrator = migrator
+        self.migrator: ConfigMigrator = migrator
 
     def load(self) -> AppConfig:
         """Read configuration, migrate legacy secrets, and return normalized settings."""
@@ -151,10 +151,8 @@ class JsonConfigStore:
 
 
 def default_config_path() -> Path:
-    """Return the XDG-compatible configuration path without creating it."""
-    xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
-    config_home = Path(xdg_config_home) if xdg_config_home else Path.home() / ".config"
-    return config_home / "bilihud" / "config.json"
+    """Return the current platform's canonical configuration path without creating it."""
+    return default_user_config_paths().file
 
 
 def _read_mapping(path: Path) -> dict[str, object] | None:

--- a/src/bilihud/live/adapters.py
+++ b/src/bilihud/live/adapters.py
@@ -9,7 +9,7 @@ from typing import TypeVar
 import aiohttp
 
 from ..app.live_control_api import LiveControlApiError
-from ..app.obs_control import ObsAdapterError
+from ..app.obs_control import ObsAdapterError, ObsProcess, ObsProcessError
 from ..auth.service import AuthenticationService
 from .api import (
     LiveApiError,
@@ -35,7 +35,7 @@ from .models import (
     SessionStatus,
     StreamCredential,
 )
-from .obs import ObsApiError, ObsWebSocketClient, is_obs_process_running, launch_obs
+from .obs import ObsApiError, ObsWebSocketClient
 
 Result = TypeVar("Result")
 
@@ -134,6 +134,10 @@ class BilibiliLiveControlApi:
 class ObsWebSocketAdapter:
     """Adapt the concrete OBS WebSocket client to the typed OBS capability."""
 
+    def __init__(self, process: ObsProcess) -> None:
+        """Create an adapter with an explicit platform process capability."""
+        self._process = process
+
     async def check_connection(self, settings: ObsSettings) -> None:
         """Check one OBS endpoint and normalize its expected failures."""
         await self._request(_obs_client(settings).check_connection())
@@ -159,16 +163,16 @@ class ObsWebSocketAdapter:
     def is_process_running(self) -> bool:
         """Return whether OBS is running through the platform process adapter."""
         try:
-            return is_obs_process_running()
-        except OSError as exc:
-            raise ObsAdapterError(f"检查 OBS 进程失败: {exc}") from exc
+            return self._process.is_running()
+        except ObsProcessError as exc:
+            raise ObsAdapterError(str(exc), process_code=exc.code) from exc
 
     def launch(self) -> None:
         """Launch OBS through the existing process adapter."""
         try:
-            launch_obs()
-        except (ObsApiError, OSError) as exc:
-            raise ObsAdapterError(str(exc)) from exc
+            self._process.launch()
+        except ObsProcessError as exc:
+            raise ObsAdapterError(str(exc), process_code=exc.code) from exc
 
     async def _request(self, operation: Awaitable[Result]) -> Result:
         """Normalize concrete OBS failures without hiding cancellation."""

--- a/src/bilihud/live/obs.py
+++ b/src/bilihud/live/obs.py
@@ -1,7 +1,5 @@
 import base64
 import hashlib
-import shutil
-import subprocess
 import uuid
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -9,6 +7,14 @@ from typing import Any
 
 import aiohttp
 
+from ..app.obs_control import ObsProcessError
+from ..platform.obs_process import (
+    LinuxObsProcess,
+    create_obs_process,
+)
+from ..platform.obs_process import (
+    is_obs_process_name as _is_obs_process_name,
+)
 from .models import (
     StreamCredential,
 )
@@ -27,50 +33,32 @@ class ObsApiError(RuntimeError):
 
 
 def is_obs_process_name(command: str) -> bool:
-    name = Path(command).name
-    return name in {"obs", "obs-studio"}
+    """Keep the historical helper export backed by the platform process adapter."""
+    return _is_obs_process_name(command)
+
+
+def is_obs_process_running(proc_root: str = "/proc") -> bool:
+    """Keep the historical Linux helper backed by the Linux process adapter."""
+    return LinuxObsProcess(proc_root=Path(proc_root)).is_running()
+
+
+def find_obs_executable() -> str | None:
+    """Keep the historical executable lookup backed by the selected platform adapter."""
+    executable = create_obs_process().find_executable()
+    return None if executable is None else str(executable)
+
+
+def launch_obs() -> None:
+    """Keep the historical launch helper while preserving its OBS error type."""
+    try:
+        create_obs_process().launch()
+    except ObsProcessError as exc:
+        raise ObsApiError(str(exc)) from exc
 
 
 def obs_check_button_state(port_valid: bool, checking: bool, connected: bool) -> tuple[bool, str]:
     """Keep the historical OBS helper name while delegating pure domain logic."""
     return _obs_check_button_state(port_valid, checking, connected)
-
-
-def is_obs_process_running(proc_root: str = "/proc") -> bool:
-    proc_path = Path(proc_root)
-    if not proc_path.exists():
-        return False
-
-    for entry in proc_path.iterdir():
-        if not entry.name.isdigit():
-            continue
-        try:
-            command = (entry / "comm").read_text(encoding="utf-8").strip()
-        except OSError:
-            continue
-        if is_obs_process_name(command):
-            return True
-    return False
-
-
-def find_obs_executable() -> str | None:
-    for command in ("obs", "obs-studio"):
-        executable = shutil.which(command)
-        if executable:
-            return executable
-    return None
-
-
-def launch_obs() -> subprocess.Popen[Any]:
-    executable = find_obs_executable()
-    if not executable:
-        raise ObsApiError("未找到 OBS 可执行文件，请先安装 OBS 或确认命令 obs/obs-studio 在 PATH 中。")
-    return subprocess.Popen(
-        [executable],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        start_new_session=True,
-    )
 
 
 def compute_obs_auth(password: str, salt: str, challenge: str) -> str:

--- a/src/bilihud/platform/__init__.py
+++ b/src/bilihud/platform/__init__.py
@@ -1,4 +1,4 @@
-"""Toolkit-neutral overlay contracts and desktop platform adapters."""
+"""Toolkit-neutral overlay contracts and desktop/OS platform adapters."""
 
 from .overlay_contracts import (
     DragMode,

--- a/src/bilihud/platform/obs_process.py
+++ b/src/bilihud/platform/obs_process.py
@@ -1,0 +1,359 @@
+"""Platform adapters for OBS process discovery and detached launch."""
+
+from __future__ import annotations
+
+import csv
+import locale
+import shutil
+import subprocess
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from ..app.obs_control import ObsProcess, ObsProcessError, ObsProcessFailureCode
+from .system import PlatformContext, PlatformKind, create_platform_context
+
+OBS_PROCESS_NAMES = frozenset({"obs", "obs-studio", "obs64"})
+
+
+@dataclass(frozen=True, slots=True)
+class CommandResult:
+    """Portable subset of a process query result used by platform adapters."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+class ProcessCommandRunner(Protocol):
+    """Execute one platform process-listing command."""
+
+    def run(self, command: Sequence[str]) -> CommandResult:
+        """Run an explicit argv command and return its captured text output."""
+        ...
+
+
+class ProcessLauncher(Protocol):
+    """Detach one already-resolved executable from the application process."""
+
+    def launch(self, command: Sequence[str]) -> None:
+        """Start an explicit argv command without taking ownership of its lifetime."""
+        ...
+
+
+class _SubprocessCommandRunner:
+    """Run process inspection commands with bounded, locale-aware text decoding."""
+
+    def run(self, command: Sequence[str]) -> CommandResult:
+        """Run one command without a shell and normalize launch errors."""
+        try:
+            result = subprocess.run(
+                list(command),
+                capture_output=True,
+                check=False,
+                encoding=locale.getpreferredencoding(False),
+                errors="replace",
+                text=True,
+                timeout=5.0,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise ObsProcessError(
+                ObsProcessFailureCode.PROCESS_QUERY_FAILED,
+                f"查询 OBS 进程超时: {command[0] if command else 'unknown'}",
+            ) from exc
+        except OSError as exc:
+            raise ObsProcessError(
+                ObsProcessFailureCode.PROCESS_QUERY_FAILED,
+                f"无法查询 OBS 进程: {exc}",
+            ) from exc
+        return CommandResult(result.returncode, result.stdout, result.stderr)
+
+
+class _PosixProcessLauncher:
+    """Detach a POSIX child into a new session owned by the desktop user."""
+
+    def launch(self, command: Sequence[str]) -> None:
+        """Start OBS with explicit argv and detached standard streams."""
+        subprocess.Popen(
+            list(command),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+
+
+class _WindowsProcessLauncher:
+    """Detach a Windows child without opening a console window."""
+
+    def launch(self, command: Sequence[str]) -> None:
+        """Start OBS with Windows process-group and detached-process flags."""
+        # These stable Win32 values are exposed as subprocess constants only on Windows.
+        creation_flags = 0x00000200 | 0x00000008
+        subprocess.Popen(
+            list(command),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+            creationflags=creation_flags,
+        )
+
+
+ExecutableLookup = Callable[[str], str | None]
+
+
+class _ObsExecutableProcess:
+    """Shared executable lookup and error normalization for concrete OS adapters."""
+
+    def __init__(
+        self,
+        *,
+        executable_names: tuple[str, ...],
+        candidate_executables: tuple[Path, ...],
+        runner: ProcessCommandRunner,
+        launcher: ProcessLauncher,
+        executable_lookup: ExecutableLookup,
+    ) -> None:
+        """Create an adapter with explicit external command and filesystem capabilities."""
+        self._executable_names = executable_names
+        self._candidate_executables = candidate_executables
+        self._runner = runner
+        self._launcher = launcher
+        self._executable_lookup = executable_lookup
+
+    def find_executable(self) -> Path | None:
+        """Find OBS in platform installation paths, then in PATH."""
+        for candidate in self._candidate_executables:
+            if candidate.is_file():
+                return candidate
+        for name in self._executable_names:
+            executable = self._executable_lookup(name)
+            if executable is not None:
+                return Path(executable)
+        return None
+
+    def launch(self) -> None:
+        """Resolve OBS and hand off its detached process lifetime to the OS."""
+        executable = self.find_executable()
+        if executable is None:
+            names = ", ".join(self._executable_names)
+            raise ObsProcessError(
+                ObsProcessFailureCode.EXECUTABLE_NOT_FOUND,
+                f"未找到 OBS 可执行文件，请确认已安装或加入 PATH（候选: {names}）。",
+            )
+        try:
+            self._launcher.launch((str(executable),))
+        except PermissionError as exc:
+            raise ObsProcessError(
+                ObsProcessFailureCode.PERMISSION_DENIED,
+                f"没有权限启动 OBS: {executable}",
+            ) from exc
+        except FileNotFoundError as exc:
+            raise ObsProcessError(
+                ObsProcessFailureCode.EXECUTABLE_NOT_FOUND,
+                f"OBS 可执行文件已不存在: {executable}",
+            ) from exc
+        except OSError as exc:
+            raise ObsProcessError(
+                ObsProcessFailureCode.LAUNCH_FAILED,
+                f"启动 OBS 失败: {exc}",
+            ) from exc
+
+
+class LinuxObsProcess(_ObsExecutableProcess):
+    """Use Linux ``/proc`` inspection and PATH executable lookup."""
+
+    def __init__(
+        self,
+        *,
+        proc_root: Path = Path("/proc"),
+        runner: ProcessCommandRunner | None = None,
+        launcher: ProcessLauncher | None = None,
+        executable_lookup: ExecutableLookup = shutil.which,
+    ) -> None:
+        """Create a Linux adapter with injectable process and launch boundaries."""
+        super().__init__(
+            executable_names=("obs", "obs-studio"),
+            candidate_executables=(),
+            runner=runner if runner is not None else _SubprocessCommandRunner(),
+            launcher=launcher if launcher is not None else _PosixProcessLauncher(),
+            executable_lookup=executable_lookup,
+        )
+        self._proc_root = proc_root
+
+    def is_running(self) -> bool:
+        """Inspect numeric Linux process directories without requiring ``ps``."""
+        if not self._proc_root.exists():
+            return False
+        try:
+            entries = tuple(self._proc_root.iterdir())
+        except OSError as exc:
+            raise ObsProcessError(
+                ObsProcessFailureCode.PROCESS_QUERY_FAILED,
+                f"无法读取 Linux 进程目录: {exc}",
+            ) from exc
+
+        for entry in entries:
+            if not entry.name.isdigit():
+                continue
+            try:
+                command = (entry / "comm").read_text(encoding="utf-8").strip()
+            except OSError:
+                continue
+            if is_obs_process_name(command):
+                return True
+        return False
+
+
+class MacOSObsProcess(_ObsExecutableProcess):
+    """Use macOS ``ps`` inspection and common OBS app-bundle locations."""
+
+    def __init__(
+        self,
+        context: PlatformContext,
+        *,
+        runner: ProcessCommandRunner | None = None,
+        launcher: ProcessLauncher | None = None,
+        executable_lookup: ExecutableLookup = shutil.which,
+    ) -> None:
+        """Create a macOS adapter with injectable command and launch boundaries."""
+        super().__init__(
+            executable_names=("obs", "obs-studio"),
+            candidate_executables=(
+                Path("/Applications/OBS.app/Contents/MacOS/obs"),
+                context.home / "Applications" / "OBS.app" / "Contents" / "MacOS" / "obs",
+            ),
+            runner=runner if runner is not None else _SubprocessCommandRunner(),
+            launcher=launcher if launcher is not None else _PosixProcessLauncher(),
+            executable_lookup=executable_lookup,
+        )
+
+    def is_running(self) -> bool:
+        """Inspect command names reported by macOS ``ps``."""
+        result = self._runner.run(("ps", "-A", "-o", "comm="))
+        _require_success(result, "ps")
+        return any(is_obs_process_name(line) for line in result.stdout.splitlines())
+
+
+class WindowsObsProcess(_ObsExecutableProcess):
+    """Use Windows ``tasklist`` and standard OBS installation directories."""
+
+    def __init__(
+        self,
+        context: PlatformContext,
+        *,
+        runner: ProcessCommandRunner | None = None,
+        launcher: ProcessLauncher | None = None,
+        executable_lookup: ExecutableLookup = shutil.which,
+    ) -> None:
+        """Create a Windows adapter with injectable command and launch boundaries."""
+        super().__init__(
+            executable_names=("obs64.exe", "obs.exe", "obs-studio.exe", "obs64", "obs", "obs-studio"),
+            candidate_executables=_windows_obs_paths(context),
+            runner=runner if runner is not None else _SubprocessCommandRunner(),
+            launcher=launcher if launcher is not None else _WindowsProcessLauncher(),
+            executable_lookup=executable_lookup,
+        )
+
+    def is_running(self) -> bool:
+        """Inspect executable names from Windows CSV task-list output."""
+        result = self._runner.run(("tasklist", "/FO", "CSV", "/NH"))
+        _require_success(result, "tasklist")
+        try:
+            rows = csv.reader(result.stdout.splitlines())
+            return any(row and is_obs_process_name(row[0]) for row in rows)
+        except csv.Error as exc:
+            raise ObsProcessError(
+                ObsProcessFailureCode.PROCESS_QUERY_FAILED,
+                f"无法解析 Windows 进程列表: {exc}",
+            ) from exc
+
+
+class UnsupportedObsProcess:
+    """Report an explicit capability failure on an unknown operating system."""
+
+    def find_executable(self) -> Path | None:
+        """Return no executable because process integration is unsupported."""
+        return None
+
+    def is_running(self) -> bool:
+        """Raise an actionable unsupported-platform failure."""
+        raise ObsProcessError(
+            ObsProcessFailureCode.UNSUPPORTED_PLATFORM,
+            "当前平台不支持 OBS 进程检测。",
+        )
+
+    def launch(self) -> None:
+        """Raise an actionable unsupported-platform failure."""
+        raise ObsProcessError(
+            ObsProcessFailureCode.UNSUPPORTED_PLATFORM,
+            "当前平台不支持启动 OBS。",
+        )
+
+
+def is_obs_process_name(command: str) -> bool:
+    """Match exact OBS executable names across path separators and Windows suffixes."""
+    normalized = command.strip().replace("\\", "/").rsplit("/", 1)[-1].casefold()
+    if normalized.endswith(".exe"):
+        normalized = normalized[:-4]
+    return normalized in OBS_PROCESS_NAMES
+
+
+def create_obs_process(context: PlatformContext | None = None) -> ObsProcess:
+    """Create the process adapter selected by one captured operating-system context."""
+    selected_context = create_platform_context() if context is None else context
+    factory = _OBS_PROCESS_FACTORIES.get(selected_context.kind, _unsupported_process)
+    return factory(selected_context)
+
+
+def _windows_obs_paths(context: PlatformContext) -> tuple[Path, ...]:
+    """Return standard Windows OBS executable locations from injected environment values."""
+    roots: list[Path] = []
+    for variable in ("ProgramFiles", "ProgramFiles(x86)", "LOCALAPPDATA"):
+        value = context.environment.get(variable)
+        if value is not None and value.strip():
+            roots.append(Path(value))
+    return tuple(root / "obs-studio" / "bin" / "64bit" / "obs64.exe" for root in roots)
+
+
+def _require_success(result: CommandResult, command_name: str) -> None:
+    """Convert a non-zero process-listing command into a typed query failure."""
+    if result.returncode == 0:
+        return
+    detail = result.stderr.strip()
+    if not detail:
+        detail = f"退出码 {result.returncode}"
+    raise ObsProcessError(
+        ObsProcessFailureCode.PROCESS_QUERY_FAILED,
+        f"{command_name} 查询 OBS 进程失败: {detail}",
+    )
+
+
+ProcessFactory = Callable[[PlatformContext], ObsProcess]
+
+
+def _unsupported_process(_context: PlatformContext) -> ObsProcess:
+    """Build the explicit unsupported-platform process capability."""
+    return UnsupportedObsProcess()
+
+
+_OBS_PROCESS_FACTORIES: dict[PlatformKind, ProcessFactory] = {
+    PlatformKind.LINUX: lambda context: LinuxObsProcess(),
+    PlatformKind.MACOS: MacOSObsProcess,
+    PlatformKind.WINDOWS: WindowsObsProcess,
+}
+
+
+__all__ = (
+    "CommandResult",
+    "LinuxObsProcess",
+    "MacOSObsProcess",
+    "ProcessCommandRunner",
+    "ProcessLauncher",
+    "UnsupportedObsProcess",
+    "WindowsObsProcess",
+    "create_obs_process",
+    "is_obs_process_name",
+)

--- a/src/bilihud/platform/paths.py
+++ b/src/bilihud/platform/paths.py
@@ -1,0 +1,83 @@
+"""Platform-specific user configuration directory resolution."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from .system import PlatformContext, PlatformKind, create_platform_context
+
+APP_CONFIG_NAME = "bilihud"
+CONFIG_FILE_NAME = "config.json"
+
+
+@dataclass(frozen=True, slots=True)
+class UserConfigPaths:
+    """Canonical user configuration directory and file for one platform."""
+
+    directory: Path
+
+    @property
+    def file(self) -> Path:
+        """Return the canonical JSON configuration file below ``directory``."""
+        return self.directory / CONFIG_FILE_NAME
+
+
+UserConfigPathResolver = Callable[[PlatformContext], UserConfigPaths]
+
+
+def _linux_paths(context: PlatformContext) -> UserConfigPaths:
+    """Resolve Linux configuration through the XDG user configuration rule."""
+    xdg_config_home = context.environment.get("XDG_CONFIG_HOME")
+    if xdg_config_home is not None:
+        candidate = Path(xdg_config_home)
+        if xdg_config_home.strip() and candidate.is_absolute():
+            return UserConfigPaths(candidate / APP_CONFIG_NAME)
+    return UserConfigPaths(context.home / ".config" / APP_CONFIG_NAME)
+
+
+def _macos_paths(context: PlatformContext) -> UserConfigPaths:
+    """Resolve macOS configuration below the user's Application Support directory."""
+    return UserConfigPaths(context.home / "Library" / "Application Support" / APP_CONFIG_NAME)
+
+
+def _windows_paths(context: PlatformContext) -> UserConfigPaths:
+    """Resolve Windows configuration below APPDATA with a controlled fallback."""
+    appdata = context.environment.get("APPDATA")
+    if appdata is not None:
+        candidate = Path(appdata)
+        if appdata.strip() and candidate.is_absolute():
+            return UserConfigPaths(candidate / APP_CONFIG_NAME)
+    return UserConfigPaths(context.home / "AppData" / "Roaming" / APP_CONFIG_NAME)
+
+
+def _fallback_paths(context: PlatformContext) -> UserConfigPaths:
+    """Provide a predictable home-directory fallback for unsupported systems."""
+    return UserConfigPaths(context.home / ".config" / APP_CONFIG_NAME)
+
+
+_PATH_RESOLVERS: dict[PlatformKind, UserConfigPathResolver] = {
+    PlatformKind.LINUX: _linux_paths,
+    PlatformKind.MACOS: _macos_paths,
+    PlatformKind.WINDOWS: _windows_paths,
+    PlatformKind.OTHER: _fallback_paths,
+}
+
+
+def resolve_user_config_paths(context: PlatformContext) -> UserConfigPaths:
+    """Resolve one canonical configuration location from captured platform facts."""
+    resolver = _PATH_RESOLVERS[context.kind]
+    return resolver(context)
+
+
+def default_user_config_paths() -> UserConfigPaths:
+    """Resolve the current process user's canonical configuration location."""
+    return resolve_user_config_paths(create_platform_context())
+
+
+__all__ = (
+    "UserConfigPaths",
+    "default_user_config_paths",
+    "resolve_user_config_paths",
+)

--- a/src/bilihud/platform/system.py
+++ b/src/bilihud/platform/system.py
@@ -1,0 +1,60 @@
+"""Shared operating-system facts used by platform capability adapters."""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from types import MappingProxyType
+
+
+class PlatformKind(StrEnum):
+    """Operating-system families supported by the platform adapters."""
+
+    LINUX = "linux"
+    MACOS = "macos"
+    WINDOWS = "windows"
+    OTHER = "other"
+
+
+@dataclass(frozen=True, slots=True)
+class PlatformContext:
+    """Immutable process facts captured once at the composition boundary."""
+
+    kind: PlatformKind
+    home: Path
+    environment: Mapping[str, str]
+
+
+def platform_kind(platform_name: str) -> PlatformKind:
+    """Normalize one interpreter platform name into the supported OS enum."""
+    if platform_name.startswith("linux"):
+        return PlatformKind.LINUX
+    if platform_name == "darwin":
+        return PlatformKind.MACOS
+    if platform_name in {"win32", "cygwin", "msys"}:
+        return PlatformKind.WINDOWS
+    return PlatformKind.OTHER
+
+
+def create_platform_context(
+    platform_name: str | None = None,
+    *,
+    environment: Mapping[str, str] | None = None,
+    home: Path | None = None,
+) -> PlatformContext:
+    """Capture platform facts, with injectable inputs for deterministic tests."""
+    selected_platform = sys.platform if platform_name is None else platform_name
+    selected_environment = os.environ if environment is None else environment
+    selected_home = Path.home() if home is None else home
+    return PlatformContext(
+        kind=platform_kind(selected_platform),
+        home=selected_home,
+        environment=MappingProxyType(dict(selected_environment)),
+    )
+
+
+__all__ = ("PlatformContext", "PlatformKind", "create_platform_context", "platform_kind")

--- a/src/bilihud/ui/settings/pages/live/page.py
+++ b/src/bilihud/ui/settings/pages/live/page.py
@@ -36,6 +36,7 @@ from bilihud.live.models import (
 from bilihud.live.validation import validate_room_id
 from bilihud.ui.settings.pages.live.credentials import LiveCredentials
 from bilihud.ui.settings.pages.live.verification import LiveVerificationDialog
+from bilihud.ui.settings.pages.live.warning import LiveWarningDialog
 from bilihud.ui.settings.pages.live.workflow import (
     LiveAction,
     LiveSettingsForm,
@@ -71,6 +72,7 @@ class LiveSettingsPage(QWidget):
         self._shutting_down = False
         self._verification_dialog: QDialog | None = None
         self._confirmation_dialog: QMessageBox | None = None
+        self._warning_dialog: LiveWarningDialog | None = None
         self._workflow = LiveSettingsWorkflow(
             service,
             task_scope,
@@ -237,6 +239,8 @@ class LiveSettingsPage(QWidget):
         self._shutting_down = True
         if self._confirmation_dialog is not None:
             self._confirmation_dialog.close()
+        if self._warning_dialog is not None:
+            self._warning_dialog.close()
         if self._verification_dialog is not None:
             self._verification_dialog.close()
         await self._workflow.shutdown()
@@ -458,6 +462,17 @@ class LiveSettingsPage(QWidget):
         dialog.finished.connect(lambda _result: self._clear_verification_dialog(dialog))
         dialog.open()
 
+    def show_warning(self, title: str, message: str, details: str) -> None:
+        """Show one non-blocking warning while keeping the page status available underneath."""
+        current = self._warning_dialog
+        if current is not None:
+            current.close()
+
+        dialog = LiveWarningDialog(self, title, message, details)
+        dialog.finished.connect(lambda _result: self._clear_warning_dialog(dialog))
+        self._warning_dialog = dialog
+        dialog.open()
+
     async def confirm_obs_switch(self) -> bool:
         """Ask asynchronously before stopping an existing OBS stream."""
         loop = asyncio.get_running_loop()
@@ -495,6 +510,11 @@ class LiveSettingsPage(QWidget):
         """Release the latest verification window after it closes."""
         if self._verification_dialog is dialog:
             self._verification_dialog = None
+
+    def _clear_warning_dialog(self, dialog: LiveWarningDialog) -> None:
+        """Release the latest warning window after it closes."""
+        if self._warning_dialog is dialog:
+            self._warning_dialog = None
 
     def _mark_obs_unchecked(self) -> None:
         self._obs_connected = False

--- a/src/bilihud/ui/settings/pages/live/warning.py
+++ b/src/bilihud/ui/settings/pages/live/warning.py
@@ -1,0 +1,94 @@
+"""Custom warning dialog for partial live-control outcomes."""
+
+from __future__ import annotations
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QShowEvent
+from PyQt6.QtWidgets import QDialog, QFrame, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
+
+
+class LiveWarningDialog(QDialog):
+    """Render a compact, non-blocking warning in the settings visual language."""
+
+    def __init__(self, parent: QWidget, title: str, message: str, details: str) -> None:
+        """Create a warning surface with one explicit acknowledgement action."""
+        super().__init__(parent)
+        self.setObjectName("live_warning_dialog")
+        self.setWindowTitle(title)
+        self.setWindowFlags(Qt.WindowType.Dialog | Qt.WindowType.FramelessWindowHint)
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose, True)
+        self.setMinimumWidth(460)
+        self.resize(480, 252)
+        self._build_ui(title, message, details)
+
+    def _build_ui(self, title: str, message: str, details: str) -> None:
+        """Build the warning hierarchy without introducing a second settings surface."""
+        root = QVBoxLayout(self)
+        root.setContentsMargins(10, 10, 10, 10)
+
+        surface = QFrame(self)
+        surface.setObjectName("warning_surface")
+        surface_layout = QVBoxLayout(surface)
+        surface_layout.setContentsMargins(22, 20, 22, 18)
+        surface_layout.setSpacing(16)
+
+        header = QHBoxLayout()
+        header.setSpacing(12)
+
+        mark = QFrame(surface)
+        mark.setObjectName("warning_mark")
+        mark.setFixedSize(40, 40)
+        mark_layout = QVBoxLayout(mark)
+        mark_layout.setContentsMargins(0, 0, 0, 0)
+        mark_label = QLabel("!", mark)
+        mark_label.setObjectName("warning_mark_label")
+        mark_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        mark_layout.addWidget(mark_label)
+        header.addWidget(mark, 0, Qt.AlignmentFlag.AlignTop)
+
+        heading = QVBoxLayout()
+        heading.setSpacing(3)
+        title_label = QLabel(title, surface)
+        title_label.setObjectName("warning_title")
+        title_label.setWordWrap(True)
+        message_label = QLabel(message, surface)
+        message_label.setObjectName("warning_message")
+        message_label.setWordWrap(True)
+        heading.addWidget(title_label)
+        heading.addWidget(message_label)
+        header.addLayout(heading, 1)
+        surface_layout.addLayout(header)
+
+        details_frame = QFrame(surface)
+        details_frame.setObjectName("warning_details_frame")
+        details_layout = QVBoxLayout(details_frame)
+        details_layout.setContentsMargins(12, 10, 12, 10)
+        details_label = QLabel(details, details_frame)
+        details_label.setObjectName("warning_details")
+        details_label.setWordWrap(True)
+        details_layout.addWidget(details_label)
+        surface_layout.addWidget(details_frame)
+
+        actions = QHBoxLayout()
+        actions.setContentsMargins(0, 0, 0, 0)
+        actions.addStretch(1)
+        acknowledge = QPushButton("知道了", surface)
+        acknowledge.setProperty("accent", True)
+        acknowledge.clicked.connect(self.accept)
+        actions.addWidget(acknowledge)
+        surface_layout.addLayout(actions)
+
+        root.addWidget(surface)
+
+    def showEvent(self, a0: QShowEvent | None) -> None:
+        """Center the transient warning over the owning settings window."""
+        self.adjustSize()
+        parent = self.parentWidget()
+        window = parent.window() if parent is not None else None
+        if window is not None:
+            self.move(window.frameGeometry().center() - self.rect().center())
+        super().showEvent(a0)
+
+
+__all__ = ("LiveWarningDialog",)

--- a/src/bilihud/ui/settings/pages/live/workflow.py
+++ b/src/bilihud/ui/settings/pages/live/workflow.py
@@ -11,6 +11,7 @@ from typing import Protocol
 
 from bilihud.app.lifecycle import TaskScope, cancel_task
 from bilihud.live.models import (
+    LiveControlErrorCode,
     LiveControlOperationResult,
     LiveControlState,
     LiveVerificationKind,
@@ -131,6 +132,10 @@ class LiveSettingsView(Protocol):
 
     def show_verification(self, url: str, kind: LiveVerificationKind) -> None:
         """Show non-blocking verification UI when the service requires it."""
+        ...
+
+    def show_warning(self, title: str, message: str, details: str) -> None:
+        """Show a non-blocking warning for a completed action with an unresolved side effect."""
         ...
 
     async def confirm_obs_switch(self) -> bool:
@@ -406,6 +411,12 @@ class LiveSettingsWorkflow:
             config_saved = self._view.save_form_config()
             outcome = await service.stop_live(values.room_id, values.obs)
             self._view.apply_service_state(outcome.state)
+            if outcome.status is StopLiveStatus.STOPPED_WITH_OBS_FAILURE:
+                self._view.show_warning(
+                    "OBS 推流状态未确认",
+                    "Bilibili 直播已停止，但 OBS 推流未能自动确认。",
+                    "请打开 OBS 手动确认推流状态。",
+                )
             if outcome.status is StopLiveStatus.STOPPED:
                 if config_saved:
                     self._view.set_status("直播已停止。", success=True)
@@ -480,6 +491,12 @@ class LiveSettingsWorkflow:
                     self._join_messages(outcome.notice, message, hud_notice, persistence_notice),
                     error=True,
                 )
+                if outcome.error.code is LiveControlErrorCode.OBS_FAILURE:
+                    self._view.show_warning(
+                        "OBS 推流未启动",
+                        "Bilibili 直播已开始，但 OBS 推流未成功启动。",
+                        f"{outcome.error.message}\n\n请检查 OBS 是否已启动以及 WebSocket 配置。",
+                    )
             else:
                 message = "直播已开始，OBS 推流已启动。" if outcome.obs_started else "直播已开始。"
                 if persistence_notice or hud_notice:

--- a/src/bilihud/ui/settings/style.py
+++ b/src/bilihud/ui/settings/style.py
@@ -148,6 +148,26 @@ def settings_stylesheet(appearance: Appearance) -> str:
         QLabel#verification_qr {{ background: #ffffff; border: 1px solid {appearance.border}; border-radius: 10px; }}
         QLabel#verification_url {{ color: {appearance.muted_text}; }}
         QFrame#verification_header {{ background: transparent; }}
+        QDialog#live_warning_dialog {{ background: transparent; }}
+        QFrame#warning_surface {{
+            background: {appearance.surface};
+            border: 1px solid {appearance.border};
+            border-radius: 10px;
+        }}
+        QFrame#warning_mark {{
+            background: #fff1d6;
+            border: 1px solid #f3c878;
+            border-radius: 20px;
+        }}
+        QLabel#warning_mark_label {{ color: #a76600; font-size: 21px; font-weight: 800; }}
+        QLabel#warning_title {{ color: {appearance.text}; font-size: 17px; font-weight: 700; }}
+        QLabel#warning_message {{ color: {appearance.text}; font-size: 13px; }}
+        QFrame#warning_details_frame {{
+            background: {appearance.surface_alt};
+            border: 1px solid {appearance.border};
+            border-radius: 6px;
+        }}
+        QLabel#warning_details {{ color: {appearance.muted_text}; font-size: 12px; }}
         QListWidget#navigation {{
             background: transparent;
             border: none;

--- a/tests/live/test_obs_api.py
+++ b/tests/live/test_obs_api.py
@@ -1,3 +1,9 @@
+from pathlib import Path
+
+import pytest
+
+from bilihud.app.obs_control import ObsAdapterError, ObsProcessError, ObsProcessFailureCode
+from bilihud.live.adapters import ObsWebSocketAdapter
 from bilihud.live.api import StreamCredential
 from bilihud.live.obs import (
     build_get_stream_status_request,
@@ -78,6 +84,31 @@ def test_is_obs_process_name_matches_common_obs_binary_names():
     assert is_obs_process_name("/usr/bin/obs-studio")
     assert not is_obs_process_name("obsidian")
     assert not is_obs_process_name("python")
+
+
+class FailingObsProcess:
+    """Expose one typed process failure for adapter-boundary verification."""
+
+    def find_executable(self) -> Path | None:
+        """Return no executable for this failure-path fake."""
+        return None
+
+    def is_running(self) -> bool:
+        """Raise the process query failure the platform adapter would provide."""
+        raise ObsProcessError(ObsProcessFailureCode.PROCESS_QUERY_FAILED, "查询失败")
+
+    def launch(self) -> None:
+        """Raise the same failure if launch is accidentally attempted."""
+        raise ObsProcessError(ObsProcessFailureCode.PROCESS_QUERY_FAILED, "查询失败")
+
+
+def test_obs_websocket_adapter_preserves_typed_process_failure_code() -> None:
+    adapter = ObsWebSocketAdapter(process=FailingObsProcess())
+
+    with pytest.raises(ObsAdapterError) as raised:
+        adapter.is_process_running()
+
+    assert raised.value.process_code is ObsProcessFailureCode.PROCESS_QUERY_FAILED
 
 
 def test_obs_check_button_state_only_depends_on_port_and_check_busy_state():

--- a/tests/platform/test_obs_process.py
+++ b/tests/platform/test_obs_process.py
@@ -1,0 +1,155 @@
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from bilihud.app.obs_control import ObsProcessError, ObsProcessFailureCode
+from bilihud.platform.obs_process import (
+    CommandResult,
+    LinuxObsProcess,
+    MacOSObsProcess,
+    WindowsObsProcess,
+    is_obs_process_name,
+)
+from bilihud.platform.system import create_platform_context
+
+
+class FakeRunner:
+    """Return deterministic process-listing output and retain argv for assertions."""
+
+    def __init__(self, result: CommandResult) -> None:
+        self.result = result
+        self.commands: list[tuple[str, ...]] = []
+
+    def run(self, command: Sequence[str]) -> CommandResult:
+        self.commands.append(tuple(command))
+        return self.result
+
+
+class FakeLauncher:
+    """Capture detached launch argv or raise one configured operating-system error."""
+
+    def __init__(self, error: OSError | None = None) -> None:
+        self.error = error
+        self.commands: list[tuple[str, ...]] = []
+
+    def launch(self, command: Sequence[str]) -> None:
+        self.commands.append(tuple(command))
+        if self.error is not None:
+            raise self.error
+
+
+def test_obs_process_name_normalization_matches_exact_windows_and_posix_names() -> None:
+    assert is_obs_process_name(r"C:\\Program Files\\obs-studio\\bin\\64bit\\OBS64.EXE")
+    assert is_obs_process_name("/usr/bin/obs-studio")
+    assert not is_obs_process_name("obsidian.exe")
+    assert not is_obs_process_name("python")
+
+
+def test_linux_process_adapter_reads_proc_comm_only(tmp_path: Path) -> None:
+    proc_root = tmp_path / "proc"
+    (proc_root / "123").mkdir(parents=True)
+    (proc_root / "123" / "comm").write_text("obs\n", encoding="utf-8")
+    (proc_root / "not-a-pid").mkdir()
+
+    adapter = LinuxObsProcess(proc_root=proc_root, executable_lookup=lambda _name: None)
+
+    assert adapter.is_running() is True
+
+
+def test_linux_process_adapter_reports_missing_process_directory_as_not_running(tmp_path: Path) -> None:
+    adapter = LinuxObsProcess(proc_root=tmp_path / "missing", executable_lookup=lambda _name: None)
+
+    assert adapter.is_running() is False
+
+
+def test_macos_process_adapter_parses_ps_output_without_using_linux_proc() -> None:
+    runner = FakeRunner(CommandResult(0, "/usr/bin/obs\nobsidian\n", ""))
+    adapter = MacOSObsProcess(
+        create_platform_context("darwin", environment={}, home=Path("/home/test")),
+        runner=runner,
+        executable_lookup=lambda _name: None,
+    )
+
+    assert adapter.is_running() is True
+    assert runner.commands == [("ps", "-A", "-o", "comm=")]
+
+
+def test_windows_process_adapter_parses_exact_tasklist_names() -> None:
+    runner = FakeRunner(
+        CommandResult(
+            0,
+            '"obsidian.exe","10","Console","1","1,000 K"\n'
+            '"OBS64.EXE","11","Console","1","2,000 K"\n',
+            "",
+        )
+    )
+    adapter = WindowsObsProcess(
+        create_platform_context("win32", environment={}, home=Path("C:/Users/test")),
+        runner=runner,
+        executable_lookup=lambda _name: None,
+    )
+
+    assert adapter.is_running() is True
+    assert runner.commands == [("tasklist", "/FO", "CSV", "/NH")]
+
+
+def test_windows_process_adapter_finds_standard_install_path_with_spaces(tmp_path: Path) -> None:
+    program_files = tmp_path / "Program Files"
+    executable = program_files / "obs-studio" / "bin" / "64bit" / "obs64.exe"
+    executable.parent.mkdir(parents=True)
+    executable.write_bytes(b"")
+    adapter = WindowsObsProcess(
+        create_platform_context("win32", environment={"ProgramFiles": str(program_files)}, home=tmp_path),
+        executable_lookup=lambda _name: None,
+    )
+
+    assert adapter.find_executable() == executable
+
+
+def test_obs_process_launch_uses_explicit_argv_and_preserves_unicode_path(tmp_path: Path) -> None:
+    executable = tmp_path / "OBS Studio 中文" / "obs64.exe"
+    launcher = FakeLauncher()
+    adapter = WindowsObsProcess(
+        create_platform_context("win32", environment={}, home=tmp_path),
+        launcher=launcher,
+        executable_lookup=lambda name: str(executable) if name == "obs64.exe" else None,
+    )
+
+    adapter.launch()
+
+    assert launcher.commands == [(str(executable),)]
+
+
+@pytest.mark.parametrize(
+    ("error", "code"),
+    [
+        (PermissionError("denied"), ObsProcessFailureCode.PERMISSION_DENIED),
+        (OSError("cannot start"), ObsProcessFailureCode.LAUNCH_FAILED),
+    ],
+)
+def test_obs_process_launch_reports_operating_system_failures(
+    tmp_path: Path,
+    error: OSError,
+    code: ObsProcessFailureCode,
+) -> None:
+    executable = tmp_path / "obs"
+    launcher = FakeLauncher(error)
+    adapter = LinuxObsProcess(
+        launcher=launcher,
+        executable_lookup=lambda _name: str(executable),
+    )
+
+    with pytest.raises(ObsProcessError) as raised:
+        adapter.launch()
+
+    assert raised.value.code is code
+
+
+def test_obs_process_launch_reports_missing_executable() -> None:
+    adapter = LinuxObsProcess(executable_lookup=lambda _name: None)
+
+    with pytest.raises(ObsProcessError) as raised:
+        adapter.launch()
+
+    assert raised.value.code is ObsProcessFailureCode.EXECUTABLE_NOT_FOUND

--- a/tests/platform/test_paths.py
+++ b/tests/platform/test_paths.py
@@ -40,7 +40,9 @@ def test_linux_paths_use_absolute_xdg_config_home(tmp_path: Path) -> None:
 def test_linux_paths_fall_back_when_xdg_config_home_is_missing_or_relative(tmp_path: Path) -> None:
     home = tmp_path / "home"
 
-    missing = resolve_user_config_paths(create_platform_context("linux", home=home))
+    missing = resolve_user_config_paths(
+        create_platform_context("linux", environment={}, home=home)
+    )
     relative = resolve_user_config_paths(
         create_platform_context("linux", environment={"XDG_CONFIG_HOME": "relative"}, home=home)
     )

--- a/tests/platform/test_paths.py
+++ b/tests/platform/test_paths.py
@@ -1,0 +1,83 @@
+from collections.abc import Mapping
+from pathlib import Path
+
+import bilihud.config.legacy as legacy_config
+import bilihud.config.store as config_store
+from bilihud.platform.paths import UserConfigPaths, resolve_user_config_paths
+from bilihud.platform.system import PlatformKind, create_platform_context, platform_kind
+
+
+class IdentityMigrator:
+    """Keep the config-store path test independent from secure storage."""
+
+    def migrate(self, raw: Mapping[str, object]) -> tuple[dict[str, object], bool]:
+        """Return the supplied mapping without changing its values."""
+        return dict(raw), False
+
+
+def test_platform_kind_normalizes_supported_interpreter_names() -> None:
+    assert platform_kind("linux") is PlatformKind.LINUX
+    assert platform_kind("darwin") is PlatformKind.MACOS
+    assert platform_kind("win32") is PlatformKind.WINDOWS
+    assert platform_kind("freebsd") is PlatformKind.OTHER
+
+
+def test_linux_paths_use_absolute_xdg_config_home(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    xdg_home = tmp_path / "xdg config"
+    context = create_platform_context(
+        "linux",
+        environment={"XDG_CONFIG_HOME": str(xdg_home)},
+        home=home,
+    )
+
+    paths = resolve_user_config_paths(context)
+
+    assert paths.directory == xdg_home / "bilihud"
+    assert paths.file == xdg_home / "bilihud" / "config.json"
+
+
+def test_linux_paths_fall_back_when_xdg_config_home_is_missing_or_relative(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+
+    missing = resolve_user_config_paths(create_platform_context("linux", home=home))
+    relative = resolve_user_config_paths(
+        create_platform_context("linux", environment={"XDG_CONFIG_HOME": "relative"}, home=home)
+    )
+
+    expected = home / ".config" / "bilihud"
+    assert missing.directory == expected
+    assert relative.directory == expected
+
+
+def test_macos_paths_use_application_support_without_linux_legacy_lookup(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    context = create_platform_context("darwin", environment={}, home=home)
+
+    paths = resolve_user_config_paths(context)
+
+    assert paths.directory == home / "Library" / "Application Support" / "bilihud"
+    assert not (home / ".config" / "bilihud" / "config.json").exists()
+
+
+def test_windows_paths_prefer_appdata_and_have_a_non_dot_config_fallback(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    appdata = tmp_path / "AppData" / "Roaming"
+
+    configured = resolve_user_config_paths(
+        create_platform_context("win32", environment={"APPDATA": str(appdata)}, home=home)
+    )
+    fallback = resolve_user_config_paths(create_platform_context("win32", environment={}, home=home))
+
+    assert configured.directory == appdata / "bilihud"
+    assert fallback.directory == home / "AppData" / "Roaming" / "bilihud"
+    assert fallback.directory != home / ".config" / "bilihud"
+
+
+def test_config_store_and_legacy_facade_share_the_canonical_path(monkeypatch, tmp_path: Path) -> None:
+    expected = UserConfigPaths(tmp_path / "Application Support" / "bilihud")
+    monkeypatch.setattr(config_store, "default_user_config_paths", lambda: expected)
+
+    assert config_store.default_config_path() == expected.file
+    assert legacy_config.get_config_path() == expected.file
+    assert config_store.JsonConfigStore(migrator=IdentityMigrator()).path == expected.file

--- a/tests/platform/test_window_platform.py
+++ b/tests/platform/test_window_platform.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from pathlib import Path
 
 import pytest
 from PyQt6.QtWidgets import QApplication
@@ -266,6 +267,28 @@ def test_generic_qt_platform_keeps_gaming_mode_on_non_wayland(monkeypatch, platf
         ),
         WindowPolicy(),
     ]
+
+
+def test_non_linux_qt_provider_does_not_attempt_to_load_layer_shell_bridge(monkeypatch) -> None:
+    """Windows and macOS use generic Qt activation without touching the Linux bridge."""
+    _app()
+    monkeypatch.setattr(window_platform.QGuiApplication, "platformName", lambda: "windows")
+
+    def fail_if_probed(_package_dir: Path) -> tuple[None, str]:
+        """Fail the test if a non-Linux provider probes the Linux bridge."""
+        raise AssertionError("Layer Shell must not be probed")
+
+    monkeypatch.setattr(
+        window_platform,
+        "load_layer_shell_bridge",
+        fail_if_probed,
+    )
+
+    platform = window_platform.DefaultOverlayPlatformFactory()(FakeWindowHost())
+
+    assert platform.capabilities.layer_shell is False
+    assert platform.prepare() == OverlayOperationResult.success()
+    assert platform.activate() == OverlayOperationResult.success()
 
 
 def test_platform_probe_logs_backend_and_selected_provider(monkeypatch, caplog) -> None:

--- a/tests/test_live_settings_workflow.py
+++ b/tests/test_live_settings_workflow.py
@@ -16,16 +16,26 @@ from bilihud.live.models import (
     StartLiveOutcome,
     StartLiveStatus,
     StopLiveOutcome,
+    StopLiveStatus,
 )
 from bilihud.ui.settings.pages.live.workflow import LiveAction, LiveSettingsForm, LiveSettingsWorkflow
 
 
 class FakeLiveService:
-    def __init__(self, outcomes: list[StartLiveOutcome]) -> None:
+    def __init__(
+        self,
+        outcomes: list[StartLiveOutcome],
+        *,
+        stop_outcome: StopLiveOutcome | None = None,
+    ) -> None:
         self.state = LiveControlState(
             session=LiveSessionInfo(status=SessionStatus.AUTHENTICATED),
         )
         self._outcomes = outcomes
+        self._stop_outcome = stop_outcome if stop_outcome is not None else StopLiveOutcome(
+            StopLiveStatus.STOPPED,
+            self.state,
+        )
         self.start_calls: list[bool] = []
 
     async def initialize(self, room_id: int | None) -> LiveControlOperationResult:
@@ -59,7 +69,7 @@ class FakeLiveService:
 
     async def stop_live(self, room_id: int | None, obs_settings: ObsSettings | None) -> StopLiveOutcome:
         del room_id, obs_settings
-        raise AssertionError("not used in this test")
+        return self._stop_outcome
 
     async def check_obs(self, settings: ObsSettings | None) -> ObsCheckOutcome:
         del settings
@@ -79,6 +89,7 @@ class FakeLiveView:
         self._save_success = save_success
         self.busy_actions: list[LiveAction | None] = []
         self.statuses: list[tuple[str, bool, bool]] = []
+        self.warnings: list[tuple[str, str, str]] = []
         self.verifications: list[tuple[str, LiveVerificationKind]] = []
         self.confirmation_count = 0
 
@@ -107,6 +118,9 @@ class FakeLiveView:
 
     def show_verification(self, url: str, kind: LiveVerificationKind) -> None:
         self.verifications.append((url, kind))
+
+    def show_warning(self, title: str, message: str, details: str) -> None:
+        self.warnings.append((title, message, details))
 
     async def confirm_obs_switch(self) -> bool:
         self.confirmation_count += 1
@@ -143,6 +157,23 @@ def _run_start_sync(
         task = workflow.start_live()
         if task is None:
             raise AssertionError("start workflow was not scheduled")
+        await task
+        await workflow.shutdown()
+        await supervisor.shutdown()
+
+    asyncio.run(run())
+
+
+def _run_stop_sync(service: FakeLiveService, view: FakeLiveView) -> None:
+    """Run one public stop workflow to completion in an isolated supervisor."""
+
+    async def run() -> None:
+        supervisor = TaskSupervisor()
+        scope = supervisor.create_scope("live-settings-test")
+        workflow = LiveSettingsWorkflow(service, scope, view)
+        task = workflow.stop_live()
+        if task is None:
+            raise AssertionError("stop workflow was not scheduled")
         await task
         await workflow.shutdown()
         await supervisor.shutdown()
@@ -197,6 +228,44 @@ def test_start_live_does_not_report_missing_credentials_as_full_success() -> Non
     assert "设置保存失败" in message
     assert error is True
     assert success is False
+
+
+def test_start_live_surfaces_obs_failure_in_a_warning_dialog() -> None:
+    outcome = StartLiveOutcome(
+        StartLiveStatus.STARTED,
+        LiveControlState(),
+        LiveControlError(LiveControlErrorCode.OBS_FAILURE, "OBS WebSocket 连接失败"),
+    )
+    view = FakeLiveView()
+
+    _run_start_sync(FakeLiveService([outcome]), view)
+
+    assert view.warnings == [
+        (
+            "OBS 推流未启动",
+            "Bilibili 直播已开始，但 OBS 推流未成功启动。",
+            "OBS WebSocket 连接失败\n\n请检查 OBS 是否已启动以及 WebSocket 配置。",
+        )
+    ]
+
+
+def test_stop_live_surfaces_unconfirmed_obs_state_in_a_warning_dialog() -> None:
+    outcome = StopLiveOutcome(
+        StopLiveStatus.STOPPED_WITH_OBS_FAILURE,
+        LiveControlState(),
+        LiveControlError(LiveControlErrorCode.OBS_FAILURE, "OBS 推流未能自动确认"),
+    )
+    view = FakeLiveView()
+
+    _run_stop_sync(FakeLiveService([], stop_outcome=outcome), view)
+
+    assert view.warnings == [
+        (
+            "OBS 推流状态未确认",
+            "Bilibili 直播已停止，但 OBS 推流未能自动确认。",
+            "请打开 OBS 手动确认推流状态。",
+        )
+    ]
 
 
 def test_start_live_presents_face_auth_and_requires_retry_after_verification() -> None:

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -314,3 +314,31 @@ def test_live_face_verification_uses_face_auth_copy() -> None:
     assert "完成人脸认证" in prompt.text()
     assert "重新点击“开始直播”" in prompt.text()
     dialog.close()
+
+
+def test_live_warning_uses_the_settings_visual_language() -> None:
+    _app()
+    page = LiveSettingsPage()
+
+    page.show_warning(
+        "OBS 推流状态未确认",
+        "Bilibili 直播已停止，但 OBS 推流未能自动确认。",
+        "请打开 OBS 手动确认推流状态。",
+    )
+    dialog = page.findChild(QDialog, "live_warning_dialog")
+
+    assert dialog is not None
+    assert dialog.windowFlags() & Qt.WindowType.FramelessWindowHint
+    assert dialog.testAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+    title = dialog.findChild(QLabel, "warning_title")
+    message = dialog.findChild(QLabel, "warning_message")
+    details = dialog.findChild(QLabel, "warning_details")
+    assert title is not None
+    assert message is not None
+    assert details is not None
+    assert title.text() == "OBS 推流状态未确认"
+    assert "Bilibili 直播已停止" in message.text()
+    assert details.text() == "请打开 OBS 手动确认推流状态。"
+
+    dialog.close()
+    page.close()


### PR DESCRIPTION
## Summary
- centralize Linux, macOS, and Windows platform context and user configuration paths
- isolate OBS process discovery, executable lookup, and detached launch behind typed platform adapters
- keep the Linux Layer Shell bridge optional at build time and probe it only for compatible Wayland runtimes
- add a themed, non-blocking warning dialog for OBS partial-success and unconfirmed-stop states
- add platform adapter tests, Qt workflow tests, documentation, and Linux/macOS/Windows pure-adapter CI coverage

## Scope decisions
- Windows uses keyring's native Windows credential backend through the existing API
- new Windows/macOS users do not receive a legacy Linux `.config` migration path
- Bilibili live start remains independent from optional OBS connectivity; the UI now makes OBS failures prominent

## Verification
- `QT_QPA_PLATFORM=offscreen UV_CACHE_DIR=/tmp/bilihud-uv-cache uv run pytest -q` -> 240 passed
- `UV_CACHE_DIR=/tmp/bilihud-uv-cache uv run ruff check src tests` -> passed
- targeted `ty check` for changed source and UI modules -> passed
- `uv build` -> passed
- `git diff --check` -> passed

## Risks
- full-repository `ty check src` still reports the repository's pre-existing unresolved `blivedm` imports; no new diagnostics were introduced by this PR
- OBS remains an optional side effect of starting/stopping Bilibili live, but its failure is now surfaced in both inline status and a high-salience dialog

Closes #49