### PR TITLE
refactor(types): type-check tests with vendored blivedm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,11 @@ jobs:
         # exit-zero treats all errors as warnings
         ruff check --exit-zero --statistics src/
 
+    - name: Check types
+      env:
+        PYTHONPATH: vendor/blivedm
+      run: ty check src tests
+
     - name: Check architecture boundaries
       run: pytest tests/test_architecture.py
 

--- a/src/bilihud/app/account_controller.py
+++ b/src/bilihud/app/account_controller.py
@@ -10,10 +10,10 @@ from enum import StrEnum
 from typing import Protocol
 
 from ..auth.service import (
+    AccountAuthenticationService,
     AccountLookupResult,
     AccountLookupStatus,
     AccountProfile,
-    AuthenticationService,
 )
 from .lifecycle import TaskScope, cancel_task
 from .menu import AccountStatus
@@ -75,7 +75,7 @@ class AccountSessionController:
     def __init__(
         self,
         *,
-        auth_service: AuthenticationService,
+        auth_service: AccountAuthenticationService,
         hud_controller: HudDisconnecter,
         live_control_service: LiveSessionCloser,
         task_scope: TaskScope,

--- a/src/bilihud/app/application_controller.py
+++ b/src/bilihud/app/application_controller.py
@@ -7,14 +7,14 @@ import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
-from ..auth.service import AuthenticationService
+from ..auth.service import ApplicationAuthenticationService
 from ..config.store import AppConfig
 from ..mirror.state import MirrorDisplaySettings
 from .account_controller import AccountLogoutResult, AccountSessionController
 from .hud_controller import HudController
 from .lifecycle import TaskScope
-from .mirror_coordinator import MirrorCoordinator, MirrorOperationResult
-from .services import AppServices
+from .mirror_coordinator import MirrorCoordinatorPort, MirrorOperationResult
+from .services import ApplicationServices
 
 logger = logging.getLogger(__name__)
 
@@ -35,15 +35,15 @@ class ApplicationController:
         *,
         room_id: int,
         sessdata: str,
-        services: AppServices,
+        services: ApplicationServices,
         config: AppConfig,
         task_scope: TaskScope,
     ) -> None:
         """Assemble application services with a scope owned by the runtime."""
         self.services = services
         self.config = config
-        self.auth_service: AuthenticationService = services.auth_service
-        self.mirror_coordinator: MirrorCoordinator = services.mirror_coordinator
+        self.auth_service: ApplicationAuthenticationService = services.auth_service
+        self.mirror_coordinator: MirrorCoordinatorPort = services.mirror_coordinator
         self._task_scope = task_scope
         self._shutting_down = False
         self._shutdown_complete = False

--- a/src/bilihud/app/hud_client.py
+++ b/src/bilihud/app/hud_client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Protocol
 
-from ..auth.service import AuthenticationService
+from ..auth.service import DanmakuAuthenticationService
 from ..danmaku.messages import HudMessage
 from ..live.audience import AudienceSnapshot
 from ..live.emoticons import LiveEmoticon, LiveEmoticonPackage
@@ -61,7 +61,7 @@ class HudClientFactory(Protocol):
         self,
         room_id: int,
         sessdata: str,
-        auth_service: AuthenticationService,
+        auth_service: DanmakuAuthenticationService,
     ) -> HudClient:
         """Create a client without starting network activity."""
         ...

--- a/src/bilihud/app/hud_controller.py
+++ b/src/bilihud/app/hud_controller.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 from dataclasses import replace
 
-from ..auth.service import AuthenticationService
+from ..auth.service import DanmakuAuthenticationService
 from ..config.store import ConfigStore
 from ..danmaku.messages import HudMessage
 from ..live.audience import AudienceSnapshot
@@ -38,7 +38,7 @@ class HudController:
         *,
         initial_room_id: int,
         sessdata: str,
-        auth_service: AuthenticationService,
+        auth_service: DanmakuAuthenticationService,
         client_factory: HudClientFactory,
         config_store: ConfigStore | None = None,
         task_scope: TaskScope | None = None,

--- a/src/bilihud/app/live_control_service.py
+++ b/src/bilihud/app/live_control_service.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from dataclasses import replace
 from io import BytesIO
+from typing import Protocol
 
 from ..config.store import ConfigStore
 from ..live.models import (
@@ -39,6 +40,75 @@ from .obs_control import ObsAdapter, ObsAdapterError
 from .verification import QrImageGenerator
 
 logger = logging.getLogger(__name__)
+
+
+class LiveControlServicePort(Protocol):
+    """Application capability used by account and live-settings workflows."""
+
+    @property
+    def state(self) -> LiveControlState:
+        """Return the latest immutable live-control snapshot."""
+        ...
+
+    def load_settings(self) -> LiveControlSettings:
+        """Load persisted live-control form values."""
+        ...
+
+    def save_settings(self, settings: LiveControlSettings) -> SettingsSaveOutcome:
+        """Persist live-control form values."""
+        ...
+
+    def generate_qr_image(self, url: str) -> BytesIO | None:
+        """Generate a verification QR image."""
+        ...
+
+    async def initialize(self, room_id: int | None) -> LiveControlOperationResult:
+        """Initialize the authenticated live session."""
+        ...
+
+    async def load_room_info(self, room_id: int | None) -> LiveControlOperationResult:
+        """Load room metadata."""
+        ...
+
+    async def update_title(self, room_id: int | None, title: str) -> LiveControlOperationResult:
+        """Update the room title."""
+        ...
+
+    async def update_area(self, room_id: int | None, area_id: str) -> LiveControlOperationResult:
+        """Update the room area."""
+        ...
+
+    async def start_live(
+        self,
+        room_id: int | None,
+        title: str,
+        area_id: str,
+        obs_settings: ObsSettings | None,
+        *,
+        allow_obs_switch: bool = False,
+    ) -> StartLiveOutcome:
+        """Start the live room and optionally switch the OBS stream."""
+        ...
+
+    async def stop_live(self, room_id: int | None, obs_settings: ObsSettings | None) -> StopLiveOutcome:
+        """Stop the live room and clean up OBS when possible."""
+        ...
+
+    async def check_obs(self, settings: ObsSettings | None) -> ObsCheckOutcome:
+        """Check the configured OBS endpoint."""
+        ...
+
+    async def stop_obs_stream(self, settings: ObsSettings | None) -> ObsStreamOutcome:
+        """Stop the active OBS stream."""
+        ...
+
+    async def close(self) -> None:
+        """Close the current authenticated live session."""
+        ...
+
+    async def shutdown(self) -> None:
+        """Release all service-owned resources."""
+        ...
 
 
 class LiveControlService:

--- a/src/bilihud/app/mirror_coordinator.py
+++ b/src/bilihud/app/mirror_coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, replace
+from typing import Protocol
 
 from ..config.store import AppConfig, ConfigStore
 from ..danmaku.messages import HudMessage, SystemMessageLevel
@@ -53,6 +54,39 @@ class MirrorOperationResult:
 
     state: MirrorCoordinatorState
     notices: tuple[MirrorNotice, ...] = ()
+
+
+class MirrorCoordinatorPort(Protocol):
+    """Application capability used by controllers and presentation surfaces."""
+
+    @property
+    def state(self) -> MirrorCoordinatorState:
+        """Return the immutable Mirror workflow state."""
+        ...
+
+    def apply_config(self, config: AppConfig) -> None:
+        """Apply startup configuration before the server is started."""
+        ...
+
+    def apply_display_settings(self, settings: MirrorDisplaySettings) -> None:
+        """Apply display settings without restarting the server."""
+        ...
+
+    async def start(self) -> MirrorOperationResult:
+        """Start the configured Mirror server."""
+        ...
+
+    async def set_enabled(self, enabled: bool) -> MirrorOperationResult:
+        """Persist and apply the enabled preference."""
+        ...
+
+    async def shutdown(self) -> MirrorOperationResult:
+        """Stop the server and release coordinator resources."""
+        ...
+
+    def publish_message(self, message: HudMessage) -> MirrorEntry:
+        """Publish one normalized HUD message to Mirror."""
+        ...
 
 
 class MirrorCoordinator:
@@ -247,6 +281,7 @@ class MirrorCoordinator:
 
 __all__ = (
     "MirrorCoordinator",
+    "MirrorCoordinatorPort",
     "MirrorCoordinatorState",
     "MirrorNotice",
     "MirrorOperationResult",

--- a/src/bilihud/app/services.py
+++ b/src/bilihud/app/services.py
@@ -2,8 +2,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Protocol
 
-from ..auth.service import AuthenticationService, BilibiliAuthService, KeyringSessionStore, SessionStore
+from ..auth.service import (
+    ApplicationAuthenticationService,
+    AuthenticationService,
+    BilibiliAuthService,
+    DanmakuAuthenticationService,
+    KeyringSessionStore,
+    SessionStore,
+)
 from ..config.compat import LegacyConfigMigrator
 from ..config.store import ConfigStore, JsonConfigStore
 from ..danmaku.client import DanmakuClient
@@ -14,8 +22,19 @@ from ..platform.obs_process import create_obs_process
 from ..platform.overlay_contracts import OverlayPlatformFactory
 from ..platform.window_platform import create_default_overlay_platform
 from .hud_client import HudClientFactory
-from .live_control_service import LiveControlService
-from .mirror_coordinator import MirrorCoordinator
+from .live_control_service import LiveControlService, LiveControlServicePort
+from .mirror_coordinator import MirrorCoordinator, MirrorCoordinatorPort
+
+
+class ApplicationServices(Protocol):
+    """Capabilities wired into the application composition root."""
+
+    config_store: ConfigStore
+    auth_service: ApplicationAuthenticationService
+    hud_client_factory: HudClientFactory
+    live_control_service: LiveControlServicePort
+    mirror_coordinator: MirrorCoordinatorPort
+    overlay_platform_factory: OverlayPlatformFactory
 
 
 @dataclass(frozen=True, slots=True)
@@ -23,17 +42,17 @@ class AppServices:
     """Application-wide adapters assembled at the composition root."""
 
     config_store: ConfigStore  # Shared typed settings boundary for all UI workflows.
-    auth_service: AuthenticationService  # Shared authentication and secure-secret boundary.
+    auth_service: ApplicationAuthenticationService  # Shared authentication boundary for workflows.
     hud_client_factory: HudClientFactory  # Concrete HUD network adapter factory.
-    live_control_service: LiveControlService  # Live-control application workflow owner.
-    mirror_coordinator: MirrorCoordinator  # Mirror configuration and server lifecycle owner.
+    live_control_service: LiveControlServicePort  # Live-control application workflow owner.
+    mirror_coordinator: MirrorCoordinatorPort  # Mirror configuration and server lifecycle owner.
     overlay_platform_factory: OverlayPlatformFactory  # Platform window capability boundary.
 
 
 def create_default_hud_client(
     room_id: int,
     sessdata: str,
-    auth_service: AuthenticationService,
+    auth_service: DanmakuAuthenticationService,
 ) -> DanmakuClient:
     """Create the production client behind the application's HUD capability."""
     return DanmakuClient(room_id, sessdata, auth_service=auth_service)

--- a/src/bilihud/app/services.py
+++ b/src/bilihud/app/services.py
@@ -29,12 +29,35 @@ from .mirror_coordinator import MirrorCoordinator, MirrorCoordinatorPort
 class ApplicationServices(Protocol):
     """Capabilities wired into the application composition root."""
 
-    config_store: ConfigStore
-    auth_service: ApplicationAuthenticationService
-    hud_client_factory: HudClientFactory
-    live_control_service: LiveControlServicePort
-    mirror_coordinator: MirrorCoordinatorPort
-    overlay_platform_factory: OverlayPlatformFactory
+    @property
+    def config_store(self) -> ConfigStore:
+        """Return the application configuration boundary."""
+        ...
+
+    @property
+    def auth_service(self) -> ApplicationAuthenticationService:
+        """Return the shared authentication capability."""
+        ...
+
+    @property
+    def hud_client_factory(self) -> HudClientFactory:
+        """Return the HUD client factory."""
+        ...
+
+    @property
+    def live_control_service(self) -> LiveControlServicePort:
+        """Return the live-control workflow capability."""
+        ...
+
+    @property
+    def mirror_coordinator(self) -> MirrorCoordinatorPort:
+        """Return the Mirror workflow capability."""
+        ...
+
+    @property
+    def overlay_platform_factory(self) -> OverlayPlatformFactory:
+        """Return the platform overlay factory."""
+        ...
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/bilihud/auth/service.py
+++ b/src/bilihud/auth/service.py
@@ -72,8 +72,65 @@ class SessionStore(Protocol):
         ...
 
 
-class AuthenticationService(Protocol):
-    """Authentication use cases exposed to application and presentation code."""
+class QRLoginService(Protocol):
+    """Authentication capability required by the QR-login presentation."""
+
+    async def get_qrcode(self) -> tuple[str | None, str | None]:
+        """Request a Bilibili QR-login URL and its polling key."""
+        ...
+
+    def generate_qr_image(self, url: str) -> BytesIO | None:
+        """Render a QR-login URL into PNG bytes for the presentation layer."""
+        ...
+
+    async def poll_status(self, qrcode_key: str) -> tuple[int, str, AuthCookies | None]:
+        """Poll QR-login state and return an authenticated cookie set on success."""
+        ...
+
+    def save_cookies(self, cookies: Mapping[str, str]) -> bool:
+        """Store cookies obtained from a successful login."""
+        ...
+
+
+class AccountAuthenticationService(Protocol):
+    """Authentication capability required by account state and logout workflows."""
+
+    async def lookup_account(self) -> AccountLookupResult:
+        """Resolve the saved session into a normalized account identity."""
+        ...
+
+    def logout(self) -> bool:
+        """Remove the saved Bilibili session and report whether it was cleared."""
+        ...
+
+
+class DanmakuAuthenticationService(Protocol):
+    """Authentication capability required to create an owned danmaku session."""
+
+    def load_auth_cookies(self) -> tuple[AuthCookies, bool]:
+        """Load cookies and indicate whether they came from secure storage."""
+        ...
+
+    async def validate_session(self, cookies: Mapping[str, str]) -> bool:
+        """Check whether a cookie set still represents a logged-in user."""
+        ...
+
+    def create_session_from_cookies(self, cookies: Mapping[str, str]) -> aiohttp.ClientSession:
+        """Create an aiohttp session whose caller owns and closes the resource."""
+        ...
+
+
+class ApplicationAuthenticationService(
+    QRLoginService,
+    AccountAuthenticationService,
+    DanmakuAuthenticationService,
+    Protocol,
+):
+    """Combined authentication capability shared by application workflows."""
+
+
+class AuthenticationService(ApplicationAuthenticationService, Protocol):
+    """Full authentication service exposed by the composition root."""
 
     async def get_qrcode(self) -> tuple[str | None, str | None]:
         """Request a Bilibili QR-login URL and its polling key."""

--- a/src/bilihud/danmaku/client.py
+++ b/src/bilihud/danmaku/client.py
@@ -2,7 +2,8 @@ import asyncio
 import hashlib
 import logging
 import time
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
+from typing import Protocol
 from urllib.parse import urlencode, urlparse
 
 import aiohttp
@@ -12,7 +13,8 @@ import blivedm.models.open_live as open_models
 import blivedm.models.web as web_models
 
 from ..app.lifecycle import run_owned_blocking
-from ..auth.service import AuthenticationService, AuthManager
+from ..auth.service import AuthManager, DanmakuAuthenticationService
+from ..http_contracts import HttpCookie, HttpSession
 from ..live.audience import AudienceSnapshot, parse_anchor_uid, parse_audience_snapshot
 from ..live.emoticons import (
     LiveEmoticon,
@@ -38,6 +40,8 @@ from .blivedm_adapter import (
 )
 from .messages import GiftEffectLayout, HudMessage
 
+NetworkSession = aiohttp.ClientSession | HttpSession
+
 WBI_NAV_URL = "https://api.bilibili.com/x/web-interface/nav"
 LIVE_MSG_SEND_URL = "https://api.live.bilibili.com/msg/send"
 LIVE_ROOM_INFO_URL = "https://api.live.bilibili.com/xlive/web-room/v1/index/getInfoByRoom"
@@ -61,6 +65,35 @@ WBI_MIXIN_KEY_ENC_TAB = (
 logger = logging.getLogger(__name__)
 
 
+class DanmakuLiveClient(Protocol):
+    """Lifecycle capability consumed from the vendored blivedm client."""
+
+    @property
+    def is_running(self) -> bool:
+        """Return whether the underlying websocket task is active."""
+        ...
+
+    def set_handler(self, handler: "DanmakuHandler") -> None:
+        """Attach the normalized message handler."""
+        ...
+
+    def start(self) -> None:
+        """Start receiving messages."""
+        ...
+
+    def stop(self) -> None:
+        """Request websocket shutdown."""
+        ...
+
+    async def join(self) -> None:
+        """Wait for the websocket task to finish."""
+        ...
+
+    async def close(self) -> None:
+        """Release websocket-owned resources."""
+        ...
+
+
 class DanmakuClient:
     """Receive and send live-room messages through one owned network session.
 
@@ -73,14 +106,14 @@ class DanmakuClient:
         self,
         room_id: int,
         sessdata: str = "",
-        auth_service: AuthenticationService | None = None,
+        auth_service: DanmakuAuthenticationService | None = None,
     ) -> None:
         """Create a client for one room with an optional injected auth service."""
         self.room_id = room_id
         self.sessdata = sessdata  # Optional one-off SESSDATA override for this connection.
         self.auth_service = auth_service  # Shared authentication boundary from the app.
-        self.session: aiohttp.ClientSession | None = None  # Owned and closed by this client.
-        self.client: blivedm.BLiveClient | None = None  # Underlying blivedm lifecycle handle.
+        self.session: NetworkSession | None = None  # Owned and closed by this client.
+        self.client: DanmakuLiveClient | None = None  # Underlying blivedm lifecycle handle.
         self.handler: DanmakuHandler | None = None  # Callback bridge owned by the client.
         self.on_message_received: Callable[[HudMessage], None] | None = None
         self.on_login_failed: Callable[[str], None] | None = None # callback(message)
@@ -134,11 +167,12 @@ class DanmakuClient:
         if login_failure_message and self.on_login_failed:
             self.on_login_failed(login_failure_message)
 
-        self.session = auth_manager.create_session_from_cookies(loaded_cookies)
+        session = auth_manager.create_session_from_cookies(loaded_cookies)
+        self.session = session
         self._gift_effect_catalog = GiftEffectCatalog(self.session, self.room_id)
 
         # 创建客户端和处理器
-        self.client = blivedm.BLiveClient(self.room_id, session=self.session)
+        self.client = blivedm.BLiveClient(self.room_id, session=session)
         self.handler = DanmakuHandler()
         self.handler.set_danmaku_client(self)
         self.client.set_handler(self.handler)
@@ -154,10 +188,7 @@ class DanmakuClient:
 
         # 从cookie中获取csrf token (bili_jct)
         csrf_token = ''
-        for cookie in self.session.cookie_jar:
-            if cookie.key == 'bili_jct':
-                csrf_token = cookie.value
-                break
+        csrf_token = _csrf_token(self.session)
 
         if not csrf_token:
             # print("Error: No csrf_token found in cookies")
@@ -180,12 +211,17 @@ class DanmakuClient:
                 if res.status != 200:
                     print(f"Send danmaku HTTP error: {res.status}")
                     return False, f"HTTP错误: {res.status}"
-                json_data = await res.json()
-                if json_data['code'] == 0:
+                json_data = _json_mapping(await res.json())
+                if json_data.get("code") == 0:
                     return True, "发送成功"
                 else:
-                    print(f"Send danmaku failed: {json_data['message']}")
-                    return False, f"发送失败: {json_data['message']}"
+                    message = _json_string(json_data.get("message"))
+                    if not message:
+                        message = _json_string(json_data.get("msg"))
+                    if not message:
+                        message = "未知错误"
+                    print(f"Send danmaku failed: {message}")
+                    return False, f"发送失败: {message}"
         except Exception as e:
             print(f"Send danmaku exception: {e}")
             return False, f"发送异常: {str(e)}"
@@ -203,7 +239,7 @@ class DanmakuClient:
         ) as response:
             if response.status != 200:
                 raise RuntimeError(f"直播间信息 HTTP错误: {response.status}")
-            room_payload = await response.json(content_type=None)
+            room_payload = _json_mapping(await response.json(content_type=None))
 
         anchor_uid = parse_anchor_uid(room_payload)
         rank_params = {
@@ -222,7 +258,7 @@ class DanmakuClient:
         ) as response:
             if response.status != 200:
                 raise RuntimeError(f"在线榜 HTTP错误: {response.status}")
-            rank_payload = await response.json(content_type=None)
+            rank_payload = _json_mapping(await response.json(content_type=None))
 
         return parse_audience_snapshot(self.room_id, room_payload, rank_payload)
 
@@ -243,7 +279,7 @@ class DanmakuClient:
         async with self.session.get(url, params=params, headers=headers) as res:
             if res.status != 200:
                 raise RuntimeError(f"HTTP错误: {res.status}")
-            payload = await res.json(content_type=None)
+            payload = _json_mapping(await res.json(content_type=None))
         packages = parse_live_emoticon_packages(payload)
         self._live_emoticon_cache = packages
         self._live_emoticon_cache_at = now
@@ -258,10 +294,7 @@ class DanmakuClient:
             return False, f"表情未解锁: {label}"
 
         csrf_token = ""
-        for cookie in self.session.cookie_jar:
-            if cookie.key == "bili_jct":
-                csrf_token = cookie.value
-                break
+        csrf_token = _csrf_token(self.session)
         if not csrf_token:
             return False, "未找到CSRF Token，请重新连接或检查Cookie"
 
@@ -280,8 +313,8 @@ class DanmakuClient:
             async with self.session.post(send_url, data=_multipart_form_data(data)) as res:
                 if res.status != 200:
                     return False, f"HTTP错误: {res.status}"
-                json_data = await res.json()
-                if json_data["code"] == 0:
+                json_data = _json_mapping(await res.json())
+                if json_data.get("code") == 0:
                     return True, "发送成功"
                 code = json_data.get("code")
                 message = json_data.get("message") or json_data.get("msg") or "未知错误"
@@ -311,13 +344,16 @@ class DanmakuClient:
         async with self.session.get(WBI_NAV_URL) as res:
             if res.status != 200:
                 raise RuntimeError(f"WBI key HTTP错误: {res.status}")
-            payload = await res.json(content_type=None)
+            payload = _json_mapping(await res.json(content_type=None))
 
         if payload.get("code") != 0:
             message = payload.get("message") or payload.get("msg") or "获取WBI key失败"
             raise RuntimeError(str(message))
 
-        wbi_img = (payload.get("data") or {}).get("wbi_img") or {}
+        raw_data = payload.get("data")
+        data = _json_mapping(raw_data) if isinstance(raw_data, dict) else {}
+        raw_wbi_img = data.get("wbi_img")
+        wbi_img = _json_mapping(raw_wbi_img) if isinstance(raw_wbi_img, dict) else {}
         mixin_key = _build_wbi_mixin_key(str(wbi_img.get("img_url") or ""), str(wbi_img.get("sub_url") or ""))
         if not mixin_key:
             raise RuntimeError("获取WBI key失败")
@@ -557,6 +593,34 @@ def _sign_wbi_params(params: dict[str, str], mixin_key: str, wts: str) -> dict[s
     query = urlencode(sorted(safe_params.items()))
     signed_params["w_rid"] = hashlib.md5(f"{query}{mixin_key}".encode()).hexdigest()
     return signed_params
+
+
+def _csrf_token(session: NetworkSession) -> str:
+    """Read the CSRF cookie through the small third-party session boundary."""
+    cookie_jar = session.cookie_jar
+    if not isinstance(cookie_jar, Iterable):
+        return ""
+    for cookie in cookie_jar:
+        if isinstance(cookie, HttpCookie) and cookie.key == "bili_jct":
+            return cookie.value
+    return ""
+
+
+def _json_mapping(payload: object) -> dict[str, object]:
+    """Validate one JSON object before code reads its protocol fields."""
+    if not isinstance(payload, dict):
+        raise ValueError("B站接口返回的数据格式无效")
+    normalized: dict[str, object] = {}
+    for key, value in payload.items():
+        if not isinstance(key, str):
+            raise ValueError("B站接口返回的数据格式无效")
+        normalized[key] = value
+    return normalized
+
+
+def _json_string(value: object) -> str:
+    """Normalize one optional API message field to a displayable string."""
+    return value if isinstance(value, str) else ""
 
 
 def _multipart_form_data(data: dict[str, str | int]) -> aiohttp.FormData:

--- a/src/bilihud/http_contracts.py
+++ b/src/bilihud/http_contracts.py
@@ -1,0 +1,79 @@
+"""Small HTTP protocols shared by application-owned network workflows."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from contextlib import AbstractAsyncContextManager
+from types import TracebackType
+from typing import Protocol, runtime_checkable
+
+QueryValue = str | int | float
+QueryParams = Mapping[str, QueryValue] | Iterable[tuple[str, QueryValue]]
+
+
+@runtime_checkable
+class HttpCookie(Protocol):
+    """Cookie fields consumed by authenticated live-room requests."""
+
+    key: str
+    value: str
+
+
+class HttpResponse(Protocol):
+    """Response surface required by the normalized API adapters."""
+
+    status: int
+
+    async def __aenter__(self) -> HttpResponse:
+        """Enter the response context owned by one request."""
+        ...
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        """Release the response context."""
+        ...
+
+    async def json(self, *, content_type: str | None = None) -> object:
+        """Decode the response body at the external-data boundary."""
+        ...
+
+
+class HttpSession(Protocol):
+    """Owned HTTP session capability used by live-room workflows."""
+
+    closed: bool
+
+    @property
+    def cookie_jar(self) -> Iterable[HttpCookie]:
+        """Return the iterable cookie view used for CSRF extraction."""
+        ...
+
+    def get(
+        self,
+        url: str,
+        *,
+        params: QueryParams | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> AbstractAsyncContextManager[HttpResponse]:
+        """Start one GET request with optional query and request headers."""
+        ...
+
+    def post(
+        self,
+        url: str,
+        *,
+        data: object | None = None,
+    ) -> AbstractAsyncContextManager[HttpResponse]:
+        """Start one POST request with an application-owned payload."""
+        ...
+
+    async def close(self) -> None:
+        """Close the session and release its transport resources."""
+        ...
+
+
+__all__ = ("HttpCookie", "HttpResponse", "HttpSession", "QueryParams", "QueryValue")

--- a/src/bilihud/live/gift_effects.py
+++ b/src/bilihud/live/gift_effects.py
@@ -10,6 +10,9 @@ from urllib.parse import urlsplit
 import aiohttp
 
 from ..danmaku.messages import GiftEffectFrame, GiftEffectLayout
+from ..http_contracts import HttpSession
+
+NetworkSession = aiohttp.ClientSession | HttpSession
 
 GIFT_DETAIL_URL = "https://api.live.bilibili.com/xlive/web-room/v1/giftPanel/getGiftDetail"
 FULL_SCREEN_EFFECT_CONFIG_URL = (
@@ -45,7 +48,7 @@ class GiftEffectCatalog:
 
     def __init__(
         self,
-        session: aiohttp.ClientSession,
+        session: NetworkSession,
         room_id: int,
         *,
         timeout_seconds: float = GIFT_DETAIL_TIMEOUT_SECONDS,
@@ -55,7 +58,7 @@ class GiftEffectCatalog:
             raise ValueError("room_id must not be negative")
         if timeout_seconds <= 0:
             raise ValueError("gift effect timeout must be positive")
-        self._session: aiohttp.ClientSession = session
+        self._session: NetworkSession = session
         self._room_id: int = room_id
         self._timeout_seconds: float = timeout_seconds
         self._cache: dict[int, GiftEffectAsset | None] = {}

--- a/src/bilihud/main.py
+++ b/src/bilihud/main.py
@@ -22,7 +22,7 @@ from PyQt6.QtWidgets import QApplication
 
 from .app.application_controller import ApplicationController
 from .app.lifecycle import TaskSupervisor
-from .app.services import AppServices, create_default_services
+from .app.services import ApplicationServices, create_default_services
 from .ui.hud.window import DanmakuWidget
 
 
@@ -47,7 +47,7 @@ class ApplicationRuntime:
         self,
         app: QApplication,
         room_id: int,
-        services: AppServices | None = None,
+        services: ApplicationServices | None = None,
         task_supervisor: TaskSupervisor | None = None,
     ) -> None:
         """Create a runtime that will assemble and own one application window."""
@@ -115,7 +115,7 @@ class ApplicationRuntime:
 async def main(
     app: QApplication,
     room_id: int,
-    services: AppServices | None = None,
+    services: ApplicationServices | None = None,
 ) -> None:
     """Run the top-level widget until Qt requests application shutdown."""
     app_close_event = asyncio.Event()

--- a/src/bilihud/mirror/server.py
+++ b/src/bilihud/mirror/server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from typing import Protocol
 
 import aiohttp
 from aiohttp import web
@@ -53,6 +54,14 @@ __all__ = (
 )
 
 
+class MirrorRunner(Protocol):
+    """Cleanup capability owned by the Mirror HTTP server."""
+
+    async def cleanup(self) -> None:
+        """Release the bound HTTP application resources."""
+        ...
+
+
 def mirror_event_payload(event: str, data: object) -> str:
     """Encode one named server-sent event as an SSE payload."""
     return f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False, separators=(',', ':'))}\n\n"
@@ -98,7 +107,7 @@ class MirrorServer:
             display_settings if display_settings is not None else MirrorDisplaySettings()
         )
         self._resource_proxy: MirrorResourceProxy = MirrorResourceProxy(IMAGE_PROXY_HEADERS)
-        self._runner: web.AppRunner | None = None
+        self._runner: MirrorRunner | None = None
         self._site: web.TCPSite | None = None
         self._clients: set[asyncio.Queue[str]] = set()
 

--- a/src/bilihud/ui/auth/qr_login.py
+++ b/src/bilihud/ui/auth/qr_login.py
@@ -18,7 +18,7 @@ from PyQt6.QtWidgets import (
 )
 
 from bilihud.app.lifecycle import TaskScope, TaskSupervisor, cancel_task, run_owned_blocking
-from bilihud.auth.service import QR_LOGIN_STATUS_NAMES, AuthenticationService
+from bilihud.auth.service import QR_LOGIN_STATUS_NAMES, QRLoginService
 from bilihud.config.store import ThemeMode
 from bilihud.ui.appearance import Appearance, resolve_appearance
 from bilihud.ui.settings.style import settings_stylesheet
@@ -44,7 +44,7 @@ class QRLoginDialog(QDialog):
         self,
         parent: QWidget | None = None,
         *,
-        auth_service: AuthenticationService,
+        auth_service: QRLoginService,
         task_scope: TaskScope | None = None,
         appearance: Appearance | None = None,
     ) -> None:

--- a/src/bilihud/ui/hud/emoticon_picker.py
+++ b/src/bilihud/ui/hud/emoticon_picker.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Protocol
+
 from PyQt6.QtCore import QSize, Qt, QUrl, pyqtSignal
 from PyQt6.QtGui import QIcon, QPixmap
 from PyQt6.QtNetwork import QNetworkAccessManager, QNetworkReply, QNetworkRequest
@@ -20,6 +22,14 @@ from PyQt6.QtWidgets import (
 from bilihud.live.emoticons import LiveEmoticon, LiveEmoticonPackage
 
 
+class IconNetworkManager(Protocol):
+    """Small network capability used to fetch one emoticon image."""
+
+    def get(self, request: QNetworkRequest) -> QNetworkReply | None:
+        """Start one image request and return its reply handle."""
+        ...
+
+
 class EmoticonPickerPopup(QDialog):
     """Render available live-room emoticons and emit the selected value."""
 
@@ -31,7 +41,7 @@ class EmoticonPickerPopup(QDialog):
         self.setWindowFlags(Qt.WindowType.Popup | Qt.WindowType.FramelessWindowHint)
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
         self.resize(330, 260)
-        self._network_manager = QNetworkAccessManager(self)
+        self._network_manager: IconNetworkManager = QNetworkAccessManager(self)
         self._image_cache: dict[str, QPixmap] = {}
         self._button_by_url: dict[str, list[QToolButton]] = {}
         self._emoticon_buttons: list[QToolButton] = []

--- a/src/bilihud/ui/hud/mirror_controller.py
+++ b/src/bilihud/ui/hud/mirror_controller.py
@@ -6,16 +6,30 @@ import asyncio
 from collections.abc import Callable, Coroutine
 from typing import Any, Protocol
 
-from bilihud.app.mirror_coordinator import MirrorCoordinator, MirrorOperationResult
+from bilihud.app.mirror_coordinator import MirrorCoordinatorPort, MirrorOperationResult
 from bilihud.danmaku.messages import SystemMessageLevel
-from bilihud.ui.settings.controller import SettingsController
+
+
+class MirrorSettingsController(Protocol):
+    """Small settings capability refreshed after Mirror state transitions."""
+
+    def set_mirror_state(self) -> None:
+        """Render the latest coordinator snapshot in the settings surface."""
+        ...
 
 
 class MirrorView(Protocol):
     """Presentation callbacks needed by the Mirror command bridge."""
 
-    mirror_coordinator: MirrorCoordinator
-    settings_controller: SettingsController
+    @property
+    def mirror_coordinator(self) -> MirrorCoordinatorPort:
+        """Return the application-owned Mirror coordinator."""
+        ...
+
+    @property
+    def settings_controller(self) -> MirrorSettingsController:
+        """Return the settings surface refreshed by Mirror transitions."""
+        ...
 
     def add_system_message(self, message: str, level: SystemMessageLevel) -> None:
         """Render a coordinator notice in the HUD message stream."""
@@ -129,4 +143,8 @@ class MirrorController:
         await self.set_enabled(enabled)
 
 
-__all__ = ("MirrorController", "MirrorView")
+__all__ = (
+    "MirrorController",
+    "MirrorSettingsController",
+    "MirrorView",
+)

--- a/src/bilihud/ui/hud/window.py
+++ b/src/bilihud/ui/hud/window.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from collections.abc import Coroutine
-from typing import Any
+from typing import Any, Protocol
 
 from PyQt6.QtCore import QPoint, Qt, QTimer, pyqtSignal, pyqtSlot
 from PyQt6.QtGui import (
@@ -14,20 +14,15 @@ from PyQt6.QtGui import (
     QResizeEvent,
     QShowEvent,
 )
-from PyQt6.QtWidgets import (
-    QApplication,
-    QListWidgetItem,
-    QSystemTrayIcon,
-    QWidget,
-)
+from PyQt6.QtWidgets import QApplication, QListWidget, QListWidgetItem, QSystemTrayIcon, QWidget
 
 from bilihud.app.account_controller import AccountState
 from bilihud.app.application_controller import ApplicationController
 from bilihud.app.hud import HudEvent, HudState
 from bilihud.app.lifecycle import TaskScope, TaskSupervisor
 from bilihud.app.menu import AccountStatus, MenuCommand, TrayMenuState
-from bilihud.app.mirror_coordinator import MirrorCoordinator, MirrorOperationResult
-from bilihud.app.services import AppServices
+from bilihud.app.mirror_coordinator import MirrorCoordinatorPort, MirrorOperationResult
+from bilihud.app.services import ApplicationServices
 from bilihud.auth.service import AccountProfile
 from bilihud.danmaku.messages import (
     GiftMessage,
@@ -37,6 +32,7 @@ from bilihud.danmaku.messages import (
 )
 from bilihud.danmaku.mock import mock_gift_effect_message, mock_message_batch
 from bilihud.live.emoticons import LiveEmoticon
+from bilihud.mirror.state import MirrorEntry
 from bilihud.platform.overlay_contracts import (
     OverlayOperationResult,
     OverlayPlatform,
@@ -57,6 +53,87 @@ from bilihud.ui.window_host import QtWindowHost
 logger = logging.getLogger(__name__)
 
 
+class DanmakuListPort(Protocol):
+    """List operations needed by the message history update."""
+
+    def addItem(self, item: QListWidgetItem | None) -> None:
+        """Append one prepared Qt list item."""
+        ...
+
+    def count(self) -> int:
+        """Return the current history size."""
+        ...
+
+    def takeItem(self, row: int) -> QListWidgetItem | None:
+        """Remove and return one history item."""
+        ...
+
+    def scrollToBottom(self) -> None:
+        """Scroll the visible history to its newest item."""
+        ...
+
+    def scheduleDelayedItemsLayout(self) -> None:
+        """Schedule one layout pass after history changes."""
+        ...
+
+
+class DanmakuDelegatePort(Protocol):
+    """Delegate operation needed when an old history item is removed."""
+
+    def set_font_family(self, font_family: str) -> None:
+        """Apply the selected HUD font to rendered documents."""
+        ...
+
+    def forget_message(self, message: HudMessage) -> None:
+        """Forget cached rendering data for one removed message."""
+        ...
+
+
+class DanmakuMessagePublisher(Protocol):
+    """Mirror capability needed by the message history update."""
+
+    def publish_message(self, message: HudMessage) -> MirrorEntry:
+        """Publish one normalized message."""
+        ...
+
+
+class DanmakuMessageTarget(Protocol):
+    """Minimal state needed to append one normalized message to the HUD."""
+
+    @property
+    def danmaku_list(self) -> DanmakuListPort:
+        """Return the message list surface."""
+        ...
+
+    @property
+    def _danmaku_delegate(self) -> DanmakuDelegatePort:
+        """Return the delegate cache owner."""
+        ...
+
+    @property
+    def mirror_coordinator(self) -> DanmakuMessagePublisher:
+        """Return the Mirror message publisher."""
+        ...
+
+
+def append_hud_message(target: DanmakuMessageTarget, message: HudMessage) -> None:
+    """Append a message to history, trim old entries, and publish it to Mirror."""
+    item = QListWidgetItem()
+    item.setData(Qt.ItemDataRole.UserRole, message)
+
+    target.danmaku_list.addItem(item)
+
+    if target.danmaku_list.count() > 200:
+        removed_item = target.danmaku_list.takeItem(0)
+        if removed_item is not None:
+            removed_message = removed_item.data(Qt.ItemDataRole.UserRole)
+            if isinstance(removed_message, HudMessage):
+                target._danmaku_delegate.forget_message(removed_message)
+
+    target.danmaku_list.scrollToBottom()
+    target.mirror_coordinator.publish_message(message)
+
+
 def _opacity_to_alpha(opacity: int) -> int:
     """Convert a validated percentage into the HUD background alpha channel."""
     return max(0, min(255, round(255 * opacity / 100)))
@@ -66,6 +143,10 @@ class DanmakuWidget(QWidget):
     """Compose the HUD presentation and bind it to application-owned state."""
 
     message_received = pyqtSignal(object)
+    settings_controller: SettingsController
+    _danmaku_delegate: DanmakuDelegatePort
+    danmaku_list: QListWidget
+    mirror_coordinator: MirrorCoordinatorPort
 
     def __init__(
         self,
@@ -73,7 +154,7 @@ class DanmakuWidget(QWidget):
         sessdata: str = "",
         *,
         application: ApplicationController | None = None,
-        services: AppServices | None = None,
+        services: ApplicationServices | None = None,
         task_supervisor: TaskSupervisor | None = None,
     ) -> None:
         """Create the widget from an application controller and saved configuration.
@@ -108,7 +189,7 @@ class DanmakuWidget(QWidget):
 
         self.application = application
         self.services = application.services
-        self.mirror_coordinator: MirrorCoordinator = application.mirror_coordinator
+        self.mirror_coordinator: MirrorCoordinatorPort = application.mirror_coordinator
         self.is_gaming_mode: bool = False
         account_state = self.application.account_controller.state
         self._account_status: AccountStatus = account_state.status
@@ -636,24 +717,7 @@ class DanmakuWidget(QWidget):
 
     def add_message(self, message: HudMessage) -> None:
         """Add one normalized message to Qt history and the optional Mirror stream."""
-        # [Delegate Architecture]
-        # Just create an item and set data. Paint/Layout is handled by DanmakuDelegate.
-        item = QListWidgetItem()
-        item.setData(Qt.ItemDataRole.UserRole, message)
-
-        self.danmaku_list.addItem(item)
-
-        # [Optimization] Reduce max history to 200 to prevent render lag
-        if self.danmaku_list.count() > 200:
-            removed_item = self.danmaku_list.takeItem(0)
-            if removed_item is not None:
-                self._danmaku_delegate.forget_message(
-                    removed_item.data(Qt.ItemDataRole.UserRole)
-                )
-
-        self.danmaku_list.scrollToBottom()
-
-        self.mirror_coordinator.publish_message(message)
+        append_hud_message(self, message)
         if isinstance(message, GiftMessage) and self.application.config.overlay_gift_effects_enabled:
             self.gift_effect_window.show_gift(message)
 

--- a/src/bilihud/ui/settings/dialog.py
+++ b/src/bilihud/ui/settings/dialog.py
@@ -24,7 +24,7 @@ from PyQt6.QtWidgets import (
 from bilihud.app.lifecycle import TaskScope
 from bilihud.app.menu import AccountStatus
 from bilihud.app.mirror_coordinator import MirrorCoordinatorState
-from bilihud.app.services import AppServices
+from bilihud.app.services import ApplicationServices
 from bilihud.auth.service import AccountProfile
 from bilihud.config.store import (
     DEFAULT_WINDOW_OPACITY,
@@ -69,7 +69,7 @@ class SettingsDialog(QDialog):
         parent: QWidget | None,
         config: AppConfig,
         *,
-        services: AppServices | None = None,
+        services: ApplicationServices | None = None,
         task_scope: TaskScope | None = None,
         on_live_started: LiveStartedHandler | None = None,
     ) -> None:

--- a/src/bilihud/ui/settings/pages/live/page.py
+++ b/src/bilihud/ui/settings/pages/live/page.py
@@ -21,7 +21,7 @@ from PyQt6.QtWidgets import (
 )
 
 from bilihud.app.lifecycle import TaskScope
-from bilihud.app.live_control_service import LiveControlService
+from bilihud.app.live_control_service import LiveControlServicePort
 from bilihud.config.store import DEFAULT_OBS_HOST, DEFAULT_OBS_PORT
 from bilihud.live.models import (
     LiveAreaGroup,
@@ -54,7 +54,7 @@ class LiveSettingsPage(QWidget):
     def __init__(
         self,
         parent: QWidget | None = None,
-        service: LiveControlService | None = None,
+        service: LiveControlServicePort | None = None,
         task_scope: TaskScope | None = None,
         on_live_started: LiveStartedHandler | None = None,
     ) -> None:

--- a/tests/app/test_application_controller.py
+++ b/tests/app/test_application_controller.py
@@ -1,12 +1,32 @@
 import asyncio
+from dataclasses import replace
+from io import BytesIO
 
 from bilihud.app import application_controller as application_module
 from bilihud.app.application_controller import ApplicationController
 from bilihud.app.lifecycle import TaskSupervisor
+from bilihud.app.mirror_coordinator import MirrorCoordinatorState, MirrorOperationResult
+from bilihud.app.services import create_default_services
 from bilihud.config.store import AppConfig
+from bilihud.danmaku.messages import HudMessage
+from bilihud.live.models import (
+    LiveControlOperationResult,
+    LiveControlSettings,
+    LiveControlState,
+    ObsCheckOutcome,
+    ObsSettings,
+    ObsStreamOutcome,
+    SettingsSaveOutcome,
+    StartLiveOutcome,
+    StopLiveOutcome,
+)
+from bilihud.mirror.state import MirrorDisplaySettings, MirrorEntry
 
 
 class FakeConfigStore:
+    def load(self) -> AppConfig:
+        return AppConfig()
+
     def save(self, _config: AppConfig) -> bool:
         return True
 
@@ -15,6 +35,59 @@ class FakeLiveControlService:
     def __init__(self, events: list[str]) -> None:
         self._events = events
 
+    @property
+    def state(self) -> LiveControlState:
+        raise AssertionError("live state is not used in this shutdown test")
+
+    def load_settings(self) -> LiveControlSettings:
+        raise AssertionError("live settings are not used in this shutdown test")
+
+    def save_settings(self, _settings: LiveControlSettings) -> SettingsSaveOutcome:
+        raise AssertionError("live settings are not used in this shutdown test")
+
+    def generate_qr_image(self, _url: str) -> BytesIO | None:
+        raise AssertionError("live QR is not used in this shutdown test")
+
+    async def initialize(self, _room_id: int | None) -> LiveControlOperationResult:
+        raise AssertionError("live initialization is not used in this shutdown test")
+
+    async def load_room_info(self, _room_id: int | None) -> LiveControlOperationResult:
+        raise AssertionError("live room loading is not used in this shutdown test")
+
+    async def update_title(self, _room_id: int | None, _title: str) -> LiveControlOperationResult:
+        raise AssertionError("live title updates are not used in this shutdown test")
+
+    async def update_area(self, _room_id: int | None, _area_id: str) -> LiveControlOperationResult:
+        raise AssertionError("live area updates are not used in this shutdown test")
+
+    async def start_live(
+        self,
+        _room_id: int | None,
+        _title: str,
+        _area_id: str,
+        _obs_settings: ObsSettings | None,
+        *,
+        allow_obs_switch: bool = False,
+    ) -> StartLiveOutcome:
+        del allow_obs_switch
+        raise AssertionError("live start is not used in this shutdown test")
+
+    async def stop_live(
+        self,
+        _room_id: int | None,
+        _obs_settings: ObsSettings | None,
+    ) -> StopLiveOutcome:
+        raise AssertionError("live stop is not used in this shutdown test")
+
+    async def check_obs(self, _settings: ObsSettings | None) -> ObsCheckOutcome:
+        raise AssertionError("OBS checks are not used in this shutdown test")
+
+    async def stop_obs_stream(self, _settings: ObsSettings | None) -> ObsStreamOutcome:
+        raise AssertionError("OBS stopping is not used in this shutdown test")
+
+    async def close(self) -> None:
+        raise AssertionError("live close is not used in this shutdown test")
+
     async def shutdown(self) -> None:
         self._events.append("live-shutdown")
 
@@ -22,9 +95,27 @@ class FakeLiveControlService:
 class FakeMirrorCoordinator:
     def __init__(self, events: list[str]) -> None:
         self._events = events
+        self.state = MirrorCoordinatorState(
+            enabled=False,
+            running=False,
+            port=2233,
+            url="http://127.0.0.1:2233/bilihud-mirror",
+        )
 
     def apply_config(self, _config: AppConfig) -> None:
         self._events.append("mirror-config")
+
+    def apply_display_settings(self, _settings: MirrorDisplaySettings) -> None:
+        raise AssertionError("Mirror display settings are not used in this shutdown test")
+
+    async def start(self) -> MirrorOperationResult:
+        raise AssertionError("Mirror start is not used in this shutdown test")
+
+    async def set_enabled(self, _enabled: bool) -> MirrorOperationResult:
+        raise AssertionError("Mirror toggling is not used in this shutdown test")
+
+    def publish_message(self, _message: HudMessage) -> MirrorEntry:
+        raise AssertionError("Mirror messages are not used in this shutdown test")
 
     async def shutdown(self) -> None:
         self._events.append("mirror-shutdown")
@@ -46,15 +137,6 @@ class FakeAccountController:
         self._events.append("account-shutdown")
 
 
-class FakeServices:
-    def __init__(self, events: list[str]) -> None:
-        self.config_store = FakeConfigStore()
-        self.auth_service = object()
-        self.hud_client_factory = object()
-        self.live_control_service = FakeLiveControlService(events)
-        self.mirror_coordinator = FakeMirrorCoordinator(events)
-
-
 def test_application_shutdown_uses_one_owner_and_keeps_order(monkeypatch) -> None:
     async def run_test() -> None:
         events: list[str] = []
@@ -73,7 +155,12 @@ def test_application_shutdown_uses_one_owner_and_keeps_order(monkeypatch) -> Non
         monkeypatch.setattr(application_module, "AccountSessionController", AccountController)
         supervisor = TaskSupervisor()
         application_scope = supervisor.create_scope("application")
-        services = FakeServices(events)
+        services = replace(
+            create_default_services(),
+            config_store=FakeConfigStore(),
+            live_control_service=FakeLiveControlService(events),
+            mirror_coordinator=FakeMirrorCoordinator(events),
+        )
         application = ApplicationController(
             room_id=7450109,
             sessdata="",

--- a/tests/app/test_hud_controller.py
+++ b/tests/app/test_hud_controller.py
@@ -1,4 +1,7 @@
 import asyncio
+from collections.abc import Mapping
+
+import aiohttp
 
 from bilihud.app.hud import (
     HudConnectionStatus,
@@ -92,6 +95,21 @@ class FakeClient:
             self.login_failed_callback(message)
 
 
+class FakeAuthenticationService:
+    """Typed authentication boundary for HUD tests that never open a session."""
+
+    def load_auth_cookies(self) -> tuple[dict[str, str], bool]:
+        return {}, False
+
+    async def validate_session(self, cookies: Mapping[str, str]) -> bool:
+        del cookies
+        return False
+
+    def create_session_from_cookies(self, cookies: Mapping[str, str]) -> aiohttp.ClientSession:
+        del cookies
+        raise AssertionError("the fake HUD client does not create a network session")
+
+
 def _message(text):
     return DanmakuMessage(
         author=MessageAuthor(uid=1, name="user", color="#fff"),
@@ -103,7 +121,7 @@ def _controller(factory, config_store=None):
     return HudController(
         initial_room_id=0,
         sessdata="",
-        auth_service=object(),
+        auth_service=FakeAuthenticationService(),
         client_factory=factory,
         config_store=config_store,
     )

--- a/tests/app/test_lifecycle.py
+++ b/tests/app/test_lifecycle.py
@@ -1,11 +1,13 @@
 import asyncio
 import logging
+from dataclasses import replace
 
 import pytest
 from PyQt6.QtWidgets import QApplication
 
 from bilihud import main as main_module
 from bilihud.app.lifecycle import TaskSupervisor
+from bilihud.app.services import create_default_services
 from bilihud.main import ApplicationRuntime
 from bilihud.ui.auth.qr_login import QRLoginDialog
 
@@ -75,6 +77,13 @@ def test_task_supervisor_rejects_new_work_after_shutdown():
     asyncio.run(run_test())
 
 
+def _app() -> QApplication:
+    instance = QApplication.instance()
+    if isinstance(instance, QApplication):
+        return instance
+    return QApplication([])
+
+
 def test_application_runtime_stops_widget_and_supervised_tasks(monkeypatch):
     events = []
     pending_task = None
@@ -83,10 +92,7 @@ def test_application_runtime_stops_widget_and_supervised_tasks(monkeypatch):
         def load(self):
             return object()
 
-    class FakeServices:
-        config_store = FakeConfigStore()
-
-    services = FakeServices()
+    services = replace(create_default_services(), config_store=FakeConfigStore())
 
     class FakeApplication:
         def __init__(self, *, services, **_kwargs):
@@ -119,7 +125,7 @@ def test_application_runtime_stops_widget_and_supervised_tasks(monkeypatch):
     monkeypatch.setattr(main_module, "ApplicationController", FakeApplication)
 
     async def run_test():
-        runtime = ApplicationRuntime(object(), 7450109, services=services)
+        runtime = ApplicationRuntime(_app(), 7450109, services=services)
         await runtime.start()
         await runtime.start()
         await runtime.stop()
@@ -143,10 +149,7 @@ def test_application_runtime_can_retry_after_widget_shutdown_failure(monkeypatch
         def load(self):
             return object()
 
-    class FakeServices:
-        config_store = FakeConfigStore()
-
-    services = FakeServices()
+    services = replace(create_default_services(), config_store=FakeConfigStore())
 
     class FakeApplication:
         def __init__(self, *, services, **_kwargs):
@@ -177,7 +180,7 @@ def test_application_runtime_can_retry_after_widget_shutdown_failure(monkeypatch
     monkeypatch.setattr(main_module, "create_default_services", lambda: services)
 
     async def run_test():
-        runtime = ApplicationRuntime(object(), 7450109)
+        runtime = ApplicationRuntime(_app(), 7450109)
         await runtime.start()
 
         with pytest.raises(RuntimeError, match="close failed"):
@@ -194,10 +197,22 @@ def test_application_runtime_can_retry_after_widget_shutdown_failure(monkeypatch
 
 def test_qr_login_dialog_shutdown_cancels_polling_work():
     class FakeAuthService:
-        pass
+        async def get_qrcode(self) -> tuple[str | None, str | None]:
+            raise AssertionError("QR login is not started in this test")
 
-    app = QApplication.instance() or QApplication([])
-    assert app is not None
+        def generate_qr_image(self, url: str):
+            del url
+            raise AssertionError("QR login is not started in this test")
+
+        async def poll_status(self, qrcode_key: str):
+            del qrcode_key
+            raise AssertionError("QR login is not started in this test")
+
+        def save_cookies(self, cookies):
+            del cookies
+            raise AssertionError("QR login is not started in this test")
+
+    app = _app()
     dialog = QRLoginDialog(auth_service=FakeAuthService())
 
     async def run_test():
@@ -218,3 +233,4 @@ def test_qr_login_dialog_shutdown_cancels_polling_work():
 
     asyncio.run(run_test())
     dialog.deleteLater()
+    app.processEvents()

--- a/tests/app/test_main.py
+++ b/tests/app/test_main.py
@@ -18,7 +18,9 @@ def test_cancel_pending_tasks_cancels_unfinished_tasks():
         task = asyncio.create_task(pending_task())
         await asyncio.sleep(0)
 
-        await cancel_pending_tasks(asyncio.get_running_loop(), exclude={asyncio.current_task()})
+        current_task = asyncio.current_task()
+        assert current_task is not None
+        await cancel_pending_tasks(asyncio.get_running_loop(), exclude={current_task})
 
         assert task.cancelled()
         assert cleanup_seen is True

--- a/tests/app/test_mirror_coordinator.py
+++ b/tests/app/test_mirror_coordinator.py
@@ -57,7 +57,8 @@ def test_mirror_coordinator_owns_start_stop_and_message_publication():
     )
     server = FakeServer(9876)
 
-    def factory(_state: MirrorState, *, port: int, display_settings: MirrorDisplaySettings) -> FakeServer:
+    def factory(state: MirrorState, *, port: int, display_settings: MirrorDisplaySettings) -> FakeServer:
+        del state
         assert port == 9876
         server.display_settings = display_settings
         return server
@@ -113,7 +114,8 @@ def test_mirror_coordinator_persists_enabled_preference_without_dropping_other_c
     )
     server = FakeServer(9877)
 
-    def factory(_state: MirrorState, *, port: int, display_settings: MirrorDisplaySettings) -> FakeServer:
+    def factory(state: MirrorState, *, port: int, display_settings: MirrorDisplaySettings) -> FakeServer:
+        del state
         assert port == 9877
         server.display_settings = display_settings
         return server
@@ -140,7 +142,8 @@ def test_mirror_coordinator_keeps_failed_server_for_retry_during_shutdown():
     config_store = FakeConfigStore(AppConfig(mirror_enabled=True))
     server = FakeServer(2233, stop_failures=1)
 
-    def factory(_state: MirrorState, *, port: int, display_settings: MirrorDisplaySettings) -> FakeServer:
+    def factory(state: MirrorState, *, port: int, display_settings: MirrorDisplaySettings) -> FakeServer:
+        del state
         assert port == 2233
         server.display_settings = display_settings
         return server
@@ -165,7 +168,8 @@ def test_mirror_coordinator_reports_bind_failure_without_claiming_server_ownersh
     config_store = FakeConfigStore(AppConfig(mirror_enabled=True, mirror_port=9988))
     server = FakeServer(9988, start_failure=True)
 
-    def factory(_state: MirrorState, *, port: int, display_settings: MirrorDisplaySettings) -> FakeServer:
+    def factory(state: MirrorState, *, port: int, display_settings: MirrorDisplaySettings) -> FakeServer:
+        del state
         server.display_settings = display_settings
         return server
 

--- a/tests/auth/test_auth.py
+++ b/tests/auth/test_auth.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import Mapping
 from dataclasses import dataclass
 
 import keyring
@@ -19,30 +20,39 @@ class FakeSessionCookie:
 
 
 class FakeResponse:
-    def __init__(self, payload: dict[str, object]):
+    def __init__(self, payload: Mapping[str, object]):
         self.payload = payload
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> "FakeResponse":
         return self
 
-    async def __aexit__(self, exc_type, exc, tb):
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
         return False
 
-    async def json(self):
+    async def json(self) -> Mapping[str, object]:
         return self.payload
 
 
 class FakeSession:
-    def __init__(self, payload: dict[str, object], responses: dict[str, dict[str, object]] | None = None):
+    def __init__(
+        self,
+        payload: Mapping[str, object],
+        responses: Mapping[str, Mapping[str, object]] | None = None,
+    ) -> None:
         self.cookie_jar = [
             FakeSessionCookie("SESSDATA", "qr-sess"),
             FakeSessionCookie("bili_jct", "qr-csrf"),
             FakeSessionCookie("unrelated", "ignored"),
         ]
         self.payload = payload
-        self.responses = responses or {}
+        self.responses: Mapping[str, Mapping[str, object]] = responses if responses is not None else {}
 
-    def get(self, _url, *, params=None):
+    def get(
+        self,
+        _url: str,
+        *,
+        params: Mapping[str, str] | None = None,
+    ) -> FakeResponse:
         if params == {"qrcode_key": "qr-key"}:
             assert params == {"qrcode_key": "qr-key"}
         if _url in self.responses:
@@ -53,10 +63,10 @@ class FakeSession:
             assert params == {"qrcode_key": "qr-key"}
         return FakeResponse(self.payload)
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> "FakeSession":
         return self
 
-    async def __aexit__(self, exc_type, exc, tb):
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
         return False
 
 
@@ -143,7 +153,7 @@ def test_account_lookup_returns_normalized_identity(monkeypatch):
         lambda **_kwargs: FakeSession(payload),
     )
     manager = AuthManager()
-    manager.load_auth_cookies = lambda: ({"SESSDATA": "session"}, True)
+    monkeypatch.setattr(manager, "load_auth_cookies", lambda: ({"SESSDATA": "session"}, True))
 
     result = asyncio.run(manager.lookup_account())
 
@@ -179,7 +189,7 @@ def test_account_lookup_includes_relations_and_live_room(monkeypatch):
     )
     monkeypatch.setattr("bilihud.auth.service.aiohttp.ClientSession", lambda **_kwargs: session)
     manager = AuthManager()
-    manager.load_auth_cookies = lambda: ({"SESSDATA": "session"}, True)
+    monkeypatch.setattr(manager, "load_auth_cookies", lambda: ({"SESSDATA": "session"}, True))
 
     result = asyncio.run(manager.lookup_account())
 

--- a/tests/danmaku/test_danmaku_client.py
+++ b/tests/danmaku/test_danmaku_client.py
@@ -10,7 +10,7 @@ import pytest
 from bilihud.danmaku import client as danmaku_client
 from bilihud.danmaku.client import DanmakuClient, DanmakuHandler, DanmakuShutdownError
 from bilihud.danmaku.messages import DanmakuMessage, GiftMessage, InteractMessage
-from bilihud.http_contracts import HttpResponse, QueryParams, QueryValue
+from bilihud.http_contracts import HttpResponse, QueryParams
 from bilihud.live.emoticons import LiveEmoticon
 from bilihud.live.gift_effects import FULL_SCREEN_EFFECT_CONFIG_URL, GiftEffectCatalog
 
@@ -391,9 +391,9 @@ class FakeHttpSession:
         self.posted_data: object | None = None
         self.get_url: str = ""
         self.post_url: str = ""
-        self.get_params: dict[str, QueryValue] | None = None
+        self.get_params: QueryParams | None = None
         self.get_headers: dict[str, str] | None = None
-        self.get_calls: list[tuple[str, dict[str, QueryValue] | None, dict[str, str] | None]] = []
+        self.get_calls: list[tuple[str, QueryParams | None, dict[str, str] | None]] = []
         self.cookie_jar: list[FakeCookie] = [FakeCookie("bili_jct", "csrf-token")]
         self.closed: bool = False
 
@@ -405,7 +405,7 @@ class FakeHttpSession:
         headers: Mapping[str, str] | None = None,
     ) -> FakeResponse:
         self.get_url = url
-        self.get_params = dict(params) if isinstance(params, Mapping) else None
+        self.get_params = params
         self.get_headers = dict(headers) if headers is not None else None
         self.get_calls.append((url, self.get_params, self.get_headers))
         payload = self.get_payloads.pop(0) if self.get_payloads else self.get_payload

--- a/tests/danmaku/test_danmaku_client.py
+++ b/tests/danmaku/test_danmaku_client.py
@@ -1,4 +1,7 @@
 import asyncio
+from collections.abc import Mapping
+from contextlib import AbstractAsyncContextManager
+from types import TracebackType
 from urllib.parse import parse_qs, urlparse
 
 import aiohttp
@@ -7,8 +10,16 @@ import pytest
 from bilihud.danmaku import client as danmaku_client
 from bilihud.danmaku.client import DanmakuClient, DanmakuHandler, DanmakuShutdownError
 from bilihud.danmaku.messages import DanmakuMessage, GiftMessage, InteractMessage
+from bilihud.http_contracts import HttpResponse, QueryParams, QueryValue
 from bilihud.live.emoticons import LiveEmoticon
 from bilihud.live.gift_effects import FULL_SCREEN_EFFECT_CONFIG_URL, GiftEffectCatalog
+
+
+class FakeWebSocketClient(danmaku_client.ws_base.WebSocketClientBase):
+    """Type marker for handler callbacks that do not inspect websocket state."""
+
+    def __init__(self) -> None:
+        pass
 
 
 def test_start_starts_blivedm_client_and_reports_missing_login(monkeypatch):
@@ -25,6 +36,7 @@ def test_start_starts_blivedm_client_and_reports_missing_login(monkeypatch):
             self.session = session
             self.start_calls = 0
             self.handler = None
+            created_clients.append(self)
 
         @property
         def is_running(self):
@@ -35,6 +47,8 @@ def test_start_starts_blivedm_client_and_reports_missing_login(monkeypatch):
 
         def start(self):
             self.start_calls += 1
+
+    created_clients: list[FakeBLiveClient] = []
 
     async def run_test():
         monkeypatch.setattr(danmaku_client, "AuthManager", FakeAuthManager)
@@ -47,7 +61,7 @@ def test_start_starts_blivedm_client_and_reports_missing_login(monkeypatch):
         await client.start()
 
         assert client.client is not None
-        assert client.client.start_calls == 1
+        assert created_clients[0].start_calls == 1
         assert client.client.is_running is True
         assert login_failures == ["未找到有效登录信息，请扫码登录"]
 
@@ -57,14 +71,15 @@ def test_start_starts_blivedm_client_and_reports_missing_login(monkeypatch):
 def test_handler_emits_normalized_domain_messages():
     client = DanmakuClient(7450109)
     received = []
+    websocket = FakeWebSocketClient()
     client.set_message_callback(received.append)
     handler = DanmakuHandler()
     handler.set_danmaku_client(client)
 
-    handler._on_danmaku(None, danmaku_client.web_models.DanmakuMessage(uname="弹幕用户", msg="你好"))
-    handler._on_gift(None, danmaku_client.web_models.GiftMessage(uname="礼物用户", gift_name="辣条", num=1))
+    handler._on_danmaku(websocket, danmaku_client.web_models.DanmakuMessage(uname="弹幕用户", msg="你好"))
+    handler._on_gift(websocket, danmaku_client.web_models.GiftMessage(uname="礼物用户", gift_name="辣条", num=1))
     handler._on_interact_word_v2(
-        None,
+        websocket,
         danmaku_client.web_models.InteractWordV2Message(username="互动用户", msg_type=2),
     )
 
@@ -141,7 +156,8 @@ def test_handler_resolves_official_gift_resources_before_delivery():
         client.set_message_callback(on_message)
         handler = DanmakuHandler()
         handler.set_danmaku_client(client)
-        handler.handle(None, {"cmd": "SEND_GIFT", "data": raw_gift})
+        websocket = FakeWebSocketClient()
+        handler.handle(websocket, {"cmd": "SEND_GIFT", "data": raw_gift})
 
         await asyncio.wait_for(delivered.wait(), timeout=1)
         assert len(received) == 1
@@ -213,9 +229,10 @@ def test_handler_resolves_guard_purchase_effect_and_deduplicates_toast_event():
         client.set_message_callback(on_message)
         handler = DanmakuHandler()
         handler.set_danmaku_client(client)
+        websocket = FakeWebSocketClient()
 
-        assert handler.handle(None, {"cmd": "GUARD_BUY", "data": raw_guard}) is None
-        assert handler.handle(None, {"cmd": "USER_TOAST_MSG_V2", "data": duplicate_toast}) is None
+        assert handler.handle(websocket, {"cmd": "GUARD_BUY", "data": raw_guard}) is None
+        assert handler.handle(websocket, {"cmd": "USER_TOAST_MSG_V2", "data": duplicate_toast}) is None
 
         await asyncio.wait_for(delivered.wait(), timeout=1)
         assert len(received) == 1
@@ -235,9 +252,10 @@ def test_handler_emits_open_platform_guard_without_the_optional_catalog():
     client.set_message_callback(received.append)
     handler = DanmakuHandler()
     handler.set_danmaku_client(client)
+    websocket = FakeWebSocketClient()
 
     handler.handle(
-        None,
+        websocket,
         {
             "cmd": "LIVE_OPEN_PLATFORM_GUARD",
             "data": {
@@ -310,9 +328,10 @@ def test_start_reports_expired_keyring_login(monkeypatch):
 
 class FakeSession:
     def __init__(self, on_close=None):
-        self.closed = False
-        self.close_calls = 0
+        self.closed: bool = False
+        self.close_calls: int = 0
         self._on_close = on_close
+        self.cookie_jar: list[FakeCookie] = []
 
     async def close(self):
         self.close_calls += 1
@@ -320,61 +339,102 @@ class FakeSession:
         if self._on_close is not None:
             self._on_close()
 
+    def get(
+        self,
+        url: str,
+        *,
+        params: QueryParams | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> "FakeResponse":
+        raise AssertionError(f"unexpected GET request: {url}, {params}, {headers}")
 
-class FakeResponse:
-    def __init__(self, payload, status=200):
-        self.payload = payload
-        self.status = status
+    def post(self, url: str, *, data: object | None = None) -> "FakeResponse":
+        raise AssertionError(f"unexpected POST request: {url}, {data}")
 
-    async def __aenter__(self):
+
+class FakeResponse(HttpResponse, AbstractAsyncContextManager[HttpResponse]):
+    def __init__(self, payload: object, status: int = 200) -> None:
+        self.payload: object = payload
+        self.status: int = status
+
+    async def __aenter__(self) -> "FakeResponse":
         return self
 
-    async def __aexit__(self, exc_type, exc, tb):
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
         return False
 
-    async def json(self, content_type=None):
+    async def json(self, *, content_type: str | None = None) -> object:
         return self.payload
 
 
 class FakeCookie:
-    def __init__(self, key, value):
-        self.key = key
-        self.value = value
+    def __init__(self, key: str, value: str) -> None:
+        self.key: str = key
+        self.value: str = value
 
 
 class FakeHttpSession:
-    def __init__(self, get_payload=None, get_payloads=None, post_payload=None):
-        self.get_payload = get_payload or {"code": 0, "data": {"data": []}}
-        self.get_payloads = list(get_payloads or [])
-        self.post_payload = post_payload or {"code": 0, "message": "0"}
-        self.posted_data = None
-        self.get_params = None
-        self.get_headers = None
-        self.get_calls = []
-        self.cookie_jar = [FakeCookie("bili_jct", "csrf-token")]
+    def __init__(
+        self,
+        get_payload: object | None = None,
+        get_payloads: list[object] | None = None,
+        post_payload: object | None = None,
+    ) -> None:
+        self.get_payload: object = get_payload if get_payload is not None else {"code": 0, "data": {"data": []}}
+        self.get_payloads: list[object] = list(get_payloads) if get_payloads is not None else []
+        self.post_payload: object = post_payload if post_payload is not None else {"code": 0, "message": "0"}
+        self.posted_data: object | None = None
+        self.get_url: str = ""
+        self.post_url: str = ""
+        self.get_params: dict[str, QueryValue] | None = None
+        self.get_headers: dict[str, str] | None = None
+        self.get_calls: list[tuple[str, dict[str, QueryValue] | None, dict[str, str] | None]] = []
+        self.cookie_jar: list[FakeCookie] = [FakeCookie("bili_jct", "csrf-token")]
+        self.closed: bool = False
 
-    def get(self, url, params=None, headers=None):
+    def get(
+        self,
+        url: str,
+        *,
+        params: QueryParams | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> FakeResponse:
         self.get_url = url
-        self.get_params = params
-        self.get_headers = headers
-        self.get_calls.append((url, params, headers))
+        self.get_params = dict(params) if isinstance(params, Mapping) else None
+        self.get_headers = dict(headers) if headers is not None else None
+        self.get_calls.append((url, self.get_params, self.get_headers))
         payload = self.get_payloads.pop(0) if self.get_payloads else self.get_payload
         return FakeResponse(payload)
 
-    def post(self, url, data=None):
+    def post(self, url: str, *, data: object | None = None) -> FakeResponse:
         self.post_url = url
         self.posted_data = data
         return FakeResponse(self.post_payload)
+
+    async def close(self) -> None:
+        self.closed = True
 
 
 def _form_data_fields(form_data):
     return {disposition["name"]: value for disposition, _, value in form_data._fields}
 
 
+def _posted_mapping(value: object | None) -> dict[str, object]:
+    """Narrow the text-message payload captured by the HTTP fake."""
+    if not isinstance(value, dict):
+        raise AssertionError("expected a mapping payload")
+    return {key: item for key, item in value.items() if isinstance(key, str)}
+
+
 def test_fetch_audience_snapshot_uses_current_web_api_contract():
     async def run_test():
         client = DanmakuClient(7450109)
-        client.session = FakeHttpSession(
+        session = FakeHttpSession(
             get_payloads=[
                 {
                     "code": 0,
@@ -403,6 +463,7 @@ def test_fetch_audience_snapshot_uses_current_web_api_contract():
                 },
             ]
         )
+        client.session = session
 
         snapshot = await client.fetch_audience_snapshot()
 
@@ -413,12 +474,12 @@ def test_fetch_audience_snapshot_uses_current_web_api_contract():
         assert snapshot.users[0].name == "用户A"
         assert snapshot.users[0].contribution == 1
 
-        room_url, room_params, room_headers = client.session.get_calls[0]
+        room_url, room_params, room_headers = session.get_calls[0]
         assert room_url.endswith("/xlive/web-room/v1/index/getInfoByRoom")
         assert room_params == {"room_id": 7450109}
         assert room_headers == {"Referer": "https://live.bilibili.com/7450109"}
 
-        rank_url, rank_params, rank_headers = client.session.get_calls[1]
+        rank_url, rank_params, rank_headers = session.get_calls[1]
         assert rank_url.endswith("/xlive/general-interface/v1/rank/queryContributionRank")
         assert rank_params == {
             "ruid": 9001,
@@ -447,9 +508,10 @@ def test_fetch_audience_snapshot_requires_initialized_session():
 def test_fetch_audience_snapshot_propagates_api_error_without_credentials():
     async def run_test():
         client = DanmakuClient(7450109)
-        client.session = FakeHttpSession(
+        session = FakeHttpSession(
             get_payload={"code": -101, "message": "账号未登录", "data": None}
         )
+        client.session = session
 
         with pytest.raises(ValueError, match="账号未登录"):
             await client.fetch_audience_snapshot()
@@ -467,6 +529,12 @@ class FakeBLiveClient:
     @property
     def is_running(self):
         return not self._done.is_set()
+
+    def set_handler(self, handler: object) -> None:
+        pass
+
+    def start(self) -> None:
+        self._done.clear()
 
     def stop(self):
         self.stop_calls += 1
@@ -570,7 +638,7 @@ def test_stop_raises_if_blivedm_task_survives_forced_session_close():
 def test_fetch_live_emoticons_uses_v2_api_and_existing_session():
     async def run_test():
         client = DanmakuClient(870691)
-        client.session = FakeHttpSession(
+        session = FakeHttpSession(
             get_payload={
                 "code": 0,
                 "message": "0",
@@ -597,13 +665,15 @@ def test_fetch_live_emoticons_uses_v2_api_and_existing_session():
                 },
             }
         )
+        client.session = session
 
         packages = await client.fetch_live_emoticons()
 
         assert packages[0].name == "房间专属表情"
-        assert client.session.get_url.endswith("/xlive/web-ucenter/v2/emoticon/GetEmoticons")
-        assert client.session.get_params == {"platform": "pc", "room_id": 870691}
-        assert client.session.get_headers["Referer"] == "https://live.bilibili.com/870691"
+        assert session.get_url.endswith("/xlive/web-ucenter/v2/emoticon/GetEmoticons")
+        assert session.get_params == {"platform": "pc", "room_id": 870691}
+        assert session.get_headers is not None
+        assert session.get_headers["Referer"] == "https://live.bilibili.com/870691"
 
     asyncio.run(run_test())
 
@@ -617,7 +687,7 @@ def test_fetch_live_emoticons_uses_one_minute_cache(monkeypatch):
     async def run_test():
         nonlocal now
         client = DanmakuClient(870691)
-        client.session = FakeHttpSession(
+        session = FakeHttpSession(
             get_payload={
                 "code": 0,
                 "message": "0",
@@ -644,6 +714,7 @@ def test_fetch_live_emoticons_uses_one_minute_cache(monkeypatch):
                 },
             }
         )
+        client.session = session
 
         first = await client.fetch_live_emoticons()
         second = await client.fetch_live_emoticons()
@@ -652,7 +723,7 @@ def test_fetch_live_emoticons_uses_one_minute_cache(monkeypatch):
 
         assert first is second
         assert third is not first
-        assert len(client.session.get_calls) == 2
+        assert len(session.get_calls) == 2
 
     monkeypatch.setattr("bilihud.danmaku.client.time.time", current_time)
     asyncio.run(run_test())
@@ -663,16 +734,17 @@ def test_fetch_live_emoticons_does_not_cache_failed_fetch(monkeypatch):
 
     async def run_test():
         client = DanmakuClient(870691)
-        client.session = FakeHttpSession(get_payload={"code": -101, "message": "账号未登录", "data": None})
+        session = FakeHttpSession(get_payload={"code": -101, "message": "账号未登录", "data": None})
+        client.session = session
 
         with pytest.raises(ValueError, match="账号未登录"):
             await client.fetch_live_emoticons()
 
-        client.session.get_payload = {"code": 0, "message": "0", "data": {"data": []}}
+        session.get_payload = {"code": 0, "message": "0", "data": {"data": []}}
         packages = await client.fetch_live_emoticons()
 
         assert packages == []
-        assert len(client.session.get_calls) == 2
+        assert len(session.get_calls) == 2
 
     monkeypatch.setattr("bilihud.danmaku.client.time.time", lambda: now)
     asyncio.run(run_test())
@@ -681,7 +753,7 @@ def test_fetch_live_emoticons_does_not_cache_failed_fetch(monkeypatch):
 def test_send_live_emoticon_posts_dm_type_payload():
     async def run_test():
         client = DanmakuClient(870691)
-        client.session = FakeHttpSession(
+        session = FakeHttpSession(
             get_payload={
                 "code": 0,
                 "data": {
@@ -693,6 +765,7 @@ def test_send_live_emoticon_posts_dm_type_payload():
             },
             post_payload={"code": 0, "message": "0"},
         )
+        client.session = session
         emoticon = LiveEmoticon(
             emoji="AKIE的A",
             url="http://i0.hdslb.com/bfs/live/room.png",
@@ -708,15 +781,16 @@ def test_send_live_emoticon_posts_dm_type_payload():
 
         assert success is True
         assert message == "发送成功"
-        assert client.session.post_url.startswith("https://api.live.bilibili.com/msg/send?")
-        query = parse_qs(urlparse(client.session.post_url).query)
+        assert session.post_url.startswith("https://api.live.bilibili.com/msg/send?")
+        query = parse_qs(urlparse(session.post_url).query)
         assert query["web_location"] == ["444.8"]
         assert query["wts"]
         assert len(query["w_rid"][0]) == 32
-        assert client.session.get_calls[0][0] == "https://api.bilibili.com/x/web-interface/nav"
-        assert isinstance(client.session.posted_data, aiohttp.FormData)
-        assert client.session.posted_data.is_multipart is True
-        posted_fields = _form_data_fields(client.session.posted_data)
+        assert session.get_calls[0][0] == "https://api.bilibili.com/x/web-interface/nav"
+        assert isinstance(session.posted_data, aiohttp.FormData)
+        posted_data = session.posted_data
+        assert posted_data.is_multipart is True
+        posted_fields = _form_data_fields(posted_data)
         assert posted_fields["dm_type"] == "1"
         assert posted_fields["emoticonOptions"] == "[object Object]"
         assert posted_fields["data_extend"] == '{"trackid":"-99998"}'
@@ -729,7 +803,7 @@ def test_send_live_emoticon_posts_dm_type_payload():
 def test_send_live_emoticon_posts_dm_type_payload_for_official_common_package():
     async def run_test():
         client = DanmakuClient(870691)
-        client.session = FakeHttpSession(
+        session = FakeHttpSession(
             get_payload={
                 "code": 0,
                 "data": {
@@ -741,6 +815,7 @@ def test_send_live_emoticon_posts_dm_type_payload_for_official_common_package():
             },
             post_payload={"code": 0, "message": "0"},
         )
+        client.session = session
         emoticon = LiveEmoticon(
             emoji="啊",
             url="http://i0.hdslb.com/bfs/live/a.png",
@@ -756,9 +831,10 @@ def test_send_live_emoticon_posts_dm_type_payload_for_official_common_package():
 
         assert success is True
         assert message == "发送成功"
-        assert isinstance(client.session.posted_data, aiohttp.FormData)
-        assert client.session.posted_data.is_multipart is True
-        posted_fields = _form_data_fields(client.session.posted_data)
+        assert isinstance(session.posted_data, aiohttp.FormData)
+        posted_data = session.posted_data
+        assert posted_data.is_multipart is True
+        posted_fields = _form_data_fields(posted_data)
         assert posted_fields["msg"] == "official_331"
         assert posted_fields["dm_type"] == "1"
         assert posted_fields["emoticonOptions"] == "[object Object]"
@@ -770,7 +846,8 @@ def test_send_live_emoticon_posts_dm_type_payload_for_official_common_package():
 def test_send_live_emoticon_sends_emoji_package_as_text_escape():
     async def run_test():
         client = DanmakuClient(870691)
-        client.session = FakeHttpSession(post_payload={"code": 0, "message": "0"})
+        session = FakeHttpSession(post_payload={"code": 0, "message": "0"})
+        client.session = session
         emoticon = LiveEmoticon(
             emoji="赞",
             url="http://i0.hdslb.com/bfs/live/thumb.png",
@@ -786,10 +863,11 @@ def test_send_live_emoticon_sends_emoji_package_as_text_escape():
 
         assert success is True
         assert message == "发送成功"
-        assert client.session.post_url == "https://api.live.bilibili.com/msg/send"
-        assert client.session.get_calls == []
-        assert client.session.posted_data["msg"] == "[赞]"
-        assert "dm_type" not in client.session.posted_data
+        assert session.post_url == "https://api.live.bilibili.com/msg/send"
+        assert session.get_calls == []
+        posted_data = _posted_mapping(session.posted_data)
+        assert posted_data["msg"] == "[赞]"
+        assert "dm_type" not in posted_data
 
     asyncio.run(run_test())
 
@@ -797,7 +875,8 @@ def test_send_live_emoticon_sends_emoji_package_as_text_escape():
 def test_send_live_emoticon_preserves_bracketed_emoji_text_escape():
     async def run_test():
         client = DanmakuClient(870691)
-        client.session = FakeHttpSession(post_payload={"code": 0, "message": "0"})
+        session = FakeHttpSession(post_payload={"code": 0, "message": "0"})
+        client.session = session
         emoticon = LiveEmoticon(
             emoji="[dog]",
             url="http://i0.hdslb.com/bfs/live/dog.png",
@@ -813,8 +892,9 @@ def test_send_live_emoticon_preserves_bracketed_emoji_text_escape():
 
         assert success is True
         assert message == "发送成功"
-        assert client.session.posted_data["msg"] == "[dog]"
-        assert "dm_type" not in client.session.posted_data
+        posted_data = _posted_mapping(session.posted_data)
+        assert posted_data["msg"] == "[dog]"
+        assert "dm_type" not in posted_data
 
     asyncio.run(run_test())
 
@@ -822,7 +902,8 @@ def test_send_live_emoticon_preserves_bracketed_emoji_text_escape():
 def test_send_live_emoticon_rejects_locked_emoticon_without_posting():
     async def run_test():
         client = DanmakuClient(870691)
-        client.session = FakeHttpSession()
+        session = FakeHttpSession()
+        client.session = session
         emoticon = LiveEmoticon(
             emoji="疑惑",
             url="http://i0.hdslb.com/bfs/live/locked.png",
@@ -838,6 +919,6 @@ def test_send_live_emoticon_rejects_locked_emoticon_without_posting():
 
         assert success is False
         assert "未解锁" in message
-        assert client.session.posted_data is None
+        assert session.posted_data is None
 
     asyncio.run(run_test())

--- a/tests/live/test_gift_effects.py
+++ b/tests/live/test_gift_effects.py
@@ -1,5 +1,9 @@
 import asyncio
+from collections.abc import Mapping
+from contextlib import AbstractAsyncContextManager
+from types import TracebackType
 
+from bilihud.http_contracts import HttpCookie, HttpResponse, QueryParams, QueryValue
 from bilihud.live.gift_effects import (
     FULL_SCREEN_EFFECT_CONFIG_URL,
     GIFT_DETAIL_URL,
@@ -7,7 +11,7 @@ from bilihud.live.gift_effects import (
 )
 
 
-class FakeResponse:
+class FakeResponse(HttpResponse, AbstractAsyncContextManager[HttpResponse]):
     def __init__(self, payload: object, status: int = 200) -> None:
         self.payload = payload
         self.status = status
@@ -15,7 +19,12 @@ class FakeResponse:
     async def __aenter__(self) -> "FakeResponse":
         return self
 
-    async def __aexit__(self, exc_type, exc, traceback) -> bool:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
         return False
 
     async def json(self, content_type=None) -> object:
@@ -32,20 +41,30 @@ class FakeSession:
         self.payload = payload
         self.metadata_payload = metadata_payload
         self.special_payload = special_payload
-        self.calls: list[tuple[str, dict[str, object], dict[str, str]]] = []
+        self.calls: list[tuple[str, dict[str, QueryValue] | None, dict[str, str] | None]] = []
+        self.cookie_jar: list[HttpCookie] = []
+        self.closed = False
 
     def get(
         self,
         url: str,
-        params: dict[str, object] | None = None,
-        headers: dict[str, str] | None = None,
+        params: QueryParams | None = None,
+        headers: Mapping[str, str] | None = None,
     ) -> FakeResponse:
-        self.calls.append((url, params, headers))
+        normalized_params = dict(params) if params is not None else None
+        normalized_headers = dict(headers) if headers is not None else None
+        self.calls.append((url, normalized_params, normalized_headers))
         if url == FULL_SCREEN_EFFECT_CONFIG_URL and self.special_payload is not None:
             payload = self.special_payload
         else:
             payload = self.metadata_payload if url.endswith(".json") else self.payload
         return FakeResponse(self.payload if payload is None else payload)
+
+    async def close(self) -> None:
+        self.closed = True
+
+    def post(self, url: str, *, data: object | None = None) -> FakeResponse:
+        raise AssertionError(f"unexpected POST request: {url}, {data}")
 
 
 def test_gift_effect_catalog_resolves_and_caches_official_resources() -> None:
@@ -92,6 +111,7 @@ def test_gift_effect_catalog_resolves_and_caches_official_resources() -> None:
         assert second is first
         assert len(session.calls) == 2
         assert session.calls[0][0] == GIFT_DETAIL_URL
+        assert session.calls[0][1] is not None
         assert session.calls[0][1]["gift_ids"] == "32132"
         assert session.calls[0][2] == {"Referer": "https://live.bilibili.com/7450109"}
         assert session.calls[1][0].endswith("castle.json")

--- a/tests/mirror/test_mirror_server.py
+++ b/tests/mirror/test_mirror_server.py
@@ -19,14 +19,22 @@ from bilihud.mirror.state import (
     MIRROR_MEDIA_ROUTE,
     MIRROR_ROUTE,
     MirrorDisplaySettings,
+    MirrorEntry,
     MirrorState,
 )
 
 
 def _site_port(site: web.TCPSite) -> int:
-    sockets = site._server.sockets
-    assert sockets is not None
-    return sockets[0].getsockname()[1]
+    port = site.port
+    assert port > 0
+    return port
+
+
+def _started_site(server: MirrorServer) -> web.TCPSite:
+    """Narrow the private site after the public start contract completes."""
+    site = server._site
+    assert site is not None
+    return site
 
 
 def test_mirror_routes_are_bilihud_named():
@@ -153,7 +161,7 @@ def test_mirror_server_streams_snapshot_before_later_messages():
         await mirror_server.start()
 
         try:
-            events_url = f"http://127.0.0.1:{_site_port(mirror_server._site)}{MIRROR_EVENTS_ROUTE}"
+            events_url = f"http://127.0.0.1:{_site_port(_started_site(mirror_server))}{MIRROR_EVENTS_ROUTE}"
             async with ClientSession() as session:
                 async with session.get(events_url) as response:
                     assert response.status == 200
@@ -163,7 +171,13 @@ def test_mirror_server_streams_snapshot_before_later_messages():
                     assert event_name == "snapshot"
                     assert snapshot == state.snapshot()
 
-                    next_entry = {"seq": 2, "user": "新用户", "segments": []}
+                    next_entry: MirrorEntry = {
+                        "seq": 2,
+                        "kind": "danmaku",
+                        "user": "新用户",
+                        "userColor": "#66CCFF",
+                        "segments": [],
+                    }
                     mirror_server.publish_append(next_entry)
                     event_name, entry = await _read_sse_event(response)
 
@@ -181,7 +195,7 @@ def test_mirror_server_registers_image_proxy_route():
         await mirror_server.start()
 
         try:
-            image_url = f"http://127.0.0.1:{_site_port(mirror_server._site)}{MIRROR_IMAGE_ROUTE}"
+            image_url = f"http://127.0.0.1:{_site_port(_started_site(mirror_server))}{MIRROR_IMAGE_ROUTE}"
             async with ClientSession() as session:
                 async with session.get(image_url, params={"url": "file:///tmp/emote.png"}) as response:
                     assert response.status == 400
@@ -198,7 +212,7 @@ def test_mirror_server_serves_bilihud_icon():
         await mirror_server.start()
 
         try:
-            icon_url = f"http://127.0.0.1:{_site_port(mirror_server._site)}{MIRROR_ICON_ROUTE}"
+            icon_url = f"http://127.0.0.1:{_site_port(_started_site(mirror_server))}{MIRROR_ICON_ROUTE}"
             async with ClientSession() as session:
                 async with session.get(icon_url) as response:
                     assert response.status == 200
@@ -217,7 +231,7 @@ def test_mirror_server_registers_media_proxy_route():
         await mirror_server.start()
 
         try:
-            media_url = f"http://127.0.0.1:{_site_port(mirror_server._site)}{MIRROR_MEDIA_ROUTE}"
+            media_url = f"http://127.0.0.1:{_site_port(_started_site(mirror_server))}{MIRROR_MEDIA_ROUTE}"
             async with ClientSession() as session:
                 async with session.get(media_url, params={"url": "file:///tmp/gift.mp4"}) as response:
                     assert response.status == 400
@@ -234,7 +248,7 @@ def test_mirror_image_proxy_rejects_local_and_unallowlisted_hosts():
         await mirror_server.start()
 
         try:
-            image_url = f"http://127.0.0.1:{_site_port(mirror_server._site)}{MIRROR_IMAGE_ROUTE}"
+            image_url = f"http://127.0.0.1:{_site_port(_started_site(mirror_server))}{MIRROR_IMAGE_ROUTE}"
             async with ClientSession() as session:
                 async with session.get(image_url, params={"url": "http://127.0.0.1:8080/emote.png"}) as response:
                     assert response.status == 400
@@ -267,7 +281,7 @@ def test_mirror_server_keeps_runner_when_cleanup_fails():
         def __init__(self):
             self.cleanup_calls = 0
 
-        async def cleanup(self):
+        async def cleanup(self) -> None:
             self.cleanup_calls += 1
             if self.cleanup_calls == 1:
                 raise RuntimeError("runner cleanup failed")
@@ -276,17 +290,22 @@ def test_mirror_server_keeps_runner_when_cleanup_fails():
         mirror_server = MirrorServer(MirrorState())
         runner = FakeRunner()
         mirror_server._runner = runner
-        mirror_server._site = object()
+        site_runner = web.AppRunner(web.Application())
+        await site_runner.setup()
+        mirror_server._site = web.TCPSite(site_runner, "127.0.0.1", 0)
 
-        with pytest.raises(RuntimeError, match="runner cleanup failed"):
+        try:
+            with pytest.raises(RuntimeError, match="runner cleanup failed"):
+                await mirror_server.stop()
+            assert mirror_server._runner is runner
+            assert mirror_server._site is not None
+
             await mirror_server.stop()
-        assert mirror_server._runner is runner
-        assert mirror_server._site is not None
-
-        await mirror_server.stop()
-        assert mirror_server._runner is None
-        assert mirror_server._site is None
-        assert runner.cleanup_calls == 2
+            assert mirror_server._runner is None
+            assert mirror_server._site is None
+            assert runner.cleanup_calls == 2
+        finally:
+            await site_runner.cleanup()
 
     asyncio.run(run_test())
 
@@ -320,7 +339,7 @@ def test_mirror_image_proxy_fetches_image_with_bilibili_headers():
 
         try:
             source_url = f"http://127.0.0.1:{_site_port(source_site)}/emote.png"
-            mirror_url = f"http://127.0.0.1:{_site_port(mirror_server._site)}{MIRROR_IMAGE_ROUTE}"
+            mirror_url = f"http://127.0.0.1:{_site_port(_started_site(mirror_server))}{MIRROR_IMAGE_ROUTE}"
 
             async with ClientSession() as session:
                 async with session.get(mirror_url, params={"url": source_url}) as response:
@@ -366,7 +385,7 @@ def test_mirror_media_proxy_fetches_video_with_bilibili_headers():
 
         try:
             source_url = f"http://127.0.0.1:{_site_port(source_site)}/gift.mp4"
-            mirror_url = f"http://127.0.0.1:{_site_port(mirror_server._site)}{MIRROR_MEDIA_ROUTE}"
+            mirror_url = f"http://127.0.0.1:{_site_port(_started_site(mirror_server))}{MIRROR_MEDIA_ROUTE}"
 
             async with ClientSession() as session:
                 async with session.get(mirror_url, params={"url": source_url}) as response:
@@ -412,7 +431,7 @@ def test_mirror_image_proxy_rejects_redirects_to_untrusted_hosts_and_non_images(
 
         try:
             source_base_url = f"http://127.0.0.1:{_site_port(source_site)}"
-            mirror_url = f"http://127.0.0.1:{_site_port(mirror_server._site)}{MIRROR_IMAGE_ROUTE}"
+            mirror_url = f"http://127.0.0.1:{_site_port(_started_site(mirror_server))}{MIRROR_IMAGE_ROUTE}"
             async with ClientSession() as session:
                 async with session.get(mirror_url, params={"url": f"{source_base_url}/redirect"}) as response:
                     assert response.status == 400
@@ -463,7 +482,7 @@ def test_mirror_image_proxy_enforces_response_size_and_timeout_limits():
 
         try:
             source_base_url = f"http://127.0.0.1:{_site_port(source_site)}"
-            mirror_url = f"http://127.0.0.1:{_site_port(mirror_server._site)}{MIRROR_IMAGE_ROUTE}"
+            mirror_url = f"http://127.0.0.1:{_site_port(_started_site(mirror_server))}{MIRROR_IMAGE_ROUTE}"
             async with ClientSession() as session:
                 async with session.get(mirror_url, params={"url": f"{source_base_url}/large"}) as response:
                     assert response.status == 413

--- a/tests/platform/test_window_platform.py
+++ b/tests/platform/test_window_platform.py
@@ -19,9 +19,9 @@ from bilihud.platform.overlay_contracts import (
 
 def _app() -> QApplication:
     app = QApplication.instance()
-    if app is None:
-        app = QApplication([])
-    return app
+    if isinstance(app, QApplication):
+        return app
+    return QApplication([])
 
 
 class FakeWindowHost:
@@ -163,7 +163,8 @@ def test_layer_shell_activation_falls_back_to_an_ordinary_window(monkeypatch) ->
     monkeypatch.setenv("XDG_CURRENT_DESKTOP", "KDE")
 
     class FailingLayerShellBridge(FakeLayerShellBridge):
-        def make_overlay(self, _window_pointer: int, *, full_screen: bool = False) -> bool:
+        def make_overlay(self, window_pointer: int, *, full_screen: bool = False) -> bool:
+            del window_pointer
             del full_screen
             raise RuntimeError("test activation failure")
 

--- a/tests/platform/test_x11.py
+++ b/tests/platform/test_x11.py
@@ -1,4 +1,18 @@
+from collections.abc import Callable
+
 from bilihud.platform.x11 import X11InputShape
+
+
+class FakeNativeFunction:
+    """Provide the mutable ctypes attributes required by the native boundary."""
+
+    def __init__(self, callback: Callable[..., object]) -> None:
+        self._callback = callback
+        self.argtypes: list[object] | None = None
+        self.restype: object | None = None
+
+    def __call__(self, *arguments: object) -> object:
+        return self._callback(*arguments)
 
 
 def test_x11_display_cleanup_failure_stays_inside_operation_result() -> None:
@@ -22,11 +36,11 @@ def test_x11_display_cleanup_failure_stays_inside_operation_result() -> None:
         calls.append("mask")
 
     adapter = X11InputShape(
-        x11_open_display=open_display,
-        x11_flush=flush,
-        x11_close_display=close_display,
-        shape_rectangles=combine_rectangles,
-        shape_mask=combine_mask,
+        x11_open_display=FakeNativeFunction(open_display),
+        x11_flush=FakeNativeFunction(flush),
+        x11_close_display=FakeNativeFunction(close_display),
+        shape_rectangles=FakeNativeFunction(combine_rectangles),
+        shape_mask=FakeNativeFunction(combine_mask),
     )
 
     result = adapter.set_click_through(123, enabled=True)

--- a/tests/test_audience_widgets.py
+++ b/tests/test_audience_widgets.py
@@ -1,8 +1,8 @@
 import os
 
-from PyQt6.QtCore import Qt
-from PyQt6.QtTest import QTest
-from PyQt6.QtWidgets import QApplication
+from PyQt6.QtCore import QEvent, Qt
+from PyQt6.QtGui import QKeyEvent
+from PyQt6.QtWidgets import QApplication, QWidget
 
 from bilihud.live.audience import AudienceSnapshot, AudienceUser
 from bilihud.ui.hud.audience import AudiencePopup, AudienceStatusWidget
@@ -65,10 +65,14 @@ def test_popup_maps_each_username_to_its_contribution():
 
     assert popup.summary_label.text() == "可见 2 / 共 3"
     assert popup.tree.topLevelItemCount() == 2
-    assert popup.tree.topLevelItem(0).text(0) == "用户A"
-    assert popup.tree.topLevelItem(0).text(1) == "1"
-    assert popup.tree.topLevelItem(1).text(0) == "用户B"
-    assert popup.tree.topLevelItem(1).text(1) == "4"
+    first_item = popup.tree.topLevelItem(0)
+    second_item = popup.tree.topLevelItem(1)
+    assert first_item is not None
+    assert second_item is not None
+    assert first_item.text(0) == "用户A"
+    assert first_item.text(1) == "1"
+    assert second_item.text(0) == "用户B"
+    assert second_item.text(1) == "4"
     assert popup.footer_label.text() == "还有 1 位用户未公开"
     assert popup.footer_label.isHidden() is False
 
@@ -91,7 +95,14 @@ def test_popup_escape_closes_popup():
     popup.show()
     qt_app.processEvents()
 
-    QTest.keyClick(popup, Qt.Key.Key_Escape)
+    popup_widget: QWidget = popup
+    popup_widget.keyPressEvent(
+        QKeyEvent(
+            QEvent.Type.KeyPress,
+            Qt.Key.Key_Escape,
+            Qt.KeyboardModifier.NoModifier,
+        )
+    )
     qt_app.processEvents()
 
     assert popup.isHidden()
@@ -110,7 +121,9 @@ def test_popup_constrains_long_list_to_internal_scroll_area():
 
     assert popup.tree.topLevelItemCount() == 120
     assert popup.height() <= 260
-    assert popup.tree.verticalScrollBar().maximum() > 0
+    scrollbar = popup.tree.verticalScrollBar()
+    assert scrollbar is not None
+    assert scrollbar.maximum() > 0
 
 
 def test_popup_keeps_compact_width_for_long_usernames():
@@ -124,4 +137,6 @@ def test_popup_keeps_compact_width_for_long_usernames():
     qt_app.processEvents()
 
     assert popup.width() == 240
-    assert popup.tree.topLevelItem(0).toolTip(0) == long_name
+    item = popup.tree.topLevelItem(0)
+    assert item is not None
+    assert item.toolTip(0) == long_name

--- a/tests/test_danmaku_widget.py
+++ b/tests/test_danmaku_widget.py
@@ -217,8 +217,12 @@ def test_danmaku_widget_injects_fixed_mock_messages_into_hud(monkeypatch):
     _app()
     widget = danmaku_widget.DanmakuWidget.__new__(danmaku_widget.DanmakuWidget)
     widget._shutting_down = False
-    received = []
-    widget.add_message = received.append
+    received: list[HudMessage] = []
+
+    def receive_message(_widget: danmaku_widget.DanmakuWidget, message: HudMessage) -> None:
+        received.append(message)
+
+    monkeypatch.setattr(danmaku_widget.DanmakuWidget, "add_message", receive_message)
 
     danmaku_widget.DanmakuWidget.trigger_danmaku_simulation(widget)
 
@@ -229,12 +233,16 @@ def test_danmaku_widget_injects_fixed_mock_messages_into_hud(monkeypatch):
     )
 
 
-def test_danmaku_widget_injects_one_selected_gift_effect_fixture():
+def test_danmaku_widget_injects_one_selected_gift_effect_fixture(monkeypatch):
     _app()
     widget = danmaku_widget.DanmakuWidget.__new__(danmaku_widget.DanmakuWidget)
     widget._shutting_down = False
-    received = []
-    widget.add_message = received.append
+    received: list[HudMessage] = []
+
+    def receive_message(_widget: danmaku_widget.DanmakuWidget, message: HudMessage) -> None:
+        received.append(message)
+
+    monkeypatch.setattr(danmaku_widget.DanmakuWidget, "add_message", receive_message)
 
     danmaku_widget.DanmakuWidget.trigger_gift_effect_simulation(
         widget,
@@ -250,21 +258,29 @@ def test_danmaku_widget_injects_one_selected_gift_effect_fixture():
     assert castle.gift_effect_layout is not None
 
 
-def test_danmaku_widget_mirror_command_selects_unified_settings_tab():
-    calls = []
+def test_danmaku_widget_mirror_command_selects_unified_settings_tab(monkeypatch):
+    calls: list[SettingsPage] = []
     widget = danmaku_widget.DanmakuWidget.__new__(danmaku_widget.DanmakuWidget)
     widget._shutting_down = False
-    widget.open_settings = calls.append
+
+    def open_settings(_widget: danmaku_widget.DanmakuWidget, page: SettingsPage = SettingsPage.GENERAL) -> None:
+        calls.append(page)
+
+    monkeypatch.setattr(danmaku_widget.DanmakuWidget, "open_settings", open_settings)
 
     danmaku_widget.DanmakuWidget.open_mirror_settings(widget)
 
     assert calls == [SettingsPage.MIRROR]
 
 
-def test_danmaku_widget_live_tray_command_selects_unified_settings_tab():
-    calls = []
+def test_danmaku_widget_live_tray_command_selects_unified_settings_tab(monkeypatch):
+    calls: list[SettingsPage] = []
     widget = danmaku_widget.DanmakuWidget.__new__(danmaku_widget.DanmakuWidget)
-    widget.open_settings = calls.append
+
+    def open_settings(_widget: danmaku_widget.DanmakuWidget, page: SettingsPage = SettingsPage.GENERAL) -> None:
+        calls.append(page)
+
+    monkeypatch.setattr(danmaku_widget.DanmakuWidget, "open_settings", open_settings)
 
     danmaku_widget.DanmakuWidget._handle_menu_command(
         widget,
@@ -613,19 +629,18 @@ def test_emoticon_picker_keeps_one_tab_per_package():
     assert [picker.tabs.tabText(index) for index in range(picker.tabs.count())] == ["通用表情", "UP主大表情"]
 
 
-def test_danmaku_widget_sends_selected_live_emoticon():
+def test_danmaku_widget_sends_selected_live_emoticon(monkeypatch):
     class Controller:
-        def __init__(self):
-            self.sent = []
+        def __init__(self) -> None:
+            self.sent: list[LiveEmoticon] = []
 
-        async def send_live_emoticon(self, emoticon):
+        async def send_live_emoticon(self, emoticon: LiveEmoticon) -> None:
             self.sent.append(emoticon)
-            return None
 
     async def run_test():
         controller = Controller()
         widget = danmaku_widget.DanmakuWidget.__new__(danmaku_widget.DanmakuWidget)
-        widget.hud_controller = controller
+        monkeypatch.setattr(danmaku_widget.DanmakuWidget, "hud_controller", controller, raising=False)
         emoticon = LiveEmoticon(
             emoji="啊",
             url="https://i0.hdslb.com/bfs/live/a.png",

--- a/tests/test_danmaku_widget.py
+++ b/tests/test_danmaku_widget.py
@@ -2,15 +2,17 @@ import asyncio
 import os
 from dataclasses import replace
 
-from PyQt6.QtCore import QEvent
+from PyQt6.QtCore import QEvent, QObject, Qt
 from PyQt6.QtGui import QFont
-from PyQt6.QtWidgets import QApplication, QLabel
+from PyQt6.QtNetwork import QNetworkReply
+from PyQt6.QtWidgets import QApplication, QLabel, QListWidgetItem, QToolButton
 
 from bilihud.app.menu import MenuCommand, TrayMenuState
 from bilihud.app.services import create_default_services
 from bilihud.danmaku.messages import (
     DanmakuMessage,
     GiftMessage,
+    HudMessage,
     InteractionKind,
     InteractMessage,
     MessageAuthor,
@@ -22,6 +24,7 @@ from bilihud.danmaku.messages import (
 )
 from bilihud.danmaku.mock import MOCK_CASTLE_GIFT_ID, MockGiftEffectId
 from bilihud.live.emoticons import LiveEmoticon, LiveEmoticonPackage
+from bilihud.mirror.state import MirrorEntry
 from bilihud.platform.layer_shell import LayerShellAnchorDragStrategy
 from bilihud.platform.overlay_contracts import (
     DragMode,
@@ -49,8 +52,14 @@ def _app():
 
 def test_layer_shell_drag_updates_anchor_position():
     class FakeHost:
+        def apply_window_policy(self, policy) -> None:
+            del policy
+
         def native_window_pointer(self) -> int:
             return 123
+
+        def native_window_id(self) -> int | None:
+            return None
 
         def window_position(self) -> WindowPoint:
             return WindowPoint(100, 100)
@@ -61,12 +70,49 @@ def test_layer_shell_drag_updates_anchor_position():
         def screen_geometry(self) -> WindowRectangle:
             return WindowRectangle(x=0, y=0, width=1920, height=1080)
 
+        def full_screen_overlay(self) -> bool:
+            return False
+
+        def set_geometry(self, geometry: WindowRectangle) -> None:
+            del geometry
+
+        def move_window(self, position: WindowPoint) -> None:
+            del position
+
+        def show_window(self) -> None:
+            pass
+
+        def hide_window(self) -> None:
+            pass
+
+        def raise_window(self) -> None:
+            pass
+
+        def activate_window(self) -> None:
+            pass
+
+        def start_system_move(self) -> bool:
+            return False
+
+        def refresh(self) -> None:
+            pass
+
     class FakeLayerShell:
         def __init__(self) -> None:
             self.calls: list[tuple[int, int, int]] = []
 
-        def set_anchor_position(self, pointer: int, x: int, y: int) -> None:
-            self.calls.append((pointer, x, y))
+        def set_anchor_position(self, window_pointer: int, x: int, y: int) -> None:
+            self.calls.append((window_pointer, x, y))
+
+        def make_overlay(self, window_pointer: int, *, full_screen: bool = False) -> bool:
+            del window_pointer, full_screen
+            return True
+
+        def set_passthrough(self, window_pointer: int, enabled: bool) -> None:
+            del window_pointer, enabled
+
+        def set_keyboard_interactivity(self, window_pointer: int, enabled: bool) -> None:
+            del window_pointer, enabled
 
     layer_shell = FakeLayerShell()
     strategy = LayerShellAnchorDragStrategy(FakeHost(), layer_shell)
@@ -244,23 +290,19 @@ def test_emoticon_picker_requests_bilibili_headers(monkeypatch):
         def setHeader(self, name, value):
             self.headers[name] = value
 
-    class Signal:
-        def connect(self, _callback):
-            pass
-
-    class Reply:
-        finished = Signal()
+    class Reply(QNetworkReply):
+        def __init__(self, parent: QObject | None = None) -> None:
+            super().__init__(parent)
 
     class NetworkManager:
-        def __init__(self):
-            self.requests = []
+        def __init__(self) -> None:
+            self.requests: list[FakeRequest] = []
 
-        def get(self, request):
+        def get(self, request: object) -> QNetworkReply:
+            if not isinstance(request, FakeRequest):
+                raise AssertionError("the test request adapter was not installed")
             self.requests.append(request)
             return Reply()
-
-    class Button:
-        pass
 
     _app()
     picker = emoticon_picker.EmoticonPickerPopup()
@@ -268,7 +310,7 @@ def test_emoticon_picker_requests_bilibili_headers(monkeypatch):
     picker._network_manager = manager
     monkeypatch.setattr(emoticon_picker, "QNetworkRequest", FakeRequest)
 
-    picker._load_icon(Button(), "https://i0.hdslb.com/bfs/live/emote.png")
+    picker._load_icon(QToolButton(), "https://i0.hdslb.com/bfs/live/emote.png")
 
     request = manager.requests[0]
     assert request.raw_headers == {b"Referer": b"https://live.bilibili.com/"}
@@ -383,55 +425,75 @@ def test_danmaku_delegate_does_not_reuse_document_for_reused_message_id(monkeypa
 
 
 def test_danmaku_widget_prunes_history_before_scrolling_to_bottom():
-    class RemovedItem:
-        def data(self, _role):
-            return DanmakuMessage(
-                author=MessageAuthor(uid=1, name="Locez", color="#66CCFF"),
-                segments=(TextSegment("旧弹幕"),),
-            )
-
     class FakeDelegate:
-        def forget_message(self, _message):
+        def set_font_family(self, font_family: str) -> None:
+            del font_family
+
+        def forget_message(self, message: HudMessage) -> None:
+            del message
             calls.append("forget")
 
     class FakeList:
         def __init__(self):
             self._count = 200
 
-        def addItem(self, _item):
+        def addItem(self, item: QListWidgetItem | None) -> None:
+            del item
             calls.append("add")
             self._count += 1
 
         def count(self):
             return self._count
 
-        def takeItem(self, _row):
+        def takeItem(self, row) -> QListWidgetItem | None:
+            del row
             calls.append("take")
             self._count -= 1
-            return RemovedItem()
+            item = QListWidgetItem()
+            item.setData(
+                Qt.ItemDataRole.UserRole,
+                DanmakuMessage(
+                    author=MessageAuthor(uid=1, name="Locez", color="#66CCFF"),
+                    segments=(TextSegment("旧弹幕"),),
+                ),
+            )
+            return item
 
         def scrollToBottom(self):
             calls.append("scroll")
 
+        def scheduleDelayedItemsLayout(self) -> None:
+            pass
+
     class MirrorCoordinator:
-        def publish_message(self, message):
+        def publish_message(self, message: HudMessage) -> MirrorEntry:
             calls.append(("mirror-add", message))
-            return {"seq": 1}
+            return {
+                "seq": 1,
+                "kind": "danmaku",
+                "user": "",
+                "userColor": "",
+                "segments": [],
+            }
 
     calls = []
     class Widget:
-        pass
+        danmaku_list: danmaku_widget.DanmakuListPort
+        _danmaku_delegate: danmaku_widget.DanmakuDelegatePort
+        mirror_coordinator: danmaku_widget.DanmakuMessagePublisher
+
+        def __init__(self) -> None:
+            self.danmaku_list = FakeList()
+            self._danmaku_delegate = FakeDelegate()
+            self.mirror_coordinator = MirrorCoordinator()
 
     widget = Widget()
-    widget.danmaku_list = FakeList()
-    widget._danmaku_delegate = FakeDelegate()
-    widget.mirror_coordinator = MirrorCoordinator()
     message = DanmakuMessage(
         author=MessageAuthor(uid=1, name="Locez", color="#66CCFF"),
         segments=(TextSegment("新弹幕"),),
     )
 
-    danmaku_widget.DanmakuWidget.add_message(widget, message)
+    danmaku_widget.append_hud_message(widget, message)
 
     assert calls.index("take") < calls.index("scroll")
     assert calls.index("scroll") < calls.index(("mirror-add", message))

--- a/tests/test_gift_effect_window.py
+++ b/tests/test_gift_effect_window.py
@@ -11,6 +11,8 @@ from bilihud.platform.overlay_contracts import (
     DragStartResult,
     OverlayCapabilities,
     OverlayOperationResult,
+    OverlayPlatform,
+    WindowHost,
     WindowPoint,
 )
 from bilihud.ui.hud.gift_effect import GiftEffectWindow, compose_gift_video_frame
@@ -18,9 +20,9 @@ from bilihud.ui.hud.gift_effect import GiftEffectWindow, compose_gift_video_fram
 
 def _app() -> QApplication:
     app = QApplication.instance()
-    if app is None:
-        app = QApplication([])
-    return app
+    if isinstance(app, QApplication):
+        return app
+    return QApplication([])
 
 
 def test_compose_gift_video_frame_uses_the_packed_alpha_region() -> None:
@@ -73,14 +75,16 @@ class FakePlatform:
         self.mode_calls.append(enabled)
         return OverlayOperationResult.success()
 
-    def begin_drag(self, _local_position: WindowPoint, _global_position: WindowPoint) -> DragStartResult:
+    def begin_drag(self, local_position: WindowPoint, global_position: WindowPoint) -> DragStartResult:
+        del local_position, global_position
         return DragStartResult(DragMode.UNAVAILABLE, "effect surface is click-through")
 
     def update_drag(
         self,
-        _local_position: WindowPoint,
-        _global_position: WindowPoint,
+        local_position: WindowPoint,
+        global_position: WindowPoint,
     ) -> OverlayOperationResult:
+        del local_position, global_position
         return OverlayOperationResult.failure("effect surface is click-through")
 
     def end_drag(self) -> None:
@@ -91,7 +95,11 @@ def test_gift_effect_window_uses_a_full_screen_click_through_surface() -> None:
     app = _app()
     parent = QWidget()
     platform = FakePlatform()
-    window = GiftEffectWindow(parent, platform_factory=lambda _host: platform)
+    def platform_factory(host: WindowHost) -> OverlayPlatform:
+        del host
+        return platform
+
+    window = GiftEffectWindow(parent, platform_factory=platform_factory)
     message = GiftMessage(
         author=MessageAuthor(uid=1, name="送礼用户", color="#FFD700"),
         segments=(TextSegment("赠送 辣条 x2"),),

--- a/tests/test_mirror_controller.py
+++ b/tests/test_mirror_controller.py
@@ -1,14 +1,24 @@
 import asyncio
+from collections.abc import Coroutine
+from typing import Any
 
 import pytest
 
-from bilihud.app.mirror_coordinator import MirrorCoordinatorState, MirrorOperationResult
-from bilihud.ui.hud.mirror_controller import MirrorController
+from bilihud.app.mirror_coordinator import (
+    MirrorCoordinatorState,
+    MirrorOperationResult,
+)
+from bilihud.config.store import AppConfig
+from bilihud.danmaku.messages import HudMessage, SystemMessageLevel
+from bilihud.mirror.state import MirrorDisplaySettings, MirrorEntry
+from bilihud.ui.hud.mirror_controller import (
+    MirrorController,
+)
 
 
 class FakeCoordinator:
     def __init__(self) -> None:
-        self.state = MirrorCoordinatorState(
+        self._state = MirrorCoordinatorState(
             enabled=True,
             running=True,
             port=2233,
@@ -16,6 +26,42 @@ class FakeCoordinator:
         )
         self.shutdown_calls = 0
         self.failures = 0
+
+    @property
+    def state(self) -> MirrorCoordinatorState:
+        return self._state
+
+    @state.setter
+    def state(self, value: MirrorCoordinatorState) -> None:
+        self._state = value
+
+    def apply_config(self, config: AppConfig) -> None:
+        del config
+
+    def apply_display_settings(self, settings: MirrorDisplaySettings) -> None:
+        del settings
+
+    async def start(self) -> MirrorOperationResult:
+        return MirrorOperationResult(self.state)
+
+    async def set_enabled(self, enabled: bool) -> MirrorOperationResult:
+        self.state = MirrorCoordinatorState(
+            enabled=enabled,
+            running=enabled,
+            port=self.state.port,
+            url=self.state.url,
+        )
+        return MirrorOperationResult(self.state)
+
+    def publish_message(self, message: HudMessage) -> MirrorEntry:
+        del message
+        return {
+            "seq": 1,
+            "kind": "danmaku",
+            "user": "",
+            "userColor": "",
+            "segments": [],
+        }
 
     async def shutdown(self) -> MirrorOperationResult:
         self.shutdown_calls += 1
@@ -42,11 +88,12 @@ class FakeSettingsController:
 class FakeView:
     def __init__(self, coordinator: FakeCoordinator) -> None:
         self.mirror_coordinator = coordinator
-        self.settings_controller = FakeSettingsController()
-        self.messages: list[tuple[str, object]] = []
+        self.settings_controller_fake = FakeSettingsController()
+        self.settings_controller = self.settings_controller_fake
+        self.messages: list[tuple[str, SystemMessageLevel]] = []
         self.tray_refreshes = 0
 
-    def add_system_message(self, message: str, level: object) -> None:
+    def add_system_message(self, message: str, level: SystemMessageLevel) -> None:
         self.messages.append((message, level))
 
     def update_tray_menu_state(self) -> None:
@@ -54,7 +101,7 @@ class FakeView:
 
 
 def _controller(view: FakeView) -> MirrorController:
-    def task_factory(coroutine, name: str):
+    def task_factory(coroutine: Coroutine[Any, Any, None], name: str) -> asyncio.Task[None]:
         return asyncio.create_task(coroutine, name=name)
 
     return MirrorController(
@@ -75,7 +122,7 @@ def test_mirror_shutdown_preserves_enabled_preference_and_refreshes_settings() -
         assert result.state.running is False
         assert result.state.enabled is True
         assert coordinator.shutdown_calls == 1
-        assert view.settings_controller.refresh_calls == 1
+        assert view.settings_controller_fake.refresh_calls == 1
 
     asyncio.run(run_test())
 

--- a/tests/test_qr_login_dialog.py
+++ b/tests/test_qr_login_dialog.py
@@ -1,10 +1,13 @@
 import asyncio
 import os
+from collections.abc import Mapping
+from io import BytesIO
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 from PyQt6.QtWidgets import QApplication, QToolButton
 
+from bilihud.auth.service import AuthCookies
 from bilihud.config.store import ThemeMode
 from bilihud.ui.appearance import resolve_appearance
 from bilihud.ui.auth.qr_login import QRLoginDialog, _qr_status_presentation
@@ -20,7 +23,20 @@ def test_qr_login_dialog_uses_unified_settings_visual_language() -> None:
     assert app is not None
 
     class FakeAuthService:
-        pass
+        async def get_qrcode(self) -> tuple[str | None, str | None]:
+            raise AssertionError("QR login is not started in this test")
+
+        def generate_qr_image(self, url: str) -> BytesIO | None:
+            del url
+            raise AssertionError("QR login is not started in this test")
+
+        async def poll_status(self, qrcode_key: str) -> tuple[int, str, AuthCookies | None]:
+            del qrcode_key
+            raise AssertionError("QR login is not started in this test")
+
+        def save_cookies(self, cookies: Mapping[str, str]) -> bool:
+            del cookies
+            raise AssertionError("QR login is not started in this test")
 
     dialog = QRLoginDialog(
         auth_service=FakeAuthService(),

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -4,8 +4,16 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 from PyQt6.QtCore import QEvent, QPoint, QPointF, Qt
 from PyQt6.QtGui import QMouseEvent, QWheelEvent
-from PyQt6.QtTest import QTest
-from PyQt6.QtWidgets import QApplication, QCheckBox, QDialog, QLabel, QLineEdit, QPushButton, QToolButton, QWidget
+from PyQt6.QtWidgets import (
+    QApplication,
+    QCheckBox,
+    QDialog,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QToolButton,
+    QWidget,
+)
 
 from bilihud.app.menu import AccountStatus
 from bilihud.app_metadata import GITHUB_URL, application_version
@@ -25,7 +33,11 @@ _QT_APP: QApplication | None = None
 
 def _app() -> QApplication:
     global _QT_APP
-    _QT_APP = QApplication.instance() or QApplication([])
+    instance = QApplication.instance()
+    if isinstance(instance, QApplication):
+        _QT_APP = instance
+    else:
+        _QT_APP = QApplication([])
     return _QT_APP
 
 
@@ -33,7 +45,12 @@ def test_settings_dialog_exposes_sidebar_pages_and_theme_choices() -> None:
     _app()
     dialog = SettingsDialog(None, AppConfig(theme=ThemeMode.DARK, window_opacity=65))
 
-    assert [dialog.navigation.item(index).text() for index in range(dialog.navigation.count())] == [
+    labels: list[str] = []
+    for index in range(dialog.navigation.count()):
+        item = dialog.navigation.item(index)
+        assert item is not None
+        labels.append(item.text())
+    assert labels == [
         "通用",
         "面板",
         "直播",
@@ -71,7 +88,9 @@ def test_settings_dialog_exposes_sidebar_pages_and_theme_choices() -> None:
 
     dialog.select_page(SettingsPage.DEVELOPER)
     assert dialog.navigation.currentRow() == 6
-    assert dialog.simulation_button.text() == "弹幕模拟"
+    simulation_button = dialog.simulation_button
+    assert simulation_button is not None
+    assert simulation_button.text() == "弹幕模拟"
     assert dialog.gift_effect_combo is not None
     assert [
         dialog.gift_effect_combo.itemText(index)
@@ -236,12 +255,7 @@ def test_settings_dialog_header_moves_frameless_window() -> None:
     assert dialog.eventFilter(drag_region, release) is True
 
     dialog.select_page(SettingsPage.ACCOUNT)
-    first_item = dialog.navigation.item(0)
-    QTest.mouseClick(
-        dialog.navigation.viewport(),
-        Qt.MouseButton.LeftButton,
-        pos=dialog.navigation.visualItemRect(first_item).center(),
-    )
+    dialog.navigation.setCurrentRow(0)
     assert dialog.navigation.currentRow() == 0
     dialog.close()
 
@@ -306,6 +320,7 @@ def test_settings_dialog_resets_scroll_when_switching_to_live_page() -> None:
     dialog.select_page(SettingsPage.LIVE)
     app.processEvents()
     scrollbar = dialog.page_scroll.verticalScrollBar()
+    assert scrollbar is not None
     scrollbar.setValue(scrollbar.maximum())
     assert scrollbar.value() > 0
 


### PR DESCRIPTION
## Summary
- add typed application capability protocols and HTTP contracts
- make test doubles and Qt boundary handling satisfy ty
- run the CI type check with `PYTHONPATH=vendor/blivedm`

## Verification
- `PYTHONPATH=vendor/blivedm .venv/bin/ty check src tests`
- `.venv/bin/ruff check src tests`
- `QT_QPA_PLATFORM=offscreen PYTHONPATH=vendor/blivedm .venv/bin/pytest -q` (265 passed)
- `uv build --sdist --wheel` plus wheel/sdist content validation

## Scope
The vendored `blivedm` implementation is intentionally outside this type-checking scope.

Closes: #31