### PR TITLE
fix(settings): refine control spacing and copy action

### DIFF
--- a/src/bilihud/ui/settings/pages/account.py
+++ b/src/bilihud/ui/settings/pages/account.py
@@ -2,13 +2,44 @@
 
 from __future__ import annotations
 
-from PyQt6.QtCore import QRectF, Qt, QUrl, pyqtSignal
-from PyQt6.QtGui import QDesktopServices, QImage, QPainter, QPainterPath, QPixmap
+from PyQt6.QtCore import QRectF, QSize, Qt, QUrl, pyqtSignal
+from PyQt6.QtGui import (
+    QClipboard,
+    QDesktopServices,
+    QGuiApplication,
+    QImage,
+    QPainter,
+    QPainterPath,
+    QPaintEvent,
+    QPalette,
+    QPen,
+    QPixmap,
+)
 from PyQt6.QtNetwork import QNetworkAccessManager, QNetworkReply, QNetworkRequest
-from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
+from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QToolButton, QVBoxLayout, QWidget
 
 from bilihud.app.menu import AccountStatus
 from bilihud.auth.service import AccountProfile
+
+
+class CopyToolButton(QToolButton):
+    """Render a compact theme-aware copy glyph without relying on desktop icon themes."""
+
+    def paintEvent(self, a0: QPaintEvent | None) -> None:
+        """Paint the button chrome and two overlapping document outlines."""
+        super().paintEvent(a0)
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        group = QPalette.ColorGroup.Active if self.isEnabled() else QPalette.ColorGroup.Disabled
+        color = self.palette().color(group, QPalette.ColorRole.ButtonText)
+        pen = QPen(color, 1.5, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap, Qt.PenJoinStyle.RoundJoin)
+        painter.setPen(pen)
+        icon_size = QSize(16, 16)
+        left = (self.width() - icon_size.width()) / 2
+        top = (self.height() - icon_size.height()) / 2
+        painter.drawRoundedRect(QRectF(left + 5, top + 1, 8, 10), 1.3, 1.3)
+        painter.drawRoundedRect(QRectF(left + 2, top + 4, 8, 10), 1.3, 1.3)
+        painter.end()
 
 
 class AccountSettingsPage(QWidget):
@@ -25,6 +56,7 @@ class AccountSettingsPage(QWidget):
         self._profile: AccountProfile | None = None
         self._avatar_generation = 0
         self._avatar_reply: QNetworkReply | None = None
+        self.live_room_copy_button: CopyToolButton | None = None
         self._network_manager = QNetworkAccessManager(self)
         self.setObjectName("settings_page")
         self._init_ui()
@@ -88,8 +120,20 @@ class AccountSettingsPage(QWidget):
         self.live_room_button = QPushButton("直播间", card)
         self.live_room_button.setProperty("link", True)
         self.live_room_button.clicked.connect(self._open_live_room)
+        self.live_room_copy_button = CopyToolButton(card)
+        self.live_room_copy_button.setObjectName("account_copy_live_room")
+        self.live_room_copy_button.setToolTip("复制直播间地址")
+        self.live_room_copy_button.setAccessibleName("复制直播间地址")
+        self.live_room_copy_button.setIconSize(QSize(16, 16))
+        self.live_room_copy_button.setFixedSize(28, 28)
+        self.live_room_copy_button.clicked.connect(self._copy_live_room)
+        live_room_actions = QHBoxLayout()
+        live_room_actions.setContentsMargins(0, 0, 0, 0)
+        live_room_actions.setSpacing(0)
+        live_room_actions.addWidget(self.live_room_button)
+        live_room_actions.addWidget(self.live_room_copy_button)
         self.account_links.addWidget(self.space_button)
-        self.account_links.addWidget(self.live_room_button)
+        self.account_links.addLayout(live_room_actions)
         self.account_links.addStretch(1)
         layout.addLayout(self.account_links)
 
@@ -156,6 +200,8 @@ class AccountSettingsPage(QWidget):
             self.account_stats.setVisible(False)
             self.space_button.setVisible(False)
             self.live_room_button.setVisible(False)
+            if self.live_room_copy_button is not None:
+                self.live_room_copy_button.setVisible(False)
         else:
             self.account_name_label.setText(self._profile.username)
             self.account_id_label.setText(f"UID {self._profile.user_id}")
@@ -164,8 +210,11 @@ class AccountSettingsPage(QWidget):
             self.account_stats.setVisible(True)
             self.space_button.setVisible(True)
             self.space_button.setToolTip(self._profile.space_url)
-            self.live_room_button.setVisible(self._profile.live_room_url is not None)
-            self.live_room_button.setToolTip(self._profile.live_room_url or "")
+            live_room_url = self._profile.live_room_url
+            self.live_room_button.setVisible(live_room_url is not None)
+            self.live_room_button.setToolTip(live_room_url or "")
+            if self.live_room_copy_button is not None:
+                self.live_room_copy_button.setVisible(live_room_url is not None)
             self._load_avatar(self._profile)
         self.login_button.setVisible(status is not AccountStatus.LOGGED_IN)
         self.logout_button.setVisible(status in (AccountStatus.LOGGED_IN, AccountStatus.LOGIN_EXPIRED))
@@ -258,6 +307,16 @@ class AccountSettingsPage(QWidget):
         """Open the account's public live-room page when one is available."""
         if self._profile is not None and self._profile.live_room_url is not None:
             QDesktopServices.openUrl(QUrl(self._profile.live_room_url))
+
+    def _copy_live_room(self) -> None:
+        """Copy the account's public live-room URL and show local feedback."""
+        if self._profile is None or self._profile.live_room_url is None:
+            return
+        clipboard = QGuiApplication.clipboard()
+        if clipboard is None:
+            return
+        clipboard.setText(self._profile.live_room_url, mode=QClipboard.Mode.Clipboard)
+        self.account_status_label.setText("直播间地址已复制")
 
 
 def _count_text(value: int | None) -> str:

--- a/src/bilihud/ui/settings/pages/live/page.py
+++ b/src/bilihud/ui/settings/pages/live/page.py
@@ -97,10 +97,11 @@ class LiveSettingsPage(QWidget):
         room_card, room_layout = self._new_card("直播间")
         room_form = QFormLayout()
         room_form.setHorizontalSpacing(18)
-        room_form.setVerticalSpacing(10)
+        room_form.setVerticalSpacing(12)
 
         room_row = QHBoxLayout()
         room_row.setContentsMargins(0, 0, 0, 0)
+        room_row.setSpacing(8)
         self.room_id_input = QLineEdit(room_card)
         self.room_id_input.setPlaceholderText("直播间 ID")
         self.room_id_input.setReadOnly(True)
@@ -114,6 +115,7 @@ class LiveSettingsPage(QWidget):
 
         title_row = QHBoxLayout()
         title_row.setContentsMargins(0, 0, 0, 0)
+        title_row.setSpacing(8)
         self.title_input = QLineEdit(room_card)
         self.title_input.setPlaceholderText("直播标题")
         self.title_input.textChanged.connect(self.update_action_state)
@@ -129,6 +131,7 @@ class LiveSettingsPage(QWidget):
 
         area_row = QHBoxLayout()
         area_row.setContentsMargins(0, 0, 0, 0)
+        area_row.setSpacing(8)
         self.area_combo = ModernComboBox(room_card)
         self.area_combo.currentIndexChanged.connect(self.update_action_state)
         area_row.addWidget(self.area_combo, 1)
@@ -159,9 +162,10 @@ class LiveSettingsPage(QWidget):
         obs_card, obs_layout = self._new_card("OBS 推流")
         obs_form = QFormLayout()
         obs_form.setHorizontalSpacing(18)
-        obs_form.setVerticalSpacing(10)
+        obs_form.setVerticalSpacing(12)
         endpoint_row = QHBoxLayout()
         endpoint_row.setContentsMargins(0, 0, 0, 0)
+        endpoint_row.setSpacing(8)
         self.obs_host_input = QLineEdit(obs_card)
         self.obs_host_input.setPlaceholderText(DEFAULT_OBS_HOST)
         self.obs_host_input.textChanged.connect(self._mark_obs_unchecked)
@@ -175,6 +179,7 @@ class LiveSettingsPage(QWidget):
 
         password_row = QHBoxLayout()
         password_row.setContentsMargins(0, 0, 0, 0)
+        password_row.setSpacing(8)
         self.obs_password_input = QLineEdit(obs_card)
         self.obs_password_input.setPlaceholderText("可留空")
         self.obs_password_input.setEchoMode(QLineEdit.EchoMode.Password)

--- a/src/bilihud/ui/settings/style.py
+++ b/src/bilihud/ui/settings/style.py
@@ -17,6 +17,7 @@ class ModernComboBox(QComboBox):
         super().__init__(parent)
         popup_view = QListView(self)
         popup_view.setUniformItemSizes(True)
+        popup_view.setSpacing(4)
         self.setView(popup_view)
 
     def showPopup(self) -> None:
@@ -183,12 +184,13 @@ def settings_stylesheet(appearance: Appearance) -> str:
         }}
         QComboBox, QSpinBox {{
             min-height: 34px;
-            padding: 0 10px;
             color: {appearance.text};
             background: {appearance.surface_alt};
             border: 1px solid {appearance.border};
             border-radius: 6px;
         }}
+        QComboBox {{ padding: 0 10px; }}
+        QSpinBox {{ padding: 0 26px 0 10px; }}
         QComboBox:focus, QSpinBox:focus {{ border-color: {appearance.accent}; }}
         QComboBox:hover, QSpinBox:hover {{ border-color: {appearance.muted_text}; }}
         QComboBox::drop-down {{
@@ -205,6 +207,8 @@ def settings_stylesheet(appearance: Appearance) -> str:
             border: none;
             background: transparent;
         }}
+        QSpinBox::up-button {{ subcontrol-position: top right; }}
+        QSpinBox::down-button {{ subcontrol-position: bottom right; }}
         QSpinBox::up-button:hover, QSpinBox::down-button:hover {{ background: {appearance.accent_soft}; }}
         QSpinBox::up-arrow, QSpinBox::down-arrow {{ image: none; width: 0px; height: 0px; }}
         QLineEdit {{
@@ -285,6 +289,19 @@ def settings_stylesheet(appearance: Appearance) -> str:
             font-size: 22px;
         }}
         QToolButton#window_close:hover {{ color: {appearance.text}; background: {appearance.surface_alt}; }}
+        QToolButton#account_copy_live_room {{
+            min-width: 28px;
+            max-width: 28px;
+            min-height: 28px;
+            max-height: 28px;
+            padding: 0;
+            color: {appearance.muted_text};
+            background: transparent;
+            border: none;
+            border-radius: 4px;
+        }}
+        QToolButton#account_copy_live_room:hover {{ color: {appearance.accent}; background: {appearance.accent_soft}; }}
+        QToolButton#account_copy_live_room:focus {{ border: 1px solid {appearance.accent}; }}
         QFrame#credential_row {{
             background: {appearance.surface_alt};
             border: 1px solid {appearance.border};

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -11,6 +11,8 @@ from PyQt6.QtWidgets import (
     QLabel,
     QLineEdit,
     QPushButton,
+    QStyle,
+    QStyleOptionSpinBox,
     QToolButton,
     QWidget,
 )
@@ -125,6 +127,9 @@ def test_settings_dialog_exposes_sidebar_pages_and_theme_choices() -> None:
     assert account_page.follower_value.text() == "34"
     assert account_page.space_button.isHidden() is False
     assert account_page.live_room_button.isHidden() is False
+    assert account_page.live_room_copy_button is not None
+    assert account_page.live_room_copy_button.isHidden() is False
+    assert account_page.live_room_copy_button.toolTip() == "复制直播间地址"
     assert account_page.login_button.isHidden() is True
     assert account_page.logout_button.isHidden() is False
 
@@ -134,6 +139,37 @@ def test_settings_dialog_exposes_sidebar_pages_and_theme_choices() -> None:
     assert account_page.logout_button.isHidden() is True
 
     dialog.close()
+
+
+def test_account_page_copies_live_room_url_from_icon_button() -> None:
+    app = _app()
+    page = AccountSettingsPage()
+    page.resize(520, 360)
+    page.show()
+    page.set_account_state(
+        AccountStatus.LOGGED_IN,
+        AccountProfile("123", "测试用户", live_room_id=456),
+    )
+    app.processEvents()
+
+    copy_button = page.live_room_copy_button
+    assert copy_button is not None
+    live_room_gap = (
+        copy_button.geometry().left()
+        - page.live_room_button.geometry().right()
+        - 1
+    )
+    assert live_room_gap == 0
+    copy_button.click()
+
+    clipboard = app.clipboard()
+    assert clipboard is not None
+    assert clipboard.text() == "https://live.bilibili.com/456"
+    assert page.account_status_label.text() == "直播间地址已复制"
+
+    page.set_account_state(AccountStatus.LOGGED_OUT, None)
+    assert copy_button.isHidden() is True
+    page.close()
 
 
 def test_settings_dialog_emits_typed_apply_and_confirm_requests() -> None:
@@ -299,6 +335,86 @@ def test_modern_combo_does_not_change_from_a_closed_wheel_event() -> None:
     dialog.close()
 
 
+def test_modern_combo_popup_separates_options() -> None:
+    app = _app()
+    dialog = SettingsDialog(None, AppConfig())
+    combo = dialog.theme_combo
+    combo.show()
+    app.processEvents()
+    combo.showPopup()
+    app.processEvents()
+
+    view = combo.view()
+    assert view is not None
+    assert view.spacing() == 4
+    first_item = view.visualRect(view.model().index(0, 0))
+    second_item = view.visualRect(view.model().index(1, 0))
+    assert second_item.top() - first_item.bottom() - 1 >= view.spacing()
+
+    combo.hidePopup()
+    dialog.close()
+
+
+def test_settings_spinbox_buttons_receive_clicks_across_their_full_hit_area() -> None:
+    app = _app()
+    dialog = SettingsDialog(None, AppConfig(window_opacity=50))
+    dialog.select_page(SettingsPage.PANEL)
+    dialog.show()
+    app.processEvents()
+
+    spinbox = dialog.opacity_spinbox
+    option = QStyleOptionSpinBox()
+    option.initFrom(spinbox)
+    option.frame = spinbox.hasFrame()
+    option.buttonSymbols = spinbox.buttonSymbols()
+    option.stepEnabled = spinbox.stepEnabled()
+    style = spinbox.style()
+
+    for subcontrol, expected_value in (
+        (QStyle.SubControl.SC_SpinBoxUp, 55),
+        (QStyle.SubControl.SC_SpinBoxDown, 45),
+    ):
+        button_rect = style.subControlRect(
+            QStyle.ComplexControl.CC_SpinBox,
+            option,
+            subcontrol,
+            spinbox,
+        )
+        spinbox.setValue(50)
+        point = QPoint(button_rect.left() + 1, button_rect.center().y())
+        target = spinbox.childAt(point)
+        if target is None:
+            target = spinbox
+        target_point = target.mapFrom(spinbox, point)
+        global_point = spinbox.mapToGlobal(point)
+        press = QMouseEvent(
+            QEvent.Type.MouseButtonPress,
+            QPointF(target_point),
+            QPointF(target_point),
+            QPointF(global_point),
+            Qt.MouseButton.LeftButton,
+            Qt.MouseButton.LeftButton,
+            Qt.KeyboardModifier.NoModifier,
+        )
+        release = QMouseEvent(
+            QEvent.Type.MouseButtonRelease,
+            QPointF(target_point),
+            QPointF(target_point),
+            QPointF(global_point),
+            Qt.MouseButton.LeftButton,
+            Qt.MouseButton.NoButton,
+            Qt.KeyboardModifier.NoModifier,
+        )
+        QApplication.sendEvent(target, press)
+        QApplication.sendEvent(target, release)
+        app.processEvents()
+
+        assert target is not spinbox.lineEdit()
+        assert spinbox.value() == expected_value
+
+    dialog.close()
+
+
 def test_settings_dialog_hides_scrollbar_for_short_page() -> None:
     app = _app()
     dialog = SettingsDialog(None, AppConfig())
@@ -348,6 +464,29 @@ def test_live_action_buttons_show_owned_busy_state() -> None:
 
     assert page.start_button.text() == "开始直播"
     assert page.start_button.property("busy") is False
+
+
+def test_live_form_leaves_space_between_compound_controls() -> None:
+    app = _app()
+    dialog = SettingsDialog(None, AppConfig())
+    dialog.select_page(SettingsPage.LIVE)
+    dialog.show()
+    app.processEvents()
+
+    page = dialog.page_stack.currentWidget()
+    assert isinstance(page, LiveSettingsPage)
+
+    def horizontal_gap(left: QWidget, right: QWidget) -> int:
+        return right.geometry().left() - left.geometry().right() - 1
+
+    assert horizontal_gap(page.room_id_input, page.refresh_room_button) == 8
+    assert horizontal_gap(page.title_input, page.update_title_button) == 8
+    assert horizontal_gap(page.area_combo, page.update_area_button) == 8
+    assert horizontal_gap(page.obs_host_input, page.obs_port_input) == 8
+    assert horizontal_gap(page.obs_password_input, page.check_obs_button) == 8
+    assert horizontal_gap(page.check_obs_button, page.stop_obs_button) == 8
+
+    dialog.close()
 
 
 def test_live_face_verification_uses_face_auth_copy() -> None:

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -10,6 +10,7 @@ from PyQt6.QtWidgets import (
     QDialog,
     QLabel,
     QLineEdit,
+    QListView,
     QPushButton,
     QStyle,
     QStyleOptionSpinBox,
@@ -345,10 +346,13 @@ def test_modern_combo_popup_separates_options() -> None:
     app.processEvents()
 
     view = combo.view()
-    assert view is not None
+    assert isinstance(view, QListView)
     assert view.spacing() == 4
-    first_item = view.visualRect(view.model().index(0, 0))
-    second_item = view.visualRect(view.model().index(1, 0))
+    model = view.model()
+    if model is None:
+        raise AssertionError("theme combo popup has no model")
+    first_item = view.visualRect(model.index(0, 0))
+    second_item = view.visualRect(model.index(1, 0))
     assert second_item.top() - first_item.bottom() - 1 >= view.spacing()
 
     combo.hidePopup()
@@ -369,6 +373,8 @@ def test_settings_spinbox_buttons_receive_clicks_across_their_full_hit_area() ->
     option.buttonSymbols = spinbox.buttonSymbols()
     option.stepEnabled = spinbox.stepEnabled()
     style = spinbox.style()
+    if style is None:
+        raise AssertionError("opacity spinbox has no style")
 
     for subcontrol, expected_value in (
         (QStyle.SubControl.SC_SpinBoxUp, 55),


### PR DESCRIPTION
## Summary

- Fix QSpinBox spinner hit areas and separate its input padding from combo boxes.
- Add breathing room to live/OBS compound controls and combo popup options.
- Add a compact live-room copy button with clipboard feedback.
- Add Qt regression coverage for the settings UI behavior.

## Verification

- `UV_CACHE_DIR=/tmp/bilihud-uv-cache uv run --offline pytest -q` (284 passed)
- `UV_CACHE_DIR=/tmp/bilihud-uv-cache uv run --offline ruff check src tests`
- `git diff --check`