### PR TITLE
fix(packaging): bundle macOS CA certificates

### DIFF
--- a/packaging/pyinstaller/build.py
+++ b/packaging/pyinstaller/build.py
@@ -132,6 +132,8 @@ def _pyinstaller_arguments(target: _BuildTarget) -> list[str]:
     )
     for package_name in ("bilihud", "blivedm", "PyQt6", "keyring"):
         arguments.extend(("--collect-all", package_name))
+    if target.platform_name == "macos":
+        arguments.extend(("--collect-all", "certifi"))
     arguments.append(str(PYINSTALLER_ENTRY_POINT))
     return arguments
 

--- a/packaging/pyinstaller/entry_point.py
+++ b/packaging/pyinstaller/entry_point.py
@@ -1,6 +1,22 @@
 """PyInstaller entry point for the installed BiliHUD application."""
 
-from bilihud.main import entry_point
+import sys
+
+from bilihud.platform.certificates import configure_macos_ca_bundle
+
+
+def main() -> None:
+    """Configure packaged platform resources before importing the application."""
+    ca_bundle_path: str | None = None
+    if sys.platform == "darwin":
+        import certifi
+
+        ca_bundle_path = certifi.where()
+    configure_macos_ca_bundle(ca_bundle_path=ca_bundle_path)
+    from bilihud.main import entry_point
+
+    entry_point()
+
 
 if __name__ == "__main__":
-    entry_point()
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ license = {text = "MIT"}
 dependencies = [
   "PyQt6",
   "aiohttp",
+  "certifi; sys_platform == 'darwin'",
   "qasync",
   "qrcode",
   "keyring",

--- a/src/bilihud/platform/certificates.py
+++ b/src/bilihud/platform/certificates.py
@@ -1,0 +1,40 @@
+"""Platform-specific certificate trust configuration for packaged runtimes."""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import MutableMapping
+from pathlib import Path
+
+from .system import PlatformKind, platform_kind
+
+
+def configure_macos_ca_bundle(
+    platform_name: str | None = None,
+    *,
+    environment: MutableMapping[str, str] | None = None,
+    ca_bundle_path: str | None = None,
+) -> None:
+    """Provide a bundled CA file when macOS OpenSSL has no usable default.
+
+    The existing ``SSL_CERT_FILE`` setting remains authoritative. On macOS,
+    an unset setting is populated from the supplied bundled CA file so aiohttp
+    can create verified HTTPS connections before application imports.
+    """
+    selected_platform = sys.platform if platform_name is None else platform_name
+    selected_environment = os.environ if environment is None else environment
+    if platform_kind(selected_platform) is not PlatformKind.MACOS:
+        return
+    if "SSL_CERT_FILE" in selected_environment:
+        return
+
+    if ca_bundle_path is None:
+        raise RuntimeError("macOS CA bundle path was not supplied")
+    bundle = Path(ca_bundle_path)
+    if not bundle.is_file():
+        raise RuntimeError(f"macOS CA bundle is unavailable: {bundle}")
+    selected_environment["SSL_CERT_FILE"] = str(bundle)
+
+
+__all__ = ("configure_macos_ca_bundle",)

--- a/tests/platform/test_certificates.py
+++ b/tests/platform/test_certificates.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import pytest
+
+from bilihud.platform.certificates import configure_macos_ca_bundle
+
+
+def test_macos_ca_bundle_is_added_when_no_override_exists(tmp_path: Path) -> None:
+    ca_bundle = tmp_path / "cacert.pem"
+    ca_bundle.write_text("test CA bundle", encoding="ascii")
+    environment: dict[str, str] = {}
+
+    configure_macos_ca_bundle(
+        "darwin",
+        environment=environment,
+        ca_bundle_path=str(ca_bundle),
+    )
+
+    assert environment == {"SSL_CERT_FILE": str(ca_bundle)}
+
+
+def test_existing_ca_override_is_preserved(tmp_path: Path) -> None:
+    ca_bundle = tmp_path / "cacert.pem"
+    ca_bundle.write_text("test CA bundle", encoding="ascii")
+    environment = {"SSL_CERT_FILE": "/custom/ca.pem"}
+
+    configure_macos_ca_bundle(
+        "darwin",
+        environment=environment,
+        ca_bundle_path=str(ca_bundle),
+    )
+
+    assert environment == {"SSL_CERT_FILE": "/custom/ca.pem"}
+
+
+@pytest.mark.parametrize("platform_name", ("linux", "win32"))
+def test_non_macos_platforms_keep_their_environment(platform_name: str, tmp_path: Path) -> None:
+    ca_bundle = tmp_path / "cacert.pem"
+    ca_bundle.write_text("test CA bundle", encoding="ascii")
+    environment: dict[str, str] = {}
+
+    configure_macos_ca_bundle(
+        platform_name,
+        environment=environment,
+        ca_bundle_path=str(ca_bundle),
+    )
+
+    assert environment == {}
+
+
+def test_missing_macos_ca_bundle_fails_explicitly(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="macOS CA bundle is unavailable"):
+        configure_macos_ca_bundle(
+            "darwin",
+            environment={},
+            ca_bundle_path=str(tmp_path / "missing.pem"),
+        )

--- a/tests/test_pyinstaller_configuration.py
+++ b/tests/test_pyinstaller_configuration.py
@@ -1,0 +1,84 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parents[1]
+BUILD_MODULE_PATH = PROJECT_ROOT / "packaging" / "pyinstaller" / "build.py"
+
+
+def _load_build_module() -> ModuleType:
+    """Load the standalone PyInstaller build helper without invoking a build."""
+    spec = importlib.util.spec_from_file_location("bilihud_pyinstaller_build", BUILD_MODULE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load build helper: {BUILD_MODULE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_entry_point_module() -> ModuleType:
+    """Load the PyInstaller entry point without importing the Qt application."""
+    entry_point_path = PROJECT_ROOT / "packaging" / "pyinstaller" / "entry_point.py"
+    spec = importlib.util.spec_from_file_location("bilihud_pyinstaller_entry_point", entry_point_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load entry point: {entry_point_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_pyinstaller_collects_certifi_only_for_macos() -> None:
+    build_module = _load_build_module()
+    macos_target = build_module._BuildTarget("macos", "arm64", False, ".dmg")
+    windows_target = build_module._BuildTarget("windows", "x64", True, ".exe")
+
+    macos_arguments = build_module._pyinstaller_arguments(macos_target)
+    windows_arguments = build_module._pyinstaller_arguments(windows_target)
+
+    assert any(
+        macos_arguments[index : index + 2] == ["--collect-all", "certifi"]
+        for index in range(len(macos_arguments) - 1)
+    )
+    assert "certifi" not in windows_arguments
+
+
+def test_pyinstaller_entry_point_configures_tls_before_application_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entry_point_module = _load_entry_point_module()
+    events: list[tuple[str, str | None]] = []
+
+    class FakeCertifiModule(ModuleType):
+        """Expose the certifi API used by the packaging entry point."""
+
+        def __init__(self) -> None:
+            super().__init__("certifi")
+
+        def where(self) -> str:
+            return "/bundle/cacert.pem"
+
+    class FakeApplicationModule(ModuleType):
+        """Record when the application entry point is invoked."""
+
+        def __init__(self) -> None:
+            super().__init__("bilihud.main")
+
+        def entry_point(self) -> None:
+            events.append(("application", None))
+
+    def record_configuration(*, ca_bundle_path: str | None) -> None:
+        events.append(("configure", ca_bundle_path))
+
+    monkeypatch.setattr(entry_point_module.sys, "platform", "darwin")
+    monkeypatch.setattr(entry_point_module, "configure_macos_ca_bundle", record_configuration)
+    monkeypatch.setitem(sys.modules, "certifi", FakeCertifiModule())
+    monkeypatch.setitem(sys.modules, "bilihud.main", FakeApplicationModule())
+
+    entry_point_module.main()
+
+    assert events == [("configure", "/bundle/cacert.pem"), ("application", None)]

--- a/uv.lock
+++ b/uv.lock
@@ -129,6 +129,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "brotli" },
+    { name = "certifi", marker = "sys_platform == 'darwin'" },
     { name = "keyring" },
     { name = "pillow" },
     { name = "pure-protobuf" },
@@ -150,6 +151,7 @@ test = [
 requires-dist = [
     { name = "aiohttp" },
     { name = "brotli" },
+    { name = "certifi", marker = "sys_platform == 'darwin'" },
     { name = "coverage", marker = "extra == 'test'" },
     { name = "ipdb", marker = "extra == 'test'" },
     { name = "keyring" },
@@ -190,6 +192,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/73/3183c9e41ca755713bdf2cc1d0810df742c09484e2e1ddd693bee53877c1/brotli-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d2d085ded05278d1c7f65560aae97b3160aeb2ea2c0b3e26204856beccb60888", size = 1488164, upload-time = "2025-11-05T18:38:53.079Z" },
     { url = "https://files.pythonhosted.org/packages/64/6a/0c78d8f3a582859236482fd9fa86a65a60328a00983006bcf6d83b7b2253/brotli-1.2.0-cp314-cp314-win32.whl", hash = "sha256:832c115a020e463c2f67664560449a7bea26b0c1fdd690352addad6d0a08714d", size = 339280, upload-time = "2025-11-05T18:38:54.02Z" },
     { url = "https://files.pythonhosted.org/packages/f5/10/56978295c14794b2c12007b07f3e41ba26acda9257457d7085b0bb3bb90c/brotli-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e7c0af964e0b4e3412a0ebf341ea26ec767fa0b4cf81abb5e897c9338b5ad6a3", size = 375639, upload-time = "2025-11-05T18:38:55.67Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add a Darwin-only certifi dependency and bundle it in macOS PyInstaller builds
- configure SSL_CERT_FILE before importing aiohttp-based application modules
- preserve an existing SSL_CERT_FILE and leave Linux and Windows behavior unchanged

## Verification

- .venv/bin/python -m pytest -q: 272 passed
- uv lock --check
- ruff check src tests packaging/pyinstaller
- ty check src tests
- uv build
- git diff --check

The macOS packaging path is fixed at the entrypoint boundary because aiohttp creates default SSL contexts in application code. The macOS release workflow should validate the packaged app on its arm64 runner.

Closes #56