### PR TITLE
fix(window): restore cross-platform window interaction

### DIFF
--- a/src/bilihud/ui/hud/window.py
+++ b/src/bilihud/ui/hud/window.py
@@ -204,7 +204,6 @@ class DanmakuWidget(QWidget):
         config = self.application.config
         self._hud_background_alpha = _opacity_to_alpha(config.window_opacity)
         self.settings_controller = SettingsController(
-            self,
             application=self.application,
             task_scope=self._task_scope.child("settings"),
             on_mirror_toggle=self._schedule_mirror_toggle,

--- a/src/bilihud/ui/settings/controller.py
+++ b/src/bilihud/ui/settings/controller.py
@@ -6,8 +6,6 @@ import asyncio
 from collections.abc import Callable
 from dataclasses import replace
 
-from PyQt6.QtWidgets import QWidget
-
 from bilihud.app.account_controller import AccountState
 from bilihud.app.application_controller import ApplicationController
 from bilihud.app.lifecycle import TaskScope
@@ -23,7 +21,6 @@ class SettingsController:
 
     def __init__(
         self,
-        parent: QWidget,
         *,
         application: ApplicationController,
         task_scope: TaskScope,
@@ -38,7 +35,6 @@ class SettingsController:
         on_live_started: LiveStartedHandler | None = None,
     ) -> None:
         """Create a lazy settings owner with explicit application and UI callbacks."""
-        self._parent = parent
         self._application = application
         self._task_scope = task_scope
         self._on_mirror_toggle = on_mirror_toggle
@@ -104,7 +100,7 @@ class SettingsController:
         if self._dialog is not None:
             return self._dialog
         dialog = SettingsDialog(
-            self._parent,
+            None,
             self._application.config,
             services=self._application.services,
             task_scope=self._task_scope,

--- a/src/bilihud/ui/window_host.py
+++ b/src/bilihud/ui/window_host.py
@@ -20,13 +20,15 @@ class QtWindowHost(WindowHost):
 
     def apply_window_policy(self, policy: WindowPolicy) -> None:
         """Map platform-selected flags and attributes to Qt."""
-        if policy.recreate_surface:
-            self._widget.setWindowFlags(self._base_window_flags(policy))
-
+        # Clear Qt's input-transparent state before rebuilding normal flags. Qt
+        # otherwise keeps WindowTransparentForInput on the recreated surface.
         self._widget.setAttribute(
             Qt.WidgetAttribute.WA_TransparentForMouseEvents,
             policy.mouse_events_transparent,
         )
+        if policy.recreate_surface:
+            self._widget.setWindowFlags(self._base_window_flags(policy))
+
         self._widget.setAttribute(
             Qt.WidgetAttribute.WA_ShowWithoutActivating,
             policy.show_without_activating,

--- a/tests/platform/test_window_platform.py
+++ b/tests/platform/test_window_platform.py
@@ -5,7 +5,8 @@ from collections.abc import Callable
 from pathlib import Path
 
 import pytest
-from PyQt6.QtWidgets import QApplication
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QApplication, QWidget
 
 from bilihud.platform import qt_window_platform, window_platform
 from bilihud.platform.overlay_contracts import (
@@ -15,6 +16,7 @@ from bilihud.platform.overlay_contracts import (
     WindowPolicy,
     WindowRectangle,
 )
+from bilihud.ui.window_host import QtWindowHost
 
 
 def _app() -> QApplication:
@@ -294,6 +296,35 @@ def test_generic_qt_platform_keeps_gaming_mode_on_non_wayland(monkeypatch, platf
         ),
         WindowPolicy(),
     ]
+
+
+def test_generic_qt_platform_restores_mouse_input_after_gaming_mode_toggle() -> None:
+    """Restoring the normal policy must remove Qt's input-transparent window flag."""
+    app = _app()
+    widget = QWidget()
+    host = QtWindowHost(widget)
+    platform = qt_window_platform.QtWindowPlatform(
+        host,
+        gaming_mode_supported=True,
+        gaming_mode_reason=None,
+        bypass_window_manager=False,
+        click_through=None,
+        click_through_supported=True,
+        prefer_system_move=False,
+    )
+
+    try:
+        assert platform.prepare() == OverlayOperationResult.success()
+        assert platform.set_gaming_mode(True) == OverlayOperationResult.success()
+        assert widget.windowFlags() & Qt.WindowType.WindowTransparentForInput
+        assert widget.testAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
+
+        assert platform.set_gaming_mode(False) == OverlayOperationResult.success()
+        assert not widget.windowFlags() & Qt.WindowType.WindowTransparentForInput
+        assert not widget.testAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
+    finally:
+        widget.close()
+        del app
 
 
 def test_non_linux_qt_provider_does_not_attempt_to_load_layer_shell_bridge(monkeypatch) -> None:

--- a/tests/test_danmaku_widget.py
+++ b/tests/test_danmaku_widget.py
@@ -184,6 +184,12 @@ def test_danmaku_widget_keeps_game_mode_controls_in_sync_with_fake_platform(tmp_
         assert widget.gaming_mode_btn.isChecked() is False
         assert widget.tray_gaming_action.isChecked() is False
         assert platform.mode_calls == [True, False]
+
+        widget.open_settings()
+        settings_dialog = widget.settings_controller.dialog
+        assert settings_dialog is not None
+        assert settings_dialog.parentWidget() is None
+        assert not settings_dialog.windowFlags() & Qt.WindowType.WindowStaysOnTopHint
     finally:
         asyncio.run(widget.shutdown())
 


### PR DESCRIPTION
## Summary

- Clear Qt's input-transparent state before rebuilding normal window flags so drag events return after gaming mode is unlocked.
- Keep the settings dialog independent from the HUD's always-on-top native owner.
- Add regression coverage for both behaviors.

## Verification

- QT_QPA_PLATFORM=offscreen uv run pytest -q: 278 passed
- uv run ruff check src tests: passed
- uv run ty check src/bilihud/ui/window_host.py: passed
- git diff --check: passed
- Full uv run ty check src is blocked by the existing environment's unresolved blivedm imports.