### PR TITLE
fix(live): use account room and persist OBS credentials

### DIFF
--- a/src/bilihud/app/live_control_api.py
+++ b/src/bilihud/app/live_control_api.py
@@ -32,6 +32,10 @@ class LiveControlApi(Protocol):
         """Close the current session and release its network resources."""
         ...
 
+    async def get_anchor_live_room_id(self) -> int:
+        """Load the live-room identifier owned by the authenticated account."""
+        ...
+
     async def load_area_groups(self) -> tuple[LiveAreaGroup, ...]:
         """Load normalized live parent areas and sub-areas."""
         ...

--- a/src/bilihud/app/live_control_service.py
+++ b/src/bilihud/app/live_control_service.py
@@ -62,8 +62,8 @@ class LiveControlServicePort(Protocol):
         """Generate a verification QR image."""
         ...
 
-    async def initialize(self, room_id: int | None) -> LiveControlOperationResult:
-        """Initialize the authenticated live session."""
+    async def initialize(self) -> LiveControlOperationResult:
+        """Initialize the authenticated session and load the account-owned room."""
         ...
 
     async def load_room_info(self, room_id: int | None) -> LiveControlOperationResult:
@@ -130,6 +130,7 @@ class LiveControlService:
         self._obs_password_store: ObsPasswordStore = obs_password_store
         self._qr_image_generator: QrImageGenerator = qr_image_generator
         self._state = LiveControlState()
+        self._anchor_room_id: int | None = None  # Authenticated account-owned room used by every live operation.
         self._generation = 0
         self._operation_gate = asyncio.Lock()
         self._active_operation: str | None = None
@@ -193,8 +194,8 @@ class LiveControlService:
         """Generate verification QR bytes through the injected image generator."""
         return self._qr_image_generator.generate_qr_image(url)
 
-    async def initialize(self, room_id: int | None) -> LiveControlOperationResult:
-        """Open the session, load areas, and optionally load the selected room."""
+    async def initialize(self) -> LiveControlOperationResult:
+        """Open the session, load areas, and resolve the authenticated account's room."""
         operation_error = await self._claim_operation("initialize")
         if operation_error is not None:
             return LiveControlOperationResult(self._state, operation_error)
@@ -204,6 +205,7 @@ class LiveControlService:
             session_info = await self._api.open_session()
             if not self._is_current(generation):
                 return LiveControlOperationResult(self._state)
+            self._anchor_room_id = None
             self._state = replace(
                 self._state,
                 session=session_info,
@@ -214,18 +216,22 @@ class LiveControlService:
                 obs_streaming=None,
             )
 
+            if session_info.status is SessionStatus.AUTHENTICATED:
+                anchor_room_id = await self._api.get_anchor_live_room_id()
+                if not validate_room_id(anchor_room_id):
+                    return LiveControlOperationResult(
+                        self._state,
+                        LiveControlError(LiveControlErrorCode.INVALID_ROOM, "未能获取当前账号的直播间。"),
+                    )
+                self._anchor_room_id = anchor_room_id
+
             areas = await self._api.load_area_groups()
             if not self._is_current(generation):
                 return LiveControlOperationResult(self._state)
             self._state = replace(self._state, areas=areas)
 
-            if room_id is not None and not validate_room_id(room_id):
-                return LiveControlOperationResult(
-                    self._state,
-                    LiveControlError(LiveControlErrorCode.INVALID_ROOM, "房间号无效。"),
-                )
-            if room_id is not None:
-                result = await self._load_room_info(generation, room_id)
+            if self._anchor_room_id is not None:
+                result = await self._load_room_info(generation, self._anchor_room_id)
                 if result.error is not None:
                     return result
             return LiveControlOperationResult(self._state)
@@ -244,8 +250,11 @@ class LiveControlService:
 
         generation = self._begin_generation()
         try:
-            if room_id is None or not validate_room_id(room_id):
+            validation_error = self._validate_authenticated_room(room_id)
+            if validation_error is not None:
                 self._state = replace(self._state, room_info=None, credentials=())
+                return LiveControlOperationResult(self._state, validation_error)
+            if room_id is None:
                 return LiveControlOperationResult(
                     self._state,
                     LiveControlError(LiveControlErrorCode.INVALID_ROOM, "房间号无效。"),
@@ -670,6 +679,7 @@ class LiveControlService:
                     obs_connected=False,
                     obs_streaming=None,
                 )
+                self._anchor_room_id = None
             finally:
                 self._closing = False
                 self._close_finished.set()
@@ -781,6 +791,10 @@ class LiveControlService:
         if area_id is not None and not area_id.strip():
             return LiveControlError(LiveControlErrorCode.INVALID_INPUT, "直播分区不能为空。")
         if self._state.session.status is SessionStatus.AUTHENTICATED:
+            if self._anchor_room_id is None:
+                return LiveControlError(LiveControlErrorCode.INVALID_ROOM, "未能获取当前账号的直播间。")
+            if room_id != self._anchor_room_id:
+                return LiveControlError(LiveControlErrorCode.INVALID_ROOM, "只能控制登录账号的直播间。")
             return None
         code = (
             LiveControlErrorCode.LOGIN_EXPIRED

--- a/src/bilihud/live/adapters.py
+++ b/src/bilihud/live/adapters.py
@@ -24,6 +24,7 @@ from .api import (
     update_room_area,
     update_room_title,
 )
+from .api import get_anchor_live_room_id as _get_anchor_live_room_id
 from .models import (
     LiveArea,
     LiveAreaGroup,
@@ -67,6 +68,10 @@ class BilibiliLiveControlApi:
         self._session = None
         if session is not None and not session.closed:
             await session.close()
+
+    async def get_anchor_live_room_id(self) -> int:
+        """Load the room owned by the authenticated account."""
+        return await self._request(_get_anchor_live_room_id(self._require_session()))
 
     async def load_area_groups(self) -> tuple[LiveAreaGroup, ...]:
         """Load and normalize the raw Bilibili area response at the boundary."""

--- a/src/bilihud/ui/settings/pages/live/page.py
+++ b/src/bilihud/ui/settings/pages/live/page.py
@@ -103,6 +103,7 @@ class LiveSettingsPage(QWidget):
         room_row.setContentsMargins(0, 0, 0, 0)
         self.room_id_input = QLineEdit(room_card)
         self.room_id_input.setPlaceholderText("直播间 ID")
+        self.room_id_input.setReadOnly(True)
         self.room_id_input.textChanged.connect(self.update_action_state)
         self.room_id_input.editingFinished.connect(self.reload_room_info)
         room_row.addWidget(self.room_id_input, 1)
@@ -220,7 +221,7 @@ class LiveSettingsPage(QWidget):
             self.set_status("直播服务尚未连接。", error=True)
             return
         settings = service.load_settings()
-        self.room_id_input.setText(str(settings.room_id) if settings.room_id is not None else "")
+        self.room_id_input.clear()
         self.title_input.setText(settings.live_title)
         self.obs_host_input.setText(settings.obs_host)
         self.obs_port_input.setText(str(settings.obs_port))
@@ -260,6 +261,7 @@ class LiveSettingsPage(QWidget):
             self._select_area(state.room_info.parent_area_id, state.room_info.area_id)
         else:
             self._is_live = False
+            self.room_id_input.clear()
         if previous_live != self._is_live:
             self.live_status_changed.emit(self._is_live)
         self.credentials_panel.set_credentials(state.credentials)

--- a/src/bilihud/ui/settings/pages/live/workflow.py
+++ b/src/bilihud/ui/settings/pages/live/workflow.py
@@ -56,8 +56,8 @@ class LiveSettingsService(Protocol):
         """Return the latest immutable service snapshot."""
         ...
 
-    async def initialize(self, room_id: int | None) -> LiveControlOperationResult:
-        """Initialize the authenticated live session and load areas."""
+    async def initialize(self) -> LiveControlOperationResult:
+        """Initialize the authenticated session and load the account-owned room."""
         ...
 
     async def load_room_info(self, room_id: int | None) -> LiveControlOperationResult:
@@ -273,7 +273,7 @@ class LiveSettingsWorkflow:
             return
         self._view.set_busy(True, "正在加载登录状态和直播分区...")
         try:
-            result = await service.initialize(self._view.form_values().room_id)
+            result = await service.initialize()
             if generation != self._load_generation:
                 return
             self._view.apply_service_state(result.state)
@@ -529,7 +529,10 @@ class LiveSettingsWorkflow:
             self._view.apply_service_state(service.state)
             self._view.set_obs_status(outcome)
             if outcome.connected:
-                self._view.set_status("OBS 已启动并且 WebSocket 可连接。", success=True)
+                if self._view.save_form_config():
+                    self._view.set_status("OBS 已启动并且 WebSocket 可连接。", success=True)
+                else:
+                    self._view.set_status("OBS 已启动并且 WebSocket 可连接，但设置保存失败。", error=True)
             elif outcome.launched:
                 self._view.set_status("已启动 OBS，请等待加载完成后重新检查。", success=True)
             elif outcome.error is not None:

--- a/tests/app/test_application_controller.py
+++ b/tests/app/test_application_controller.py
@@ -48,7 +48,7 @@ class FakeLiveControlService:
     def generate_qr_image(self, _url: str) -> BytesIO | None:
         raise AssertionError("live QR is not used in this shutdown test")
 
-    async def initialize(self, _room_id: int | None) -> LiveControlOperationResult:
+    async def initialize(self) -> LiveControlOperationResult:
         raise AssertionError("live initialization is not used in this shutdown test")
 
     async def load_room_info(self, _room_id: int | None) -> LiveControlOperationResult:

--- a/tests/app/test_live_control_service.py
+++ b/tests/app/test_live_control_service.py
@@ -9,6 +9,7 @@ from bilihud.live.models import (
     LiveArea,
     LiveAreaGroup,
     LiveControlErrorCode,
+    LiveControlSettings,
     LiveSessionInfo,
     LiveStartResponse,
     LiveVerificationKind,
@@ -27,12 +28,16 @@ class FakeLiveApi:
         *,
         session: LiveSessionInfo | None = None,
         room_info: RoomInfo | None = None,
+        anchor_room_id: int = 7450109,
         start_response: LiveStartResponse | None = None,
     ) -> None:
         self.session = session if session is not None else LiveSessionInfo(SessionStatus.AUTHENTICATED)
-        self.room_info = room_info if room_info is not None else RoomInfo(7450109, "旧标题", "9", "371")
+        self.anchor_room_id = anchor_room_id
+        self.room_info = room_info if room_info is not None else RoomInfo(anchor_room_id, "旧标题", "9", "371")
         self.start_response = start_response if start_response is not None else LiveStartResponse(0, "ok")
         self.start_calls = 0
+        self.anchor_room_calls = 0
+        self.room_info_calls: list[int] = []
         self.updated_titles: list[str] = []
         self.updated_areas: list[str] = []
         self.version_started: asyncio.Event | None = None
@@ -45,10 +50,15 @@ class FakeLiveApi:
     async def close_session(self) -> None:
         self.closed = True
 
+    async def get_anchor_live_room_id(self) -> int:
+        self.anchor_room_calls += 1
+        return self.anchor_room_id
+
     async def load_area_groups(self) -> tuple[LiveAreaGroup, ...]:
         return (LiveAreaGroup("9", "游戏", (LiveArea("371", "主机游戏"),)),)
 
     async def get_room_info(self, room_id: int) -> RoomInfo:
+        self.room_info_calls.append(room_id)
         return self.room_info
 
     async def update_room_title(self, room_id: int, title: str) -> None:
@@ -104,8 +114,8 @@ class FakeObs:
 
 
 class FakeConfigStore:
-    def __init__(self) -> None:
-        self.config = AppConfig()
+    def __init__(self, config: AppConfig | None = None) -> None:
+        self.config = config if config is not None else AppConfig()
 
     def load(self) -> AppConfig:
         return self.config
@@ -135,11 +145,16 @@ class FakeQrImageGenerator:
         return None
 
 
-def make_service(api: FakeLiveApi, obs: FakeObs) -> LiveControlService:
+def make_service(
+    api: FakeLiveApi,
+    obs: FakeObs,
+    *,
+    config: AppConfig | None = None,
+) -> LiveControlService:
     return LiveControlService(
         api=api,
         obs=obs,
-        config_store=FakeConfigStore(),
+        config_store=FakeConfigStore(config),
         obs_password_store=FakeObsPasswordStore(),
         qr_image_generator=FakeQrImageGenerator(),
     )
@@ -149,6 +164,68 @@ def run(coroutine: Coroutine[Any, Any, object]) -> object:
     return asyncio.run(coroutine)
 
 
+def test_initialize_uses_the_authenticated_account_room_instead_of_the_configured_room() -> None:
+    api = FakeLiveApi(
+        anchor_room_id=778899,
+        room_info=RoomInfo(778899, "主播房间", "9", "371"),
+    )
+    service = make_service(api, FakeObs(), config=AppConfig(room_id=7450109))
+
+    async def scenario() -> None:
+        result = await service.initialize()
+
+        assert result.success
+        assert result.state.room_info is not None
+        assert result.state.room_info.room_id == 778899
+
+    run(scenario())
+    assert api.anchor_room_calls == 1
+    assert api.room_info_calls == [778899]
+
+
+def test_live_operations_reject_a_room_not_owned_by_the_authenticated_account() -> None:
+    api = FakeLiveApi(anchor_room_id=778899, room_info=RoomInfo(778899, "主播房间", "9", "371"))
+    service = make_service(api, FakeObs())
+
+    async def scenario() -> None:
+        await service.initialize()
+        outcome = await service.start_live(7450109, "标题", "371", None)
+
+        assert outcome.error is not None
+        assert outcome.error.code is LiveControlErrorCode.INVALID_ROOM
+        assert outcome.error.message == "只能控制登录账号的直播间。"
+
+    run(scenario())
+    assert api.start_calls == 0
+    assert api.updated_titles == []
+
+
+def test_save_settings_persists_the_obs_password_through_the_secure_store() -> None:
+    password_store = FakeObsPasswordStore()
+    service = LiveControlService(
+        api=FakeLiveApi(),
+        obs=FakeObs(),
+        config_store=FakeConfigStore(),
+        obs_password_store=password_store,
+        qr_image_generator=FakeQrImageGenerator(),
+    )
+
+    outcome = service.save_settings(
+        LiveControlSettings(
+            room_id=7450109,
+            live_title="标题",
+            live_parent_area_id="9",
+            live_area_id="371",
+            obs_host="127.0.0.1",
+            obs_port=4455,
+            obs_password="secret",
+        )
+    )
+
+    assert outcome.success
+    assert password_store.password == "secret"
+
+
 def test_start_live_syncs_room_starts_obs_and_returns_credentials_without_qt() -> None:
     credential = StreamCredential("rtmp-1", "rtmp://server", "key")
     api = FakeLiveApi(start_response=LiveStartResponse(0, "ok", (credential,)))
@@ -156,7 +233,7 @@ def test_start_live_syncs_room_starts_obs_and_returns_credentials_without_qt() -
     service = make_service(api, obs)
 
     async def scenario() -> None:
-        await service.initialize(7450109)
+        await service.initialize()
         outcome = await service.start_live(
             7450109,
             "新标题",
@@ -182,7 +259,7 @@ def test_start_live_reports_missing_credentials_after_bilibili_accepts_request()
     service = make_service(api, FakeObs())
 
     async def scenario() -> None:
-        await service.initialize(7450109)
+        await service.initialize()
         outcome = await service.start_live(7450109, "标题", "371", None)
 
         assert outcome.status is StartLiveStatus.STARTED_WITHOUT_CREDENTIALS
@@ -199,7 +276,7 @@ def test_start_live_routes_face_auth_response_to_verification_outcome() -> None:
     service = make_service(api, FakeObs())
 
     async def scenario() -> None:
-        await service.initialize(7450109)
+        await service.initialize()
         outcome = await service.start_live(7450109, "标题", "371", None)
 
         assert outcome.status is StartLiveStatus.VERIFICATION_REQUIRED
@@ -218,7 +295,7 @@ def test_expired_saved_login_blocks_start_before_api_mutation() -> None:
     service = make_service(api, FakeObs())
 
     async def scenario() -> None:
-        await service.initialize(7450109)
+        await service.initialize()
         outcome = await service.start_live(7450109, "标题", "371", None)
 
         assert outcome.error is not None
@@ -235,7 +312,7 @@ def test_duplicate_start_returns_operation_in_progress_without_second_api_call()
     service = make_service(api, FakeObs())
 
     async def scenario() -> None:
-        await service.initialize(7450109)
+        await service.initialize()
         first = asyncio.create_task(service.start_live(7450109, "标题", "371", None))
         assert api.version_started is not None
         await api.version_started.wait()

--- a/tests/test_live_settings_workflow.py
+++ b/tests/test_live_settings_workflow.py
@@ -27,6 +27,7 @@ class FakeLiveService:
         outcomes: list[StartLiveOutcome],
         *,
         stop_outcome: StopLiveOutcome | None = None,
+        check_outcome: ObsCheckOutcome | None = None,
     ) -> None:
         self.state = LiveControlState(
             session=LiveSessionInfo(status=SessionStatus.AUTHENTICATED),
@@ -36,10 +37,10 @@ class FakeLiveService:
             StopLiveStatus.STOPPED,
             self.state,
         )
+        self._check_outcome = check_outcome
         self.start_calls: list[bool] = []
 
-    async def initialize(self, room_id: int | None) -> LiveControlOperationResult:
-        del room_id
+    async def initialize(self) -> LiveControlOperationResult:
         raise AssertionError("not used in this test")
 
     async def load_room_info(self, room_id: int | None) -> LiveControlOperationResult:
@@ -73,7 +74,9 @@ class FakeLiveService:
 
     async def check_obs(self, settings: ObsSettings | None) -> ObsCheckOutcome:
         del settings
-        raise AssertionError("not used in this test")
+        if self._check_outcome is None:
+            raise AssertionError("not used in this test")
+        return self._check_outcome
 
     async def stop_obs_stream(self, settings: ObsSettings | None) -> ObsStreamOutcome:
         del settings
@@ -84,17 +87,25 @@ class FakeLiveService:
 
 
 class FakeLiveView:
-    def __init__(self, *, confirm_switch: bool = True, save_success: bool = True) -> None:
+    def __init__(
+        self,
+        *,
+        confirm_switch: bool = True,
+        save_success: bool = True,
+        obs: ObsSettings | None = None,
+    ) -> None:
         self._confirm_switch = confirm_switch
         self._save_success = save_success
+        self._obs = obs
         self.busy_actions: list[LiveAction | None] = []
         self.statuses: list[tuple[str, bool, bool]] = []
         self.warnings: list[tuple[str, str, str]] = []
         self.verifications: list[tuple[str, LiveVerificationKind]] = []
         self.confirmation_count = 0
+        self.save_calls = 0
 
     def form_values(self) -> LiveSettingsForm:
-        return LiveSettingsForm(7450109, "测试直播", "1", "371", None)
+        return LiveSettingsForm(7450109, "测试直播", "1", "371", self._obs)
 
     def apply_service_state(self, state: LiveControlState) -> None:
         del state
@@ -114,6 +125,7 @@ class FakeLiveView:
         self.statuses.append((message, error, success))
 
     def save_form_config(self) -> bool:
+        self.save_calls += 1
         return self._save_success
 
     def show_verification(self, url: str, kind: LiveVerificationKind) -> None:
@@ -181,6 +193,53 @@ def _run_stop_sync(service: FakeLiveService, view: FakeLiveView) -> None:
     asyncio.run(run())
 
 
+def _run_check_sync(service: FakeLiveService, view: FakeLiveView) -> None:
+    """Run one public OBS check workflow to completion in an isolated supervisor."""
+
+    async def run() -> None:
+        supervisor = TaskSupervisor()
+        scope = supervisor.create_scope("live-settings-test")
+        workflow = LiveSettingsWorkflow(service, scope, view)
+        task = workflow.check_obs()
+        if task is None:
+            raise AssertionError("OBS check workflow was not scheduled")
+        await task
+        await workflow.shutdown()
+        await supervisor.shutdown()
+
+    asyncio.run(run())
+
+
+def test_check_obs_saves_form_credentials_after_a_successful_connection() -> None:
+    service = FakeLiveService(
+        [],
+        check_outcome=ObsCheckOutcome(connected=True, process_running=True),
+    )
+    view = FakeLiveView(obs=ObsSettings("127.0.0.1", 4455, "secret"))
+
+    _run_check_sync(service, view)
+
+    assert view.save_calls == 1
+    assert view.statuses[-1] == ("OBS 已启动并且 WebSocket 可连接。", False, True)
+
+
+def test_check_obs_does_not_save_credentials_when_connection_is_not_confirmed() -> None:
+    service = FakeLiveService(
+        [],
+        check_outcome=ObsCheckOutcome(
+            connected=False,
+            process_running=True,
+            error=LiveControlError(LiveControlErrorCode.OBS_FAILURE, "连接失败"),
+        ),
+    )
+    view = FakeLiveView(obs=ObsSettings("127.0.0.1", 4455, "secret"))
+
+    _run_check_sync(service, view)
+
+    assert view.save_calls == 0
+    assert view.statuses[-1] == ("连接失败", True, False)
+
+
 def test_start_live_connects_hud_to_the_started_room() -> None:
     connected_rooms: list[int] = []
 
@@ -224,6 +283,7 @@ def test_start_live_does_not_report_missing_credentials_as_full_success() -> Non
     _run_start_sync(service, view)
 
     message, error, success = view.statuses[-1]
+    assert view.save_calls == 1
     assert "直播已开始" in message
     assert "设置保存失败" in message
     assert error is True

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -78,6 +78,7 @@ def test_settings_dialog_exposes_sidebar_pages_and_theme_choices() -> None:
         "停止直播",
         "检查 OBS",
     }
+    assert live_page.room_id_input.isReadOnly() is True
 
     dialog.select_page(SettingsPage.MIRROR)
     assert dialog.page_title.text() == "显示与特效"


### PR DESCRIPTION
## Summary

- Resolve live-control operations from the authenticated account's own room and reject non-owned rooms.
- Persist OBS credentials after a successful connection check while retaining the pre-start save path.

## Verification

- `uv run pytest -q` - 277 passed
- `uv run ruff check src tests` - passed
- Targeted `uv run ty check` - passed
- `uv build` - passed
- `git diff --check` - passed

## Known limitation

- Full `ty check src` remains blocked by six pre-existing unresolved `blivedm` imports in the ty environment.